### PR TITLE
 Render summary from data-service API on the curator-service home page.

### DIFF
--- a/verification/curator-service/package-lock.json
+++ b/verification/curator-service/package-lock.json
@@ -1645,6 +1645,14 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "babel-jest": {
       "version": "25.4.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.4.0.tgz",
@@ -3311,6 +3319,24 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",

--- a/verification/curator-service/package.json
+++ b/verification/curator-service/package.json
@@ -44,6 +44,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "mongoose": "^5.9.10"

--- a/verification/curator-service/src/controllers/home.ts
+++ b/verification/curator-service/src/controllers/home.ts
@@ -8,14 +8,13 @@ interface Case {
 }
 
 function getLatestCaseDate(cases: [Case]): Date {
-    cases.sort((case1, case2) => {
-        const time1 = case1.date.getTime();
-        const time2 = case2.date.getTime();
-        if (time1 > time2) return 1;
-        if (time1 < time2) return -1;
-        return 0;
-    });
-    return cases[cases.length - 1].date;
+    return cases.reduce((case1, case2) =>
+        // These casts are required.
+        // JSON deserialization doesn't add functions to the object.
+        new Date(case1.date).getTime() > new Date(case2.date).getTime()
+            ? case1
+            : case2,
+    ).date;
 }
 
 /**
@@ -32,6 +31,7 @@ export const index = async (req: Request, res: Response): Promise<void> => {
             `Found ${cases.length} cases (latest case date: ${latestDate}).`,
         );
     } catch (err) {
+        console.log(err);
         res.status(500).send(err);
     }
 };

--- a/verification/curator-service/src/controllers/home.ts
+++ b/verification/curator-service/src/controllers/home.ts
@@ -1,10 +1,37 @@
 import { Request, Response } from 'express';
+import axios from 'axios';
+
+interface Case {
+    _id: string;
+    outcome: string;
+    date: Date;
+}
+
+function getLatestCaseDate(cases: [Case]): Date {
+    cases.sort((case1, case2) => {
+        const time1 = case1.date.getTime();
+        const time2 = case2.date.getTime();
+        if (time1 > time2) return 1;
+        if (time1 < time2) return -1;
+        return 0;
+    });
+    return cases[cases.length - 1].date;
+}
 
 /**
  * Get the home page.
  *
  * Handles HTTP GET /.
  */
-export const index = (req: Request, res: Response): void => {
-    res.send('Curator service under construction.');
+export const index = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const response = await axios.get<[Case]>('/cases');
+        const cases = response.data;
+        const latestDate = getLatestCaseDate(cases);
+        res.send(
+            `Found ${cases.length} cases (latest case date: ${latestDate}).`,
+        );
+    } catch (err) {
+        res.status(500).send(err);
+    }
 };

--- a/verification/curator-service/src/index.ts
+++ b/verification/curator-service/src/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
+import axios from 'axios';
 
 // Controllers (route handlers).
 import * as homeController from './controllers/home';
@@ -25,6 +26,8 @@ apiRouter.put('/sources/:id', sourcesController.update);
 apiRouter.delete('/sources/:id', sourcesController.del);
 app.use('/api', apiRouter);
 
+// Configure dependencies.
+axios.defaults.baseURL = process.env.DATASERVER_API_URL;
 (async (): Promise<void> => {
     try {
         console.log('Connecting to instance', process.env.DB_CONNECTION_STRING);

--- a/verification/curator-service/test/home.test.ts
+++ b/verification/curator-service/test/home.test.ts
@@ -1,8 +1,28 @@
 import request from 'supertest';
 import app from '../src/index';
+import axios, { AxiosResponse } from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('GET /', () => {
     it('should return 200 OK', (done) => {
+        const cases = [
+            {
+                _id: 'abc123',
+                outcome: 'recovered',
+                date: '2020-04-21',
+            },
+        ];
+        const axiosResponse: AxiosResponse = {
+            data: cases,
+            status: 200,
+            statusText: 'OK',
+            config: {},
+            headers: {},
+        };
+        mockedAxios.get.mockResolvedValue(axiosResponse);
+
         request(app).get('/').expect(200, done);
     });
 });

--- a/verification/curator-service/test/home.test.ts
+++ b/verification/curator-service/test/home.test.ts
@@ -14,7 +14,7 @@ describe('GET /', () => {
                 date: '2020-04-21',
             },
         ];
-        const axiosResponse: AxiosResponse = {
+        const axiosResponse = {
             data: cases,
             status: 200,
             statusText: 'OK',

--- a/verification/curator-service/test/home.test.ts
+++ b/verification/curator-service/test/home.test.ts
@@ -6,12 +6,17 @@ jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('GET /', () => {
-    it('should return 200 OK', (done) => {
+    it('should return 200 OK with latest date', (done) => {
         const cases = [
             {
                 _id: 'abc123',
                 outcome: 'recovered',
-                date: '2020-04-21',
+                date: new Date('2020-04-21').toJSON(),
+            },
+            {
+                _id: 'def456',
+                outcome: 'recovered',
+                date: new Date('2020-04-22').toJSON(),
             },
         ];
         const axiosResponse = {
@@ -23,6 +28,8 @@ describe('GET /', () => {
         };
         mockedAxios.get.mockResolvedValue(axiosResponse);
 
-        request(app).get('/').expect(200, done);
+        request(app)
+            .get('/')
+            .expect(200, /2020-04-22/, done);
     });
 });

--- a/verification/curator-service/test/home.test.ts
+++ b/verification/curator-service/test/home.test.ts
@@ -6,7 +6,7 @@ jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('GET /', () => {
-    it('should return 200 OK with latest date', (done) => {
+    it('should return 200 OK with latest case date', (done) => {
         const cases = [
             {
                 _id: 'abc123',


### PR DESCRIPTION
Couple things:

- Not in love with the solution to type HTTP client responses (e.g. duplicating the interface definition). It's probably worth having a published type for clients to ingest that API data (at least for Node clients), but I'm satisfied with this as a starting point.
- I'll catch up with Allyson on front end plans tomorrow. For now, just getting this on the home page as a placeholder.
- Vagrant set up would be great. ;-) To test locally, I manually ran a local MongoDB and both Node apps. Not terrible, but could be better.