### PR TITLE
Linting and formatting code. 

### DIFF
--- a/data-serving/data-service/.eslintrc.js
+++ b/data-serving/data-service/.eslintrc.js
@@ -4,7 +4,6 @@ module.exports = {
         "node": true
     },
     "extends": [
-        "eslint:recommended",
         "plugin:@typescript-eslint/eslint-recommended",
         "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
         "plugin:prettier/recommended" // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -1,8 +1,8 @@
-import { Request, Response } from "express";
+import { Request, Response } from 'express';
 
 /**
  * Get a specific case.
- * 
+ *
  * Handles HTTP GET /cases/:id.
  */
 export const getCase = (req: Request, res: Response) => {
@@ -11,7 +11,7 @@ export const getCase = (req: Request, res: Response) => {
 
 /**
  * List all cases.
- * 
+ *
  * Handles HTTP GET /cases.
  */
 export const listCases = (req: Request, res: Response) => {

--- a/data-serving/data-service/src/controllers/home.ts
+++ b/data-serving/data-service/src/controllers/home.ts
@@ -1,8 +1,8 @@
-import { Request, Response } from "express";
+import { Request, Response } from 'express';
 
 /**
  * Get the home page.
- * 
+ *
  * Handles HTTP GET /.
  */
 export const index = (req: Request, res: Response) => {

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -1,17 +1,17 @@
-import express from "express";
+import express from 'express';
 
 // Controllers (route handlers).
-import * as homeController from "./controllers/home";
-import * as caseController from "./controllers/case";
+import * as homeController from './controllers/home';
+import * as caseController from './controllers/case';
 
 const app = express();
 
 // Express configuration.
-app.set("port", process.env.PORT || 3000);
+app.set('port', process.env.PORT || 3000);
 
 // Configure app routes.
-app.get("/", homeController.index);
-app.get("/cases/:id", caseController.getCase);
-app.get("/cases", caseController.listCases);
+app.get('/', homeController.index);
+app.get('/cases/:id', caseController.getCase);
+app.get('/cases', caseController.listCases);
 
 export default app;

--- a/data-serving/data-service/src/server.ts
+++ b/data-serving/data-service/src/server.ts
@@ -1,9 +1,9 @@
-import app from "./index";
+import app from './index';
 
 // Start Express server.
-const server = app.listen(app.get("port"), () => {
-    console.log('App running at http://localhost:%d.', app.get("port"));
-    console.log("  Press CTRL-C to stop\n");
+const server = app.listen(app.get('port'), () => {
+    console.log('App running at http://localhost:%d.', app.get('port'));
+    console.log('  Press CTRL-C to stop\n');
 });
 
 export default server;

--- a/data-serving/data-service/test/case.test.ts
+++ b/data-serving/data-service/test/case.test.ts
@@ -1,16 +1,14 @@
-import request from "supertest";
-import app from "../src/index";
+import request from 'supertest';
+import app from '../src/index';
 
-describe("GET /cases/:id", () => {
-    it("should return 200 OK", (done) => {
-        request(app).get("/cases/id")
-            .expect(200, done);
+describe('GET /cases/:id', () => {
+    it('should return 200 OK', (done) => {
+        request(app).get('/cases/id').expect(200, done);
     });
 });
 
-describe("GET /cases", () => {
-    it("should return 200 OK", (done) => {
-        request(app).get("/cases")
-            .expect(200, done);
+describe('GET /cases', () => {
+    it('should return 200 OK', (done) => {
+        request(app).get('/cases').expect(200, done);
     });
 });

--- a/data-serving/data-service/test/home.test.ts
+++ b/data-serving/data-service/test/home.test.ts
@@ -1,9 +1,8 @@
-import request from "supertest";
-import app from "../src/index";
+import request from 'supertest';
+import app from '../src/index';
 
-describe("GET /", () => {
-    it("should return 200 OK", (done) => {
-        request(app).get("/")
-            .expect(200, done);
+describe('GET /', () => {
+    it('should return 200 OK', (done) => {
+        request(app).get('/').expect(200, done);
     });
 });

--- a/data-serving/data-service/test/index.test.ts
+++ b/data-serving/data-service/test/index.test.ts
@@ -1,9 +1,8 @@
-import request from "supertest";
-import app from "../src/index";
+import request from 'supertest';
+import app from '../src/index';
 
-describe("GET /random-url", () => {
-    it("should return 404", (done) => {
-        request(app).get("/random-url")
-            .expect(404, done);
+describe('GET /random-url', () => {
+    it('should return 404', (done) => {
+        request(app).get('/random-url').expect(404, done);
     });
 });


### PR DESCRIPTION
Removed a (redundant) base config from eslintrc which was causing issues.

Mostly whitespace, double->single quotes, and EOL chars.