### PR TITLE
add simple docker file for curator server

### DIFF
--- a/verification/curator-service/.dockerignore
+++ b/verification/curator-service/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/verification/curator-service/Dockerfile
+++ b/verification/curator-service/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:12
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE 3001
+CMD [ "npm", "start" ]


### PR DESCRIPTION
```
docker build . -t timothe/curator
Sending build context to Docker daemon  440.8kB
Step 1/7 : FROM node:12
 ---> 406aa3abbc6c
Step 2/7 : WORKDIR /usr/src/app
 ---> Using cache
 ---> cf67b089e577
Step 3/7 : COPY package*.json ./
 ---> Using cache
 ---> 8c30d5cd4100
Step 4/7 : RUN npm install
 ---> Using cache
 ---> d8aa7509a963
Step 5/7 : COPY . .
 ---> 7cd17bbbe603
Step 6/7 : EXPOSE 3001
 ---> Running in 448d0419acac
Removing intermediate container 448d0419acac
 ---> 3f8e34c315c0
Step 7/7 : CMD [ "npm", "start" ]
 ---> Running in 5b41ebadf68b
Removing intermediate container 5b41ebadf68b
 ---> d4ca9e9086c5
Successfully built d4ca9e9086c5
Successfully tagged timothe/curator:latest
timothe-macbookpro:curator-service timothe$ docker run -p 44444:3001 timothe/curator

> curator-service@1.0.0 start /usr/src/app
> node dist/server.js

App running at http://localhost:3001.
  Press CTRL-C to stop


```