### PR TITLE
Update converter to export to latest data format

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -210,10 +210,7 @@
               }
             },
             "purpose": {
-              "enum": [
-                "family",
-                "conference"
-              ]
+              "bsonType": "string"
             },
             "additionalInformation": {
               "bsonType": "string"

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -2,12 +2,6 @@
   "$jsonSchema": {
     "bsonType": "object",
     "additionalProperties": false,
-    "required": [
-      "_id",
-      "location",
-      "source",
-      "revisionMetadata"
-    ],
     "properties": {
       "_id": {
         "bsonType": "objectId"
@@ -318,29 +312,104 @@
         "bsonType": "object",
         "additionalProperties": false,
         "properties": {
-          "additionalInformation": {
+          "ID": {
             "bsonType": "string"
           },
-          "notesForDiscussion": {
+          "age": {
             "bsonType": "string"
           },
-          "geoResolution": {
+          "sex": {
+            "bsonType": "string"
+          },
+          "city": {
+            "bsonType": "string"
+          },
+          "province": {
+            "bsonType": "string"
+          },
+          "country": {
+            "bsonType": "string"
+          },
+          "latitude": {
+            "bsonType": "double"
+          },
+          "longitude": {
+            "bsonType": "double"
+          },
+          "geo_resolution": {
+            "bsonType": "string"
+          },
+          "date_onset_symptoms": {
+            "bsonType": "string"
+          },
+          "date_admission_hospital": {
+            "bsonType": "string"
+          },
+          "date_confirmation": {
             "bsonType": "string"
           },
           "symptoms": {
             "bsonType": "string"
           },
-          "chronicDiseaseBinary": {
+          "lives_in_Wuhan": {
+            "bsonType": "string"
+          },
+          "travel_history_dates": {
+            "bsonType": "string"
+          },
+          "travel_history_location": {
+            "bsonType": "string"
+          },
+          "reported_market_exposure": {
+            "bsonType": "string"
+          },
+          "additional_information": {
+            "bsonType": "string"
+          },
+          "chronic_disease_binary": {
             "bsonType": "bool"
           },
-          "chronicDisease": {
+          "chronic_disease": {
+            "bsonType": "string"
+          },
+          "source": {
+            "bsonType": "string"
+          },
+          "sequence_available": {
             "bsonType": "string"
           },
           "outcome": {
             "bsonType": "string"
           },
-          "adminId": {
+          "date_death_or_discharge": {
             "bsonType": "string"
+          },
+          "notes_for_discussion": {
+            "bsonType": "string"
+          },
+          "location": {
+            "bsonType": "string"
+          },
+          "admin3": {
+            "bsonType": "string"
+          },
+          "admin2": {
+            "bsonType": "string"
+          },
+          "admin1": {
+            "bsonType": "string"
+          },
+          "country_new": {
+            "bsonType": "string"
+          },
+          "admin_id": {
+            "bsonType": "double"
+          },
+          "data_moderator_initials": {
+            "bsonType": "string"
+          },
+          "travel_history_binary": {
+            "bsonType": "bool"
           }
         }
       }

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -331,10 +331,10 @@
             "bsonType": "string"
           },
           "latitude": {
-            "bsonType": "double"
+            "bsonType": "string"
           },
           "longitude": {
-            "bsonType": "double"
+            "bsonType": "string"
           },
           "geo_resolution": {
             "bsonType": "string"
@@ -367,7 +367,7 @@
             "bsonType": "string"
           },
           "chronic_disease_binary": {
-            "bsonType": "bool"
+            "bsonType": "string"
           },
           "chronic_disease": {
             "bsonType": "string"
@@ -403,13 +403,13 @@
             "bsonType": "string"
           },
           "admin_id": {
-            "bsonType": "double"
+            "bsonType": "string"
           },
           "data_moderator_initials": {
             "bsonType": "string"
           },
           "travel_history_binary": {
-            "bsonType": "bool"
+            "bsonType": "string"
           }
         }
       }

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -212,5 +212,5 @@ def convert_imported_case(id: str, values_to_archive: Series) -> Dict[str, Any]:
     Converts original field names and values to the importedCase archival
     object.
     '''
-    return {k: v for k, v in values_to_archive.iteritems()
+    return {k: str(v) for k, v in values_to_archive.iteritems()
             if pd.notna(v)}

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -41,32 +41,27 @@ def convert_range(
         range_min = parse_fn(value_range[0])
         if len(value_range) == 1:
             return {
-                'range': {
-                    'max': format_fn(range_min)
-                }
+                'start': format_fn(range_min)
+
             } if value.startswith('-') else {
-                'range': {
-                    'min': format_fn(range_min)
-                }
+                'end': format_fn(range_min)
+
             }
 
         # Handle cases with a min and max.
         range_max = parse_fn(value_range[1])
         return {
-            'range': {
-                'min': format_fn(range_min),
-                'max': format_fn(range_max)
-            }
+            'start': format_fn(range_min),
+            'end': format_fn(range_max)
+
         }
 
     # We have a specific value. We create a range with identical min and max
     # values.
     parsed_value = parse_fn(value)
     return {
-        'range': {
-            'min': format_fn(parsed_value),
-            'max': format_fn(parsed_value)
-        }
+        'start': format_fn(parsed_value),
+        'end': format_fn(parsed_value)
     }
 
 
@@ -88,7 +83,7 @@ def convert_event(id: str, name: str, date_str: str) -> Dict[str, str]:
 
         return {
             'name': name,
-            'date': date_range
+            'dateRange': date_range
         }
     except (TypeError, ValueError):
         logging.warning(
@@ -115,7 +110,10 @@ def convert_events(id: str, dates: str, outcome: str) -> List[Dict[str, Any]]:
 def convert_age(id: str, age: str) -> Dict[str, Any]:
     '''Converts age column to the new demographics.age object. '''
     try:
-        return convert_range(age, float, lambda x: x)
+        age_range = convert_range(age, float, lambda x: x)
+        return {
+            'ageRange': age_range
+        } if age_range else None
     except ValueError:
         logging.warning('[%s] [demographics.age] value error %s', id, age)
 
@@ -143,7 +141,7 @@ def convert_location(id: str, location_id: float, country: str, adminL1: str,
 
     try:
         if pd.notna(location_id):
-            location['id'] = float(location_id)
+            location['id'] = str(int(location_id))
     except (TypeError, ValueError):
         logging.warning(
             '[%s] [location.id] invalid value %s', id, location_id)

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -15,7 +15,7 @@ def trim_string_array(values: List[str]) -> List[str]:
     values = [x.strip() for x in values]
 
     # Remove empty strings that can result from trailing delimiters ('cough,')
-    values = [i for i in values if i]
+    values = [str(i) for i in values if i]
 
     return values
 
@@ -82,7 +82,7 @@ def convert_event(id: str, name: str, date_str: str) -> Dict[str, str]:
             })
 
         return {
-            'name': name,
+            'name': str(name),
             'dateRange': date_range
         }
     except (TypeError, ValueError):
@@ -101,7 +101,7 @@ def convert_events(id: str, dates: str, outcome: str) -> List[Dict[str, Any]]:
     # The old data model had an outcome string, which will become an event in
     # the new data model, but it won't have a date associated with it.
     if outcome and type(outcome) is str:
-        events.append({'name': outcome})
+        events.append({'name': str(outcome)})
 
     # Filter out None values.
     return [e for e in events if e]
@@ -147,16 +147,16 @@ def convert_location(id: str, location_id: float, country: str, adminL1: str,
             '[%s] [location.id] invalid value %s', id, location_id)
 
     if pd.notna(country):
-        location['country'] = country
+        location['country'] = str(country)
 
     if pd.notna(adminL1):
-        location['administrativeAreaLevel1'] = adminL1
+        location['administrativeAreaLevel1'] = str(adminL1)
 
     if pd.notna(adminL2):
-        location['administrativeAreaLevel2'] = adminL2
+        location['administrativeAreaLevel2'] = str(adminL2)
 
     if pd.notna(locality):
-        location['locality'] = locality
+        location['locality'] = str(locality)
 
     geometry = {}
 


### PR DESCRIPTION
Changes to converter include:
- range representation changes
- the fact that location id should be a string (even though historic data has ints)

Also updates schema to reflect what the imported data will look like (as opposed to new data entered via the server), i.e. the imported data:
- won't have ids (mongodb will autogenerate on import);
- may not have some of the required fields, since almost no column has 100% coverage
- may have many more fields in importedCase

Tested with mongoimport:
`417 document(s) imported successfully. 24 document(s) failed to import.`