### PR TITLE
Add npm scripts for jest watch mode(s).

### DIFF
--- a/data-serving/data-service/package.json
+++ b/data-serving/data-service/package.json
@@ -14,7 +14,9 @@
     "import-data": "mongoimport --db dev --collection covid19 --file ../samples/line-list.json",
     "lint": "tsc --noEmit && eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
     "start": "node dist/server.js",
-    "test": "jest --forceExit --coverage --verbose --detectOpenHandles"
+    "test": "jest --clearCache && jest --forceExit --coverage --verbose --detectOpenHandles",
+    "test-watch": "jest --clearCache && jest --verbose --detectOpenHandles --watch",
+    "test-watch-all": "jest --clearCache && jest --coverage --verbose --detectOpenHandles --watchAll"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
- Prepending a clearCache command to prevent issues when files are moved/created.
- Not running coverage for watching specific files; mostly useless information.
- To use the single-file command, it'd be `npm run test-watch -- test/home.test.ts`, for example.