### PR TITLE
Covert source and pathogens fields

### DIFF
--- a/data-serving/scripts/README.md
+++ b/data-serving/scripts/README.md
@@ -33,13 +33,13 @@ We are currently populating the following new (top-level) fields in the schema:
 - ChronicDisease
 - Notes
 - RevisionMetadata
+- Source
+- Pathogens
 
 The following fields are not yet populated:
 
 - TravelHistory
-- Source
 - OutbreakSpecifics
-- Pathogens
 
 ### Original fields
 

--- a/data-serving/scripts/convert_data.py
+++ b/data-serving/scripts/convert_data.py
@@ -12,8 +12,8 @@ import sys
 from converters import (
     convert_demographics, convert_dictionary_field, convert_events,
     convert_imported_case, convert_location, convert_revision_metadata_field,
-    convert_notes_field)
-from pandas import DataFrame, Series
+    convert_notes_field, convert_source_field, convert_pathogens_field)
+from pandas import DataFrame
 from typing import Any
 
 
@@ -104,15 +104,23 @@ def convert(df_import: DataFrame) -> DataFrame:
             x['chronic_disease']),
         axis=1)
 
-    # Generate revision metadata.
+    # Generate new revision metadata column.
     df_export['revisionMetadata'] = df_import.apply(
         lambda x: convert_revision_metadata_field(
             x['data_moderator_initials']
         ), axis=1)
 
-    # Generate notes.
+    # Generate new notes column.
     df_export['notes'] = df_import.apply(lambda x: convert_notes_field(
         [x['notes_for_discussion'], x['additional_information']]), axis=1)
+
+    # Generate new source column.
+    df_export['source'] = df_import.apply(lambda x: convert_source_field(
+        x['source']), axis=1)
+
+    # Generate new pathogens column.
+    df_export['pathogens'] = df_import.apply(lambda x: convert_pathogens_field(
+        x['sequence_available']), axis=1)
 
     # Archive the original fields.
     df_export['importedCase'] = df_import.apply(lambda x: convert_imported_case(

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -14,8 +14,8 @@ from urllib.parse import urlparse
 
 def is_url(value: str) -> bool:
     try:
-        urlparse(value)
-        return True
+        parts = urlparse(value)
+        return parts.scheme and parts.netloc
     except:
         return False
 

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -9,6 +9,15 @@ import re
 from constants import VALID_SEXES
 from pandas import Series
 from typing import Any, Callable, Dict, List
+from urllib.parse import urlparse
+
+
+def is_url(value: str) -> bool:
+    try:
+        urlparse(value)
+        return True
+    except:
+        return False
 
 
 def trim_string_array(values: List[str]) -> List[str]:
@@ -271,6 +280,37 @@ def convert_notes_field(notes_fields: [str]) -> Dict[str, Any]:
     notes = '; '.join([x for x in notes_fields if pd.notna(x)])
 
     return notes if notes else None
+
+
+def convert_source_field(source: str) -> Dict[str, str]:
+    '''
+    Converts the source field to a new source object that has either a URL or
+    an unknown reference type.
+    '''
+    if pd.isna(source):
+        return None
+
+    return {
+        'url': source
+    } if is_url(source) else {
+        'other': source
+    }
+
+
+def convert_pathogens_field(sequence: str) -> List[Dict[str, Any]]:
+    '''
+    Converts the sequence field to an array of pathogens that may have sequence
+    source data.
+    '''
+    cov_pathogen = {
+        'name': 'sars-cov-2'
+    }
+
+    source = convert_source_field(sequence)
+    if source:
+        cov_pathogen['sequenceSource'] = source
+
+    return [cov_pathogen]
 
 
 def convert_imported_case(values_to_archive: Series) -> Dict[str, Any]:


### PR DESCRIPTION
This is lossless.

Note that we only have URL/other text present in the source data so these are the only fields of these new objects we can automatically populate.

Examples:

```
"sequenceSource": {
    "url": "https://github.com/openZH/covid_19"
}
```
```
"sequenceSource": {
    "other": "10.03.2020"
}
```
```
"source": {
    "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
}
```
```
"source": {
    "other": "Iran Ministry of Health"
}
```
