### PR TITLE
Flatten Case data to display it in the table

### DIFF
--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -138,6 +138,7 @@ export default class LinelistTable extends React.Component<{}, LinelistTableStat
                         // https://docs.mongodb.com/manual/text-search/
                         search: false,
                         filtering: true,
+                        padding: "dense",
                         pageSize: 10,
                         pageSizeOptions: [5, 10, 20, 50, 100],
                     }}

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -19,6 +19,7 @@ interface Event {
 
 interface Demographics {
     sex: string;
+    age: string;
 }
 
 interface Source {
@@ -41,6 +42,17 @@ interface LinelistTableState {
     url: string,
 }
 
+// Material table doesn't handle structured fields well, we flatten all fields in this row.
+interface TableRow {
+    id: string;
+    // demographics
+    sex: string;
+    age: string;
+    // source
+    source_url: string;
+    notes: string;
+}
+
 export default class LinelistTable extends React.Component<{}, LinelistTableState> {
     constructor(props: any) {
         super(props);
@@ -50,15 +62,15 @@ export default class LinelistTable extends React.Component<{}, LinelistTableStat
         }
     }
 
-    addCase(newRowData: Case) {
+    addCase(newRowData: TableRow) {
         return new Promise((resolve, reject) => {
             const newCase = {
                 demographics: {
-                    sex: newRowData.demographics
+                    sex: newRowData.sex
                 },
                 notes: newRowData.notes,
                 source: {
-                    url: newRowData.source
+                    url: newRowData.source_url
                 }
             }
             const response = axios.post(this.state.url, newCase);
@@ -72,9 +84,9 @@ export default class LinelistTable extends React.Component<{}, LinelistTableStat
         });
     }
 
-    deleteCase(rowData: Case) {
+    deleteCase(rowData: TableRow) {
         return new Promise((reject) => {
-            let deleteUrl = this.state.url + rowData._id;
+            let deleteUrl = this.state.url + rowData.id;
             const response = axios.delete(deleteUrl);
             response.then(() => {
                 // Refresh the table data
@@ -85,7 +97,7 @@ export default class LinelistTable extends React.Component<{}, LinelistTableStat
         })
     }
 
-    editCase(newRowData: Case, oldRowData: Case | undefined) {
+    editCase(newRowData: TableRow, oldRowData: TableRow | undefined) {
         return new Promise(() => {
             console.log("TODO: edit " + newRowData);
             // Refresh the table data
@@ -99,18 +111,11 @@ export default class LinelistTable extends React.Component<{}, LinelistTableStat
                 <MaterialTable
                     tableRef={this.state.tableRef}
                     columns={[
-                        { title: 'ID', field: '_id', filtering: false },
-                        {
-                            title: 'Demographics', field: 'demographics',
-                            filtering: false,
-                            render: rowData => <span>{rowData.demographics?.sex}</span>,
-                        },
+                        { title: 'ID', field: 'id', filtering: false },
+                        { title: 'Sex', field: 'sex', filtering: false },
+                        { title: 'Age', field: 'age', filtering: false },
                         { title: 'Notes', field: 'notes' },
-                        {
-                            title: 'Source', field: 'source',
-                            filtering: false,
-                            render: rowData => <span>{rowData.source?.url}</span>,
-                        },
+                        { title: 'Source URL', field: 'source_url', filtering: false },
                     ]}
 
                     data={query =>
@@ -122,8 +127,19 @@ export default class LinelistTable extends React.Component<{}, LinelistTableStat
                             listUrl += query.filters.map((filter) => `${filter.column.field}:${filter.value}`).join(",");
                             const response = axios.get<ListResponse>(listUrl);
                             response.then(result => {
+                                let flattened_cases: TableRow[] = [];
+                                const cases = result.data.cases;
+                                for (const c of cases) {
+                                    flattened_cases.push({
+                                        id: c._id,
+                                        sex: c.demographics?.sex,
+                                        age: c.demographics?.age,
+                                        notes: c.notes,
+                                        source_url: c.source?.url,
+                                    });
+                                }
                                 resolve({
-                                    data: result.data.cases,
+                                    data: flattened_cases,
                                     page: query.page,
                                     totalCount: result.data.total,
                                 });
@@ -143,10 +159,10 @@ export default class LinelistTable extends React.Component<{}, LinelistTableStat
                         pageSizeOptions: [5, 10, 20, 50, 100],
                     }}
                     editable={{
-                        onRowAdd: (newRowData: Case) => this.addCase(newRowData),
-                        onRowUpdate: (newRowData: Case, oldRowData: Case | undefined) =>
+                        onRowAdd: (newRowData: TableRow) => this.addCase(newRowData),
+                        onRowUpdate: (newRowData: TableRow, oldRowData: TableRow | undefined) =>
                             this.editCase(newRowData, oldRowData),
-                        onRowDelete: (rowData: Case) => this.deleteCase(rowData),
+                        onRowDelete: (rowData: TableRow) => this.deleteCase(rowData),
                     }}
                 />
             </Paper>


### PR DESCRIPTION
You have noticed I'm sure but we can't pass dotted.field.expression as material-table columns which means we should flatten all the received Case structure to display each field nicely and be able to update them as well.

I am not sure what to make of arrays yet, let's discuss tomorrow.