### PR TITLE
Grant retrieval lambda write access to S3.

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 
 SOURCE_ID_FIELD = "sourceId"
-OUTPUT_BUCKET = "epid-raw-sources"
+OUTPUT_BUCKET = "epid-sources-raw"
 TIME_FILEPART_FORMAT = "/%Y/%m/%d/%H%M/"
 
 s3_client = boto3.client("s3")

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -6,7 +6,7 @@ Resources:
   RawSourcesBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: epid-raw-sources
+      BucketName: epid-sources-raw
   RetrievalFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -3,6 +3,10 @@ Transform: AWS::Serverless-2016-10-31
 Description: AWS Lambda functions for epid ingestion
 
 Resources:
+  RawSourcesBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: epid-raw-sources
   RetrievalFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
@@ -14,6 +18,8 @@ Resources:
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
+        - S3WritePolicy:
+            BucketName: !Ref RawSourcesBucket
       Timeout: 10 # Seconds
 
 # Declare values that can be imported to other CloudFormation stacks, or should


### PR DESCRIPTION
Overlooked this previously, since `sam local invoke` executes with the default profile/credentials configured in `~/.aws/`. I created a profile referencing the lambda function role ARN in order to test this stuff locally, but there's some issues assuming the role from the CLI. Didn't spin too long on it, since policy updates should be very infrequent.