### PR TITLE
[data conversion] Convert symptoms and chronic_disease fields

### DIFF
--- a/data-serving/scripts/constants.py
+++ b/data-serving/scripts/constants.py
@@ -1,8 +1,2 @@
-''' The name of the id field in the input csv. '''
-CSV_ID_FIELD = 'ID'
-
-''' The top-level fields that belong to the JSON schema. '''
-OUTPUT_COLUMNS = ['demographics', 'events', 'location', 'importedCase']
-
 ''' Valid values for sex field. '''
 VALID_SEXES = ['female', 'male', 'other']

--- a/data-serving/scripts/convert_data.py
+++ b/data-serving/scripts/convert_data.py
@@ -1,4 +1,7 @@
-'''Script to convert CSV line-list data into json compliant with the MongoDB schema.'''
+'''
+Script to convert CSV line-list data into json compliant with the MongoDB
+schema.
+'''
 
 import argparse
 import csv
@@ -7,7 +10,8 @@ import json
 import pandas as pd
 import sys
 from constants import CSV_ID_FIELD, OUTPUT_COLUMNS
-from converters import convert_demographics, convert_events, convert_imported_case, convert_location
+from converters import (convert_demographics, convert_events,
+                        convert_imported_case, convert_location)
 from pandas import DataFrame
 
 
@@ -16,9 +20,12 @@ def main():
                         filemode='w', level=logging.DEBUG)
 
     parser = argparse.ArgumentParser(
-        description='Convert CSV line-list data into json compliant with the MongoDB schema.')
+        description='Convert CSV line-list data into json compliant with the '
+        'MongoDB schema.')
     parser.add_argument('--infile', type=argparse.FileType('r'))
-    parser.add_argument('--outfile', nargs='?', type=argparse.FileType('w', encoding='UTF-8'),
+    parser.add_argument('--outfile',
+                        nargs='?',
+                        type=argparse.FileType('w', encoding='UTF-8'),
                         default=sys.stdout)
     parser.add_argument('--sample_rate', default=1.0, type=float)
 
@@ -31,8 +38,8 @@ def main():
         original_rows = original_cases.shape[0]
         original_cases = original_cases.sample(frac=args.sample_rate)
         print(
-            f'Downsampling to {args.sample_rate*100} % of cases from {original_rows} to'
-            f'{original_cases.shape[0]} rows')
+            f'Downsampling to {args.sample_rate*100} % of cases from '
+            f'{original_rows} to {original_cases.shape[0]} rows')
 
     print('Converting data to new schema')
     converted_cases = convert(original_cases)
@@ -49,8 +56,8 @@ def read_csv(infile: str) -> DataFrame:
 
 def convert(cases: DataFrame) -> DataFrame:
     # demographics
-    cases['demographics'] = cases.apply(
-        lambda x: convert_demographics(x[CSV_ID_FIELD], x['age'], x['sex']), axis=1)
+    cases['demographics'] = cases.apply(lambda x: convert_demographics(
+        x[CSV_ID_FIELD], x['age'], x['sex']), axis=1)
 
     # events
     cases['events'] = cases.apply(
@@ -77,9 +84,8 @@ def convert(cases: DataFrame) -> DataFrame:
         axis=1)
 
     # Archive the original fields.
-    cases['importedCase'] = cases.apply(
-        lambda x: convert_imported_case(x[CSV_ID_FIELD],
-                                        x[cases.columns.difference(OUTPUT_COLUMNS)]), axis=1)
+    cases['importedCase'] = cases.apply(lambda x: convert_imported_case(
+        x[CSV_ID_FIELD], x[cases.columns.difference(OUTPUT_COLUMNS)]), axis=1)
 
     # Filter down to only the new fields.
     return cases.filter(items=OUTPUT_COLUMNS)

--- a/data-serving/scripts/convert_data.py
+++ b/data-serving/scripts/convert_data.py
@@ -9,7 +9,7 @@ import logging
 import json
 import pandas as pd
 import sys
-from converters import (convert_demographics,
+from converters import (convert_demographics, convert_dictionary_field,
                         convert_events, convert_imported_case, convert_location)
 from pandas import DataFrame, Series
 from typing import Any
@@ -86,6 +86,22 @@ def convert(df_import: DataFrame) -> DataFrame:
             'confirmed': x['date_confirmation'],
             'deathOrDischarge': x['date_death_or_discharge']
         }, x['outcome']), axis=1)
+
+    # Generate new symptoms column.
+    df_export['symptoms'] = df_import.apply(
+        lambda x: convert_dictionary_field(
+            x['ID'],
+            'symptoms',
+            x['symptoms']),
+        axis=1)
+
+    # Generate new chronic disease column.
+    df_export['chronicDisease'] = df_import.apply(
+        lambda x: convert_dictionary_field(
+            x['ID'],
+            'chronicDisease',
+            x['chronic_disease']),
+        axis=1)
 
     # Archive the original fields.
     df_export['importedCase'] = df_import.apply(lambda x: convert_imported_case(

--- a/data-serving/scripts/convert_data.py
+++ b/data-serving/scripts/convert_data.py
@@ -9,10 +9,10 @@ import logging
 import json
 import pandas as pd
 import sys
-from constants import CSV_ID_FIELD, OUTPUT_COLUMNS
-from converters import (convert_demographics, convert_events,
-                        convert_imported_case, convert_location)
-from pandas import DataFrame
+from converters import (convert_demographics,
+                        convert_events, convert_imported_case, convert_location)
+from pandas import DataFrame, Series
+from typing import Any
 
 
 def main():
@@ -54,26 +54,21 @@ def read_csv(infile: str) -> DataFrame:
     return pd.read_csv(infile, header=0, low_memory=False, encoding='utf-8')
 
 
-def convert(cases: DataFrame) -> DataFrame:
-    # demographics
-    cases['demographics'] = cases.apply(lambda x: convert_demographics(
-        x[CSV_ID_FIELD], x['age'], x['sex']), axis=1)
+def convert(df_import: DataFrame) -> DataFrame:
+    # Operate on a separate output dataframe so we don't clobber or mutate the
+    # original data.
+    df_export = pd.DataFrame(columns={})
 
-    # events
-    cases['events'] = cases.apply(
-        lambda x: convert_events(x[CSV_ID_FIELD], {
-            'onsetSymptoms': x['date_onset_symptoms'],
-            'admissionHospital': x['date_admission_hospital'],
-            'confirmed': x['date_confirmation'],
-            'deathOrDischarge': x['date_death_or_discharge']
-        }, x['outcome']), axis=1)
+    # Generate new demographics column.
+    df_export['demographics'] = df_import.apply(lambda x: convert_demographics(
+        x['ID'], x['age'], x['sex']), axis=1)
 
-    # location
-    cases['location'] = cases.apply(
+    # Generate new location column.
+    df_export['location'] = df_import.apply(
         lambda
         x:
         convert_location(
-            x[CSV_ID_FIELD],
+            x['ID'],
             x['admin_id'],
             x['country'],
             x['admin1'],
@@ -83,12 +78,20 @@ def convert(cases: DataFrame) -> DataFrame:
             x['longitude']),
         axis=1)
 
-    # Archive the original fields.
-    cases['importedCase'] = cases.apply(lambda x: convert_imported_case(
-        x[CSV_ID_FIELD], x[cases.columns.difference(OUTPUT_COLUMNS)]), axis=1)
+    # Generate new events column.
+    df_export['events'] = df_import.apply(
+        lambda x: convert_events(x['ID'], {
+            'onsetSymptoms': x['date_onset_symptoms'],
+            'admissionHospital': x['date_admission_hospital'],
+            'confirmed': x['date_confirmation'],
+            'deathOrDischarge': x['date_death_or_discharge']
+        }, x['outcome']), axis=1)
 
-    # Filter down to only the new fields.
-    return cases.filter(items=OUTPUT_COLUMNS)
+    # Archive the original fields.
+    df_export['importedCase'] = df_import.apply(lambda x: convert_imported_case(
+        x['ID'], x), axis=1)
+
+    return df_export
 
 
 def write_json(cases: DataFrame, outfile: str) -> None:

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -10,7 +10,7 @@ from pandas import Series
 from typing import Any, Callable, Dict, List
 
 
-def trim_string_array(values: [str]):
+def trim_string_array(values: List[str]) -> List[str]:
     # Remove whitespace that might surround the delimiter ('cough, fever')
     values = [x.strip() for x in values]
 
@@ -24,7 +24,7 @@ def convert_range(
         value: str, parse_fn: Callable[[str],
                                        str],
         format_fn: Callable[[Any],
-                            Any]):
+                            Any]) -> Dict[str, Any]:
     '''
     Converts either a string representation of a single value or a range of
     values into a range object. The values can be of any types using the custom

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -10,6 +10,16 @@ from pandas import Series
 from typing import Any, Callable, Dict, List
 
 
+def trim_string_array(values: [str]):
+    # Remove whitespace that might surround the delimiter ('cough, fever')
+    values = [x.strip() for x in values]
+
+    # Remove empty strings that can result from trailing delimiters ('cough,')
+    values = [i for i in values if i]
+
+    return values
+
+
 def convert_range(
         value: str, parse_fn: Callable[[str],
                                        str],
@@ -25,11 +35,7 @@ def convert_range(
 
     # First check if the value is represented as a range.
     if type(value) is str and value.find('-') >= 0:
-        value_range = value.split('-')
-        # Remove whitespace that might surround the dash ('23 - 72')
-        value_range = [x.strip() for x in value_range]
-        # Remove empty strings that can result from open ranges ('18-')
-        value_range = [i for i in value_range if i]
+        value_range = trim_string_array(value.split('-'))
 
         # Handle open ranges (i.e. missing min or max).
         range_min = parse_fn(value_range[0])

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -10,10 +10,15 @@ from pandas import Series
 from typing import Any, Callable, Dict, List
 
 
-def convert_range(value: str, parse_fn: Callable[[str], str], format_fn: Callable[[Any], Any]):
+def convert_range(
+        value: str, parse_fn: Callable[[str],
+                                       str],
+        format_fn: Callable[[Any],
+                            Any]):
     '''
-    Converts either a string representation of a single value or a range of values into a range 
-    object. The values can be of any types using the custom parse and format functions.
+    Converts either a string representation of a single value or a range of
+    values into a range object. The values can be of any types using the custom
+    parse and format functions.
     '''
     if pd.isna(value):
         return None
@@ -48,7 +53,8 @@ def convert_range(value: str, parse_fn: Callable[[str], str], format_fn: Callabl
             }
         }
 
-    # We have a specific value. We create a range with identical min and max values.
+    # We have a specific value. We create a range with identical min and max
+    # values.
     parsed_value = parse_fn(value)
     return {
         'range': {
@@ -60,16 +66,19 @@ def convert_range(value: str, parse_fn: Callable[[str], str], format_fn: Callabl
 
 def convert_event(id: str, name: str, date_str: str) -> Dict[str, str]:
     '''
-    Converts a single event date column to the new event object with a name and range of dates.
+    Converts a single event date column to the new event object with a name and
+    range of dates.
     '''
     if pd.isna(date_str):
         return None
 
     try:
-        date_range = convert_range(date_str, lambda x: datetime.datetime.strptime(
-            x, '%d.%m.%Y'), lambda x: {
+        date_range = convert_range(
+            date_str,
+            lambda x: datetime.datetime.strptime(x, '%d.%m.%Y'),
+            lambda x: {
                 '$date': x.strftime('%Y-%m-%dT%H:%M:%SZ')
-        })
+            })
 
         return {
             'name': name,
@@ -82,14 +91,14 @@ def convert_event(id: str, name: str, date_str: str) -> Dict[str, str]:
 
 def convert_events(id: str, dates: str, outcome: str) -> List[Dict[str, Any]]:
     '''
-    Converts event date columns to the new events array. Also includes the outcome field as an
-    event, even though we don't have an associated date.
+    Converts event date columns to the new events array. Also includes the
+    outcome field as an event, even though we don't have an associated date.
     '''
     events = list(map(lambda i: convert_event(
         id, i[0], i[1]), dates.items()))
 
-    # The old data model had an outcome string, which will become an event in the new data model,
-    # but it won't have a date associated with it.
+    # The old data model had an outcome string, which will become an event in
+    # the new data model, but it won't have a date associated with it.
     if outcome and type(outcome) is str:
         events.append({'name': outcome})
 
@@ -120,8 +129,9 @@ def convert_demographics(id: str, age: str, sex: str) -> Dict[str, Any]:
     return demographics if demographics else None
 
 
-def convert_location(id: str, location_id: float, country: str, adminL1: str, adminL2: str,
-                     locality: str, latitude: float, longitude: float) -> Dict[str, Any]:
+def convert_location(id: str, location_id: float, country: str, adminL1: str,
+                     adminL2: str, locality: str, latitude: float,
+                     longitude: float) -> Dict[str, Any]:
     '''Converts location fields to a location object.'''
     location = {}
 
@@ -167,6 +177,9 @@ def convert_location(id: str, location_id: float, country: str, adminL1: str, ad
 
 
 def convert_imported_case(id: str, values_to_archive: Series) -> Dict[str, Any]:
-    '''Converts original field names and values to the importedCase archival object. '''
+    '''
+    Converts original field names and values to the importedCase archival
+    object.
+    '''
     return {k: v for k, v in values_to_archive.iteritems()
             if pd.notna(v)}

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -182,6 +182,33 @@ def convert_location(id: str, location_id: float, country: str, adminL1: str,
     return location
 
 
+def convert_dictionary_field(
+        id: str, field_name: str, value: str) -> Dict[
+        str, List[str]]:
+    if pd.isna(value):
+        return None
+    if type(value) is not str:
+        logging.warning(
+            '[%s] [field_name] invalid value %s', id, value)
+        return None
+
+    is_comma_delimited = value.find(',') >= 0
+    is_colon_delimited = value.find(':') >= 0
+
+    if is_comma_delimited:
+        if is_colon_delimited:
+            logging.warning(
+                '[%s] [field_name] two delimiters detected, using comma %s', id,
+                value)
+
+        return {'provided': trim_string_array(value.split(','))}
+    if is_colon_delimited:
+        return {'provided': trim_string_array(value.split(':'))}
+
+    # Assuming this wasn't a list, but a singular value.
+    return {'provided': value}
+
+
 def convert_imported_case(id: str, values_to_archive: Series) -> Dict[str, Any]:
     '''
     Converts original field names and values to the importedCase archival


### PR DESCRIPTION
This PR has a few commits, probably worth looking individually:

- First one is just autopep8 with new line lengths
- Second is separating input and output dataframes in preparation for adding the symptoms field, which has the same name in both input + output data sets -- it's also just cleaner and faster
- Third is the new conversions

Example of a comma-separated chronicDisease field (with unrelated stuff omitted for brevity):

```
{
    ...
    "chronicDisease": {
      "provided": [
        "diabetes",
        "hypertension",
        "obesity"
      ]
    },
    "importedCase": {
      ...
      "chronic_disease": "diabetes, hypertension, obesity",
      ...
    }
  }
```

And one with colon-separated symptoms:

```
  {
    ...
    "symptoms": {
      "provided": [
        "fever",
        "cough",
        "shortness of breath"
      ]
    },
    "importedCase": {
      ...
      "symptoms": "fever:cough:shortness of breath",
      ...
    }
  }
```