### PR TITLE
Convert notes and revisionMetadata fields

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -286,9 +286,7 @@
         "bsonType": "object",
         "additionalProperties": false,
         "required": [
-          "id",
-          "moderator",
-          "date"
+          "id"
         ],
         "properties": {
           "id": {

--- a/data-serving/scripts/README.md
+++ b/data-serving/scripts/README.md
@@ -31,6 +31,8 @@ We are currently populating the following new (top-level) fields in the schema:
 - Events
 - Symptoms
 - ChronicDisease
+- Notes
+- RevisionMetadata
 
 The following fields are not yet populated:
 
@@ -38,8 +40,6 @@ The following fields are not yet populated:
 - Source
 - OutbreakSpecifics
 - Pathogens
-- Notes
-- RevisionMetadata
 
 ### Original fields
 

--- a/data-serving/scripts/convert_data.py
+++ b/data-serving/scripts/convert_data.py
@@ -9,8 +9,10 @@ import logging
 import json
 import pandas as pd
 import sys
-from converters import (convert_demographics, convert_dictionary_field,
-                        convert_events, convert_imported_case, convert_location)
+from converters import (
+    convert_demographics, convert_dictionary_field, convert_events,
+    convert_imported_case, convert_location, convert_revision_metadata_field,
+    convert_notes_field)
 from pandas import DataFrame, Series
 from typing import Any
 
@@ -102,9 +104,19 @@ def convert(df_import: DataFrame) -> DataFrame:
             x['chronic_disease']),
         axis=1)
 
+    # Generate revision metadata.
+    df_export['revisionMetadata'] = df_import.apply(
+        lambda x: convert_revision_metadata_field(
+            x['data_moderator_initials']
+        ), axis=1)
+
+    # Generate notes.
+    df_export['notes'] = df_import.apply(lambda x: convert_notes_field(
+        [x['notes_for_discussion'], x['additional_information']]), axis=1)
+
     # Archive the original fields.
     df_export['importedCase'] = df_import.apply(lambda x: convert_imported_case(
-        x['ID'], x), axis=1)
+        x), axis=1)
 
     return df_export
 

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -253,7 +253,7 @@ def convert_dictionary_field(
 def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
         str, str]:
     '''
-    Populates a revisionMetadata field with an initial revision version of 0 and
+    Populates a revisionMetadata field with an initial revision number of 0 and
     the data moderator's initials where available.
     '''
     revision_metadata = {
@@ -267,7 +267,7 @@ def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
 
 
 def convert_notes_field(notes_fields: [str]) -> Dict[str, Any]:
-    '''Creates a notes field from up to a list of original notes fields '''
+    '''Creates a notes field from a list of original notes fields.'''
     notes = '; '.join([x for x in notes_fields if pd.notna(x)])
 
     return notes if notes else None

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -250,7 +250,30 @@ def convert_dictionary_field(
     return {'provided': [value]}
 
 
-def convert_imported_case(id: str, values_to_archive: Series) -> Dict[str, Any]:
+def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
+        str, str]:
+    '''
+    Populates a revisionMetadata field with an initial revision version of 0 and
+    the data moderator's initials where available.
+    '''
+    revision_metadata = {
+        'id': 0
+    }
+
+    if pd.notna(data_moderator_initials):
+        revision_metadata['moderator'] = data_moderator_initials
+
+    return revision_metadata
+
+
+def convert_notes_field(notes_fields: [str]) -> Dict[str, Any]:
+    '''Creates a notes field from up to a list of original notes fields '''
+    notes = '; '.join([x for x in notes_fields if pd.notna(x)])
+
+    return notes if notes else None
+
+
+def convert_imported_case(values_to_archive: Series) -> Dict[str, Any]:
     '''
     Converts original field names and values to the importedCase archival
     object.


### PR DESCRIPTION
No lossiness since original fields are strings, so still 99.7% conversion success

100% successfully imported into mongodb (with removal of a couple of required fields in revisionMetadata in the schema)

Sample notes conversion:
```
{
   ...
   "notes": "https://new.qq.com/omn/20200215/20200215A0LD4100.html; Contact with other confirmed cases; quarantined",
    "importedCase": {
      "ID": "000-1-10046",
      ...
      "additional_information": "Contact with other confirmed cases; quarantined",
      "notes_for_discussion": "https://new.qq.com/omn/20200215/20200215A0LD4100.html",
      ...
    }
}
```

Sample revisionMetadata conversion:
```
{
    ...
    "revisionMetadata": {
      "id": 0,
      "moderator": "TR"
    },
    "importedCase": {
      "ID": "003-40161",
      ...
      "data_moderator_initials": "TR",
      ...
    }
}
```