### PR TITLE
reenabled curl fetches of docker stack in github workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,8 +14,7 @@ jobs:
           time: "30s"
       - name: Print Logs
         run: docker-compose -f dev/docker-compose.yml logs
-      # Flaky on github, need to figure out why.
-      # - name: Test Curator Service
-      #   run: docker-compose -f dev/docker-compose.yml exec -T curator curl --retry-connrefused --retry 20 --retry-delay 5 -f --silent --show-error http://localhost:3001
-      # - name: Test Data Service
-      #   run: docker-compose -f dev/docker-compose.yml exec -T data curl --retry-connrefused --retry 20 --retry-delay 5 -f --silent --show-error http://localhost:3000
+      - name: Test Curator Service
+        run: docker-compose -f dev/docker-compose.yml exec -T curator curl --retry-connrefused --retry 20 --retry-delay 5 -f --silent --show-error http://localhost:3001/api/sources
+      - name: Test Data Service
+        run: docker-compose -f dev/docker-compose.yml exec -T data curl --retry-connrefused --retry 20 --retry-delay 5 -f --silent --show-error http://localhost:3000/api/cases


### PR DESCRIPTION
Last time I merged the CL calling /api/cases from the curator service which made the tests fail and I couldn't figure out why, I was just tired I guess.
Now calling the /api/sources and /api/cases directly instead of / to make it explicit and easier to debug.