### PR TITLE
dotenv set up for both services

### DIFF
--- a/data-serving/data-service/package-lock.json
+++ b/data-serving/data-service/package-lock.json
@@ -945,6 +945,15 @@
       "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
       "dev": true
     },
+    "@types/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
+      "dev": true,
+      "requires": {
+        "dotenv": "*"
+      }
+    },
     "@types/eslint": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-6.8.0.tgz",
@@ -2373,6 +2382,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/data-serving/data-service/package.json
+++ b/data-serving/data-service/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/body-parser": "^1.19.0",
     "@types/chai": "^4.2.11",
+    "@types/dotenv": "^8.2.0",
     "@types/eslint": "^6.8.0",
     "@types/express": "^4.17.6",
     "@types/jest": "^25.2.1",
@@ -43,6 +44,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-validator": "^6.4.0"
   }

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -1,11 +1,14 @@
 import express from 'express';
 import bodyParser from 'body-parser';
+import dotenv from 'dotenv';
 
 // Controllers (route handlers).
 import * as homeController from './controllers/home';
 import * as caseController from './controllers/case';
 
 const app = express();
+
+dotenv.config();
 
 // Express configuration.
 app.set('port', process.env.PORT || 3000);

--- a/verification/curator-service/package-lock.json
+++ b/verification/curator-service/package-lock.json
@@ -963,6 +963,15 @@
       "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
       "dev": true
     },
+    "@types/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
+      "dev": true,
+      "requires": {
+        "dotenv": "*"
+      }
+    },
     "@types/eslint": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-6.8.0.tgz",
@@ -2393,6 +2402,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/verification/curator-service/package.json
+++ b/verification/curator-service/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/chai": "^4.2.11",
+    "@types/dotenv": "^8.2.0",
     "@types/eslint": "^6.8.0",
     "@types/express": "^4.17.6",
     "@types/jest": "^25.2.1",
@@ -41,6 +42,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "dotenv": "^8.2.0",
     "express": "^4.17.1"
   }
 }

--- a/verification/curator-service/src/index.ts
+++ b/verification/curator-service/src/index.ts
@@ -1,10 +1,13 @@
 import express from 'express';
+import dotenv from 'dotenv';
 
 // Controllers (route handlers).
 import * as homeController from './controllers/home';
 import * as sourcesController from './controllers/sources';
 
 const app = express();
+
+dotenv.config();
 
 // Express configuration.
 app.set('port', process.env.PORT || 3001);


### PR DESCRIPTION
Documentation [here](https://www.npmjs.com/package/dotenv). By convention, `.env` contains secrets and is .gitignored/strongly discouraged from being uploaded. We could share a copy in drive for development, perhaps.

As an example:

```
alex@anblox:~/.../data-serving/data-service$ cat .env && echo
PORT=3002
alex@anblox:~/.../data-serving/data-service$ npm run start

> data-service@1.0.0 start [...]/data-serving/data-service
> node dist/server.js

App running at http://localhost:3002.
  Press CTRL-C to stop
```