### PR TITLE
stop testing on node 10.x we're not using it

### DIFF
--- a/.github/workflows/curator-api-node.yml
+++ b/.github/workflows/curator-api-node.yml
@@ -7,28 +7,24 @@ on:
   push:
     branches: [master]
     paths:
-    - '.github/workflows/curator-api-node.yml'
-    - 'verification/curator-service/api/**'
+      - ".github/workflows/curator-api-node.yml"
+      - "verification/curator-service/api/**"
   pull_request:
     branches: [master]
     paths:
-    - '.github/workflows/curator-api-node.yml'
-    - 'verification/curator-service/api/**'
+      - ".github/workflows/curator-api-node.yml"
+      - "verification/curator-service/api/**"
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
       - name: Build and test
         run: |
           npm ci

--- a/.github/workflows/curator-ui-node.yml
+++ b/.github/workflows/curator-ui-node.yml
@@ -7,28 +7,24 @@ on:
   push:
     branches: [master]
     paths:
-    - '.github/workflows/curator-ui-node.yml'
-    - 'verification/curator-service/ui/**'
+      - ".github/workflows/curator-ui-node.yml"
+      - "verification/curator-service/ui/**"
   pull_request:
     branches: [master]
     paths:
-    - '.github/workflows/curator-ui-node.yml'
-    - 'verification/curator-service/ui/**'
+      - ".github/workflows/curator-ui-node.yml"
+      - "verification/curator-service/ui/**"
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
       - name: Build and test
         run: |
           npm ci

--- a/.github/workflows/data-service-node.yml
+++ b/.github/workflows/data-service-node.yml
@@ -7,28 +7,24 @@ on:
   push:
     branches: [master]
     paths:
-    - '.github/workflows/data-service-node.yml'
-    - 'data-serving/data-service/**'
+      - ".github/workflows/data-service-node.yml"
+      - "data-serving/data-service/**"
   pull_request:
     branches: [master]
     paths:
-    - '.github/workflows/data-service-node.yml'
-    - 'data-serving/data-service/**'
+      - ".github/workflows/data-service-node.yml"
+      - "data-serving/data-service/**"
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
       - name: Build and test
         run: |
           npm ci


### PR DESCRIPTION
```
timothe-macbookpro~/healthmap/healthmap-gdo-temp(nodes|…) % node --version
v12.16.2
```

No strong feeling about this but seems like we're just wasting free build time of github actions with that node version.