### PR TITLE
Create a bare-bones SAM/CF structure and retrieval Lambda function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local AWS testing and deployment artifacts.
+.aws

--- a/ingestion/functions/.gitignore
+++ b/ingestion/functions/.gitignore
@@ -1,0 +1,244 @@
+
+# Created by https://www.gitignore.io/api/osx,linux,python,windows,pycharm,visualstudiocode
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### OSX ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# Build folder
+
+*/build/*
+
+# End of https://www.gitignore.io/api/osx,linux,python,windows,pycharm,visualstudiocode

--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -1,0 +1,5 @@
+# Ingestion functions
+
+This directory contains AWS Lambda functions used in the epid ingestion system.
+
+TODO(axmb): Add additional information and commands.

--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -1,5 +1,9 @@
 # Ingestion functions
 
-This directory contains AWS Lambda functions used in the epid ingestion system.
+This directory contains AWS [Lambda functions](https://aws.amazon.com/lambda/)
+used in the epid ingestion system.
+
+The functions are managed, developed, and deployed using
+[SAM](https://aws.amazon.com/serverless/sam/).
 
 TODO(axmb): Add additional information and commands.

--- a/ingestion/functions/retrieval/requirements.txt
+++ b/ingestion/functions/retrieval/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/ingestion/functions/retrieval/requirements.txt
+++ b/ingestion/functions/retrieval/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.23.0

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -1,0 +1,39 @@
+import json
+import requests
+
+
+def lambda_handler(event, context):
+    """Global ingestion retrieval function.
+
+    Will be used to scrape source content and persist it to S3.
+    For now, logs and returns the IP of the machine on which it executes.
+    For more information on logging, see:
+      https://docs.aws.amazon.com/lambda/latest/dg/python-logging.html
+
+    Parameters
+    ----------
+    event: dict, required
+        In the canonical CloudWatch ScheduledEvent format.
+        For more information, see:
+          https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#schedule_event_type
+
+    context: object, required
+        Lambda Context runtime methods and attributes.
+        For more information, see:
+          https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
+
+    Returns
+    ------
+    JSON object containing the machine IP.
+
+       For more information on return types, see:
+         https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
+    """
+
+    try:
+        ip = requests.get("http://checkip.amazonaws.com/").text.strip()
+        print(ip)
+        return {'ip': ip}
+    except requests.RequestException as e:
+        print(e)
+        raise e

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -33,7 +33,7 @@ def lambda_handler(event, context):
     try:
         ip = requests.get("http://checkip.amazonaws.com/").text.strip()
         print(ip)
-        return {'ip': ip}
+        return {"ip": ip}
     except requests.RequestException as e:
         print(e)
         raise e

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -11,7 +11,7 @@ from retrieval import retrieval
 def scheduled_event():
     """Loads CloudWatch ScheduledEvent from file."""
     current_dir = os.path.dirname(__file__)
-    file_path = os.path.join(current_dir, 'scheduled_event.json')
+    file_path = os.path.join(current_dir, "scheduled_event.json")
     with open(file_path) as event_file:
         return json.load(event_file)
 
@@ -20,4 +20,4 @@ def test_lambda_handler(scheduled_event, requests_mock):
     expected_ip = "123.4.5.6"
     requests_mock.get("http://checkip.amazonaws.com/", text=expected_ip)
     response = retrieval.lambda_handler(scheduled_event, "")
-    assert response['ip'] == expected_ip
+    assert response["ip"] == expected_ip

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -1,0 +1,23 @@
+import logging
+import json
+import os
+import pytest
+import requests
+
+from retrieval import retrieval
+
+
+@pytest.fixture()
+def scheduled_event():
+    """Loads CloudWatch ScheduledEvent from file."""
+    current_dir = os.path.dirname(__file__)
+    file_path = os.path.join(current_dir, 'scheduled_event.json')
+    with open(file_path) as event_file:
+        return json.load(event_file)
+
+
+def test_lambda_handler(scheduled_event, requests_mock):
+    expected_ip = "123.4.5.6"
+    requests_mock.get("http://checkip.amazonaws.com/", text=expected_ip)
+    response = retrieval.lambda_handler(scheduled_event, "")
+    assert response['ip'] == expected_ip

--- a/ingestion/functions/retrieval/scheduled_event.json
+++ b/ingestion/functions/retrieval/scheduled_event.json
@@ -1,0 +1,12 @@
+{
+  "id": "53dc4d37-cffa-4f76-80c9-8b7d4a4d2eaa",
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "account": "123456789012",
+  "time": "2019-10-08T16:53:06Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:events:us-east-1:123456789012:rule/MyScheduledRule"
+  ],
+  "detail": {}
+}

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -16,6 +16,10 @@ Resources:
         - AWSLambdaReadOnlyAccess
       Timeout: 10 # Seconds
 
+# Declare values that can be imported to other CloudFormation stacks, or should
+# be made easily visable on the console.
+# For more information:
+#   https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html
 Outputs:
   RetrievalFunction:
     Description: "Retrieval Lambda function ARN"

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: AWS Lambda functions for epid ingestion
+
+Resources:
+  RetrievalFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: retrieval/
+      Handler: retrieval.lambda_handler
+      Runtime: python3.8
+      Description: Retrieve the executing machine IP
+      # Function's execution role
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSLambdaReadOnlyAccess
+      Timeout: 10 # Seconds
+
+Outputs:
+  RetrievalFunction:
+    Description: "Retrieval Lambda function ARN"
+    Value: !GetAtt RetrievalFunction.Arn

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -8,7 +8,7 @@ Resources:
     Properties:
       CodeUri: retrieval/
       Handler: retrieval.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.6
       Description: Retrieve the executing machine IP
       # Function's execution role
       Policies:

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -17,7 +17,7 @@ Resources:
       Timeout: 10 # Seconds
 
 # Declare values that can be imported to other CloudFormation stacks, or should
-# be made easily visable on the console.
+# be made easily visible on the console.
 # For more information:
 #   https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html
 Outputs:


### PR DESCRIPTION
Didn't add detailed documentation (I can do that in a subsequent PR). To test locally:

- Install the [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html). Set up your AWS credentials if you haven't.
- Run the following:

```
$ cd ingestion/functions
$ sam build
$ sam local invoke "RetrievalFunction" -e retrieval/scheduled_event.json
```

Finer point: would prefer to add a venv set up for the python, but can do in a later PR. Until then I've found it simplest to run utilities as modules using the function's configured Python version, e.g. `python3.8 -m pytest retrieval/retrieval_test.py`.

Coarser point:

I did a fair bit of research on managing serverless resources, e.g. Lambdas and their accoutrements. _Some_ sort of framework is a huge help (as compared to, say, manually zipping/uploading Lambda packages, and configuring integration points in AWS console): for easier/better development (e.g. local testing) and deployment (e.g. defining config in yaml, as opposed to everyone's local env/in CLI commands).

SAM seems the best option from a maintenance perspective. Serverless(.com) is a classic entry in the space, but given the BCH team is invested in AWS, it'd probably be more overhead than SAM. I'll probably talk with Jared and Gaurav about SAM and serverless in general (or slap it in a doc) -- it's a non-trivial decision, and ties into other aspects of how AWS is managed.