### PR TITLE
Exclude node_modules in sample vscode settings.json.

### DIFF
--- a/dev/.vscode/settings.json
+++ b/dev/.vscode/settings.json
@@ -21,6 +21,12 @@
   "[markdown]": {
     "editor.formatOnSave": false
   },
+  "editor.rulers": [
+    80
+  ],
+  "files.exclude": {
+      "**/node_modules/": true
+  },
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,
@@ -39,8 +45,5 @@
     "--max-line-length",
     "80",
     "--experimental"
-  ],
-  "editor.rulers": [
-    80
   ]
 }


### PR DESCRIPTION
(And small ~alphabetization fix.)