### PR TITLE
Refactor conversion script into parsers, converters, and utils

### DIFF
--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -21,8 +21,7 @@ from utils import format_iso_8601_date, is_url, warn
 def convert_range(value: Any, parser: Callable[[Any], Any],
                   formatter: Callable[[Any], Any]) -> Dict[str, Any]:
     '''
-    Converts a value to a a range format, given the provided parser and
-    formatter.
+    Converts a value to a range format, given the provided parser and formatter.
 
     Parameters:
       value: Input to be parsed and formatted as a range.
@@ -224,7 +223,7 @@ def convert_demographics(id: str, age: Any, sex: str) -> Dict[str, Any]:
 
     try:
         converted_age = convert_age_range(age)
-        if converted_age:
+        if converted_age is not None:
             demographics['ageRange'] = converted_age
     except ValueError as e:
         warn(id, 'demographics.ageRange', age, e)
@@ -281,14 +280,14 @@ def convert_location(id: str, country: str, adminL1: str,
 
     try:
         parsed_latitude = parse_latitude(latitude)
-        if parsed_latitude:
+        if parsed_latitude is not None:
             geometry['latitude'] = parsed_latitude
     except ValueError as e:
         warn(id, 'location.latitude', latitude, e)
 
     try:
         parsed_longitude = parse_longitude(longitude)
-        if parsed_longitude:
+        if parsed_longitude is not None:
             geometry['longitude'] = parsed_longitude
     except ValueError as e:
         warn(id, 'location.longitude', longitude, e)

--- a/data-serving/scripts/converters.py
+++ b/data-serving/scripts/converters.py
@@ -1,248 +1,297 @@
-'''Library of conversion functions for converting CSV line-list data to json.'''
+'''
+Library of conversion functions for converting CSV line-list data to json.
 
-import datetime
-import logging
-import math
-import numbers
+The converters are specifically responsible for converting the input fields to
+the new format; they call parsers as necessary to parse typed values from input
+strings and then format them to match the output schema.
+
+Converters log errors thrown by the parsers, since they have the context on
+which row failed to convert.
+'''
+
 import pandas as pd
-import pycountry
-import re
-from constants import LOCATIONS, VALID_SEXES
+from parsers import (parse_age, parse_bool, parse_date,
+                     parse_latitude, parse_location, parse_longitude,
+                     parse_range, parse_sex, parse_string_list)
 from pandas import Series
 from typing import Any, Callable, Dict, List
-from urllib.parse import urlparse
+from utils import format_iso_8601_date, is_url, warn
 
 
-def is_url(value: str) -> bool:
-    try:
-        parts = urlparse(value)
-        return parts.scheme and parts.netloc
-    except:
-        return False
-
-
-def convert_bool(value: str) -> bool:
-    if pd.isna(value) or value == 'na':
-        return None
-
-    # Throw an error if the value can't be converted to a boolean.
-    if not re.match(r'\b(true|yes|false|no)\b', value, re.IGNORECASE):
-        raise ValueError('not a valid bool')
-
-    # If it can be converted to a boolean, return whether it's True or False.
-    match = re.match(r'\b(true|yes)\b', value, re.IGNORECASE)
-    return True if match else False
-
-
-def trim_string_array(values: List[str]) -> List[str]:
-    # Remove whitespace that might surround the delimiter ('cough, fever')
-    values = [x.strip() for x in values]
-
-    # Remove empty strings that can result from trailing delimiters ('cough,')
-    values = [str(i) for i in values if i]
-
-    # Remove duplicate values
-    return list(set(values))
-
-
-def convert_range(
-        value: str, parse_fn: Callable[[str],
-                                       str],
-        format_fn: Callable[[Any],
-                            Any]) -> Dict[str, Any]:
+def convert_range(value: Any, parser: Callable[[Any], Any],
+                  formatter: Callable[[Any], Any]) -> Dict[str, Any]:
     '''
-    Converts either a string representation of a single value or a range of
-    values into a range object. The values can be of any types using the custom
-    parse and format functions.
-    '''
-    if pd.isna(value):
-        return None
+    Converts a value to a a range format, given the provided parser and
+    formatter.
 
-    # First check if the value is represented as a range.
-    if type(value) is str and value.find('-') >= 0:
-        value_range = trim_string_array(value.split('-'))
+    Parameters:
+      value: Input to be parsed and formatted as a range.
+      parser: Function to parse the start and end values into the expected type.
+      formatter: Function to format the output start and end values.
 
-        # Handle open ranges (i.e. missing min or max).
-        first_val = parse_fn(value_range[0])
-        if len(value_range) == 1:
-            return {
-                'end': format_fn(first_val)
-
-            } if value.startswith('-') else {
-                'start': format_fn(first_val)
-            }
-
-        # Handle cases with a min and max.
-        second_val = parse_fn(value_range[1])
-        return {
-            'start': format_fn(first_val),
-            'end': format_fn(second_val)
-
+    Returns:
+      None: When the input value is empty.
+      Dict[str, Any]: When the value is present and successfully parsed. The
+        dictionary is in the format:
+        {
+          'start': Any,
+          'end': Any
         }
+        where start == end if value represents a single value, as opposed to a
+        range, and where the type of the values is dictated by the parser and
+        formatter.
+    '''
+    start, end = parse_range(value, parser)
 
-    # We have a specific value. We create a range with identical min and max
-    # values.
-    parsed_value = parse_fn(value)
-    return {
-        'start': format_fn(parsed_value),
-        'end': format_fn(parsed_value)
-    }
+    range = {}
+    if start is not None:
+        range['start'] = formatter(start)
+    if end is not None:
+        range['end'] = formatter(end)
 
-
-def convert_date_range(date_str: str) -> Dict[str, Any]:
-    return convert_range(
-        date_str,
-        lambda x: datetime.datetime.strptime(x, '%d.%m.%Y'),
-        lambda x: {
-            '$date': x.strftime('%Y-%m-%dT%H:%M:%SZ')
-        })
+    return range if range else None
 
 
-def convert_event(id: str, name: str, date_str: str) -> Dict[str, str]:
+def convert_age_range(ages: Any) -> Dict[str, float]:
+    '''
+    Converts an age value to the expected age range output format. This wraps
+    convert_range with a date-specific parser and formatter.
+
+    Parameters:
+      ages: A representation of an age expected to be a string in one of the
+        following formats:
+        - "x": Single age in years.
+        - "x months": Single age in months.
+        - "x weeks": Single age in weeks.
+        - "x - y": Age range.
+        - "x -": Age range start.
+        - "- y": Age range end.
+
+    Raises:
+      ValueError if the value can't be successfully parsed into an age.
+    Returns:
+      None: When the input value is empty.
+      Dict[str, float]: When the value is present and successfully parsed. The
+        dictionary in the format:
+        {
+          'start': float,
+          'end': float
+        }
+        where start == end if value represents a single age.
+    '''
+    return convert_range(ages, parse_age, lambda x: x)
+
+
+def convert_date_range(dates: Any) -> Dict[str, Dict[str, str]]:
+    '''
+    Converts a date value to the expected date range output format. This wraps
+    convert_range with a date-specific parser and formatter.
+
+    Parameters:
+      dates: A representation of date(s) expected to be a string in one of the
+        following formats:
+        - "dd.mm.YY": Single date.
+        - "dd.mm.YY - dd.mm.YY": Date range.
+        - "dd.mm.YY -": Date range start.
+        - "- dd.mm.YY": Date range end.
+
+    Raises:
+      ValueError if the value can't be successfully parsed into a datetime.
+    Returns:
+      None: When the input value is empty.
+      Dict[str, Dict[str, str]]: When the value is present and successfully
+        parsed. The dictionary in the format:
+        {
+          'start': {
+            '$date': str,
+          },
+          'end': {
+            '$date': str
+          }
+        }
+        where the strings are ISO 8601 date representations, and start == end if
+        the value represents a single date.
+    '''
+    return convert_range(dates, parse_date, lambda x: {
+        '$date': format_iso_8601_date(x)
+    })
+
+
+def convert_event(id: str, name: str, dates: Any) -> Dict[str, Any]:
     '''
     Converts a single event date column to the new event object with a name and
     range of dates.
+
+    Parameters:
+      id: The id of the input row for logging a failed conversion.
+      name: The name of the event.
+      dates: The value representing the date(s) of the event, to be parsed into
+        a date range.
+
+    Returns:
+      None: When the input value is empty.
+      Dict[str, str]: When the values are present and succesfully parsed. The
+        dictionary is in the format:
+        {
+          'name': str,
+          'dateRange': {
+            'start': {
+              '$date': str,
+            },
+            'end': {
+              '$date': str
+            }
+          }
+        }
+        where the date strings are ISO 8601 date representations.
+
     '''
-    if pd.isna(date_str):
+    if pd.isna(dates):
         return None
 
     try:
-        date_range = convert_date_range(date_str)
-
         return {
-            'name': str(name),
-            'dateRange': date_range
+            'name': name,
+            'dateRange': convert_date_range(dates)
         }
-    except (TypeError, ValueError):
-        logging.warning(
-            '[%s] [event[name=%s]] invalid value %s', id, name, date_str)
+    except ValueError as e:
+        warn(id, 'event[name="' + name + '"', dates, e)
 
 
-def convert_events(id: str, dates: str, outcome: str) -> List[Dict[str, Any]]:
+def convert_events(id: str, dates: Dict[str, Any],
+                   outcome: str) -> List[Dict[str, Any]]:
     '''
     Converts event date columns to the new events array. Also includes the
     outcome field as an event, even though we don't have an associated date.
+
+    Parameters:
+      id: The id of the input row for logging a failed conversion.
+      dates: A map from event name to event date.
+      outcome: String representing the outcome of the case.
+
+    Returns:
+      List[Dict[str, Any]]: Always. List of events in the format:
+        [{
+          'name': str,
+          'dateRange': {
+            'start': {
+              '$date': str,
+            },
+            'end': {
+              '$date': str
+            }
+          }
+        }]
+        where the date strings are ISO 8601 date representations.
     '''
     events = list(map(lambda i: convert_event(
         id, i[0], i[1]), dates.items()))
 
     # The old data model had an outcome string, which will become an event in
     # the new data model, but it won't have a date associated with it.
-    if outcome and type(outcome) is str:
+    if pd.notna(outcome):
         events.append({'name': str(outcome)})
 
     # Filter out None values.
-    return [e for e in events if e]
+    events = [e for e in events if e]
+
+    return events if events else None
 
 
-def parse_age(age: str) -> float:
-    if type(age) is str:
-        # Convert ages in the format of "x month(s)" to floats
-        num_months = re.findall(r'(\d+)\smonth', age)
-        if num_months:
-            return int(num_months[0]) / 12
+def convert_demographics(id: str, age: Any, sex: str) -> Dict[str, Any]:
+    '''
+    Converts age and sex columns to the new demographics object.
 
-        # Convert ages in the format "x week(s)" to floats
-        num_weeks = re.findall(r'(\d+)\sweek', age)
-        if num_weeks:
-            return int(num_weeks[0]) / 52
+    Parameters:
+      id: The id of the input row for logging a failed conversion.
 
-    return float(age)
+    Returns:
+      Dict[str, Any]: Always. Dictionary is in the format:
+        {
+          'ageRange': {
+            'start': {
+              '$date': str,
+            },
+            'end': {
+              '$date': str
+            },
+          'sex': str,
+          'species': str
+        }
 
-
-def convert_age(id: str, age: str) -> Dict[str, Any]:
-    '''Converts age column to the new demographics.ageRange object. '''
-    try:
-        age_range = convert_range(age, parse_age, lambda x: x)
-
-        if not age_range:
-            return None
-        if 'start' in age_range and(
-                age_range['start'] < -1 or age_range['start'] > 300):
-            raise ValueError('age_range.start outside of valid range')
-        if 'end' in age_range and(
-                age_range['end'] < -1 or age_range['end'] > 300):
-            raise ValueError('age_range.end outside of valid range')
-
-        return age_range
-    except ValueError:
-        logging.warning('[%s] [demographics.ageRange] value error %s', id, age)
-
-
-def convert_sex(id: str, sex: str) -> str:
-    if pd.isna(sex):
-        return None
-
-    try:
-        if str(sex).lower() not in VALID_SEXES:
-            raise ValueError('sex not in enum')
-
-        return str(sex).capitalize()
-    except ValueError:
-        logging.warning('[%s] [demographics.sex] value error %s', id, sex)
-
-
-def convert_demographics(id: str, age: str, sex: str) -> Dict[str, Any]:
-    '''Converts age and sex columns to the new demographics object. '''
+    '''
     demographics = {}
 
-    converted_age = convert_age(id, age)
-    if converted_age:
-        demographics['ageRange'] = converted_age
+    try:
+        converted_age = convert_age_range(age)
+        if converted_age:
+            demographics['ageRange'] = converted_age
+    except ValueError as e:
+        warn(id, 'demographics.ageRange', age, e)
 
-    converted_sex = convert_sex(id, sex)
-    if converted_sex:
-        demographics['sex'] = converted_sex
+    try:
+        parsed_sex = parse_sex(sex)
+        if parsed_sex:
+            demographics['sex'] = parsed_sex
+    except ValueError as e:
+        warn(id, 'demographics.sex', age, e)
 
     demographics['species'] = 'Homo sapien'
 
-    # If the dictionary is empty, we want to omit it from the JSON output
-    return demographics if demographics else None
+    return demographics
 
 
 def convert_location(id: str, country: str, adminL1: str,
                      adminL2: str, locality: str, latitude: float,
                      longitude: float) -> Dict[str, Any]:
-    '''Converts location fields to a location object.'''
+    '''
+    Converts location fields to a location object.
+
+    Parameters:
+      id: The id of the input row for logging a failed conversion.
+
+    Returns:
+      Dict[str, Any]: Always. The dictionary is in the format:
+        {
+          'country': str,
+          'administrativeAreaLevel1': str,
+          'administrativeAreaLevel2': str,
+          'locality': str,
+          'geometry': {
+          'latitude': float,
+          'longitude': float
+          }
+        }
+    '''
     location = {}
 
     if pd.notna(country):
-        location['country'] = str(country)
+        location['country'] = country
 
     if pd.notna(adminL1):
-        location['administrativeAreaLevel1'] = str(adminL1)
+        location['administrativeAreaLevel1'] = adminL1
 
     if pd.notna(adminL2):
-        location['administrativeAreaLevel2'] = str(adminL2)
+        location['administrativeAreaLevel2'] = adminL2
 
     if pd.notna(locality):
-        location['locality'] = str(locality)
+        location['locality'] = locality
 
     geometry = {}
 
     try:
-        if pd.notna(latitude):
-            normalized_latitude = float(latitude)
-
-            if normalized_latitude < -90 or normalized_latitude > 90:
-                raise ValueError('latitude outside of valid range')
-
-            geometry['latitude'] = normalized_latitude
-    except (TypeError, ValueError):
-        logging.warning(
-            '[%s] [location.latitude] invalid value %s', id, latitude)
+        parsed_latitude = parse_latitude(latitude)
+        if parsed_latitude:
+            geometry['latitude'] = parsed_latitude
+    except ValueError as e:
+        warn(id, 'location.latitude', latitude, e)
 
     try:
-        if pd.notna(longitude):
-            normalized_longitude = float(longitude)
-
-            if normalized_longitude < -180 or normalized_latitude > 180:
-                raise ValueError('longitude outside of valid range')
-
-            geometry['longitude'] = normalized_longitude
-    except (TypeError, ValueError):
-        logging.warning(
-            '[%s] [location.longitude] invalid value %s', id, longitude)
+        parsed_longitude = parse_longitude(longitude)
+        if parsed_longitude:
+            geometry['longitude'] = parsed_longitude
+    except ValueError as e:
+        warn(id, 'location.longitude', longitude, e)
 
     if geometry:
         location['geometry'] = geometry
@@ -250,31 +299,30 @@ def convert_location(id: str, country: str, adminL1: str,
     return location
 
 
-def convert_dictionary_field(
-        id: str, field_name: str, value: str) -> Dict[
+def convert_dictionary_field(id: str, field_name: str, value: str) -> Dict[
         str, List[str]]:
-    if pd.isna(value):
-        return None
-    if type(value) is not str:
-        logging.warning(
-            '[%s] [field_name] invalid value %s', id, value)
-        return None
+    '''
+    Converts a list of strings into a dictionary-style field.
 
-    is_comma_delimited = value.find(',') >= 0
-    is_colon_delimited = value.find(':') >= 0
+    Parameters:
+      id: The id of the input row for logging a failed conversion.
+      field_name: The name of the dictionary-style field for logging a failed
+        conversion.
+      value: The value to be converted.
 
-    if is_comma_delimited:
-        if is_colon_delimited:
-            logging.warning(
-                '[%s] [field_name] two delimiters detected, using comma %s', id,
-                value)
-
-        return {'provided': trim_string_array(value.split(','))}
-    if is_colon_delimited:
-        return {'provided': trim_string_array(value.split(':'))}
-
-    # Assuming this wasn't a list, but a singular value.
-    return {'provided': [value]}
+    Returns:
+      None: When the input value is empty.
+      Dict[str, List[str]]: When the value is present and successfully parsed.
+        The dictionary in the format:
+        {
+          'provided': List[str]
+        }
+    '''
+    try:
+        string_list = parse_string_list(value)
+        return {'provided': string_list} if string_list else None
+    except ValueError as e:
+        warn(id, 'field_name.provided', value, e)
 
 
 def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
@@ -282,6 +330,13 @@ def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
     '''
     Populates a revisionMetadata field with an initial revision number of 0 and
     the data moderator's initials where available.
+
+    Returns:
+      Dict[str, str]: Always. The dictionary is in the format:
+        {
+          'id': int,
+          'moderator': str
+        }
     '''
     revision_metadata = {
         'id': 0
@@ -293,10 +348,14 @@ def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
     return revision_metadata
 
 
-def convert_notes_field(notes_fields: [str]) -> Dict[str, Any]:
-    '''Creates a notes field from a list of original notes fields.'''
-    notes = '; '.join([x for x in notes_fields if pd.notna(x)])
+def convert_notes_field(notes_fields: [str]) -> str:
+    '''
+    Creates a notes field from a list of original notes fields.
 
+    Returns:
+      str: Always.
+    '''
+    notes = '; '.join([x for x in notes_fields if pd.notna(x)])
     return notes if notes else None
 
 
@@ -304,6 +363,15 @@ def convert_source_field(source: str) -> Dict[str, str]:
     '''
     Converts the source field to a new source object that has either a URL or
     an unknown reference type.
+
+    Returns:
+      None: When the input is empty.
+      Dict[str, str]: When the input is nonempty. The dictionary is in the
+        format:
+        {
+          'url': str,
+          'other': str
+        }
     '''
     if pd.isna(source):
         return None
@@ -319,6 +387,16 @@ def convert_pathogens_field(sequence: str) -> List[Dict[str, Any]]:
     '''
     Converts the sequence field to an array of pathogens that may have sequence
     source data.
+
+    Returns:
+      List[Dict[str, Any]]: Always. The output is in the format:
+        [{
+          'name': str,
+          'sequenceSource': {
+            'url': str,
+            'other': str
+          }
+        }]
     '''
     cov_pathogen = {
         'name': 'sars-cov-2'
@@ -333,100 +411,81 @@ def convert_pathogens_field(sequence: str) -> List[Dict[str, Any]]:
 
 def convert_outbreak_specifics(id: str, reported_market_exposure: str,
                                lives_in_wuhan: str) -> Dict[str, bool]:
+    '''
+    Converts the covid-19-specific fields into a new outbreakSpecifics
+    object.
+
+    Parameters:
+      id: The id of the input row for logging a failed conversion.
+
+    Returns:
+      None: When the input is empty.
+      Dict[str, bool]: When the input is nonempty. The dictionary is in the
+        format:
+        {
+          'reportedMarketExposure': bool,
+          'livesInWuhan': bool
+        }
+    '''
+
     outbreak_specifics = {}
 
     try:
-        normalized = convert_bool(reported_market_exposure)
+        normalized = parse_bool(reported_market_exposure)
         if normalized is not None:
             outbreak_specifics['reportedMarketExposure'] = normalized
-    except ValueError:
-        logging.warning(
-            '[%s] [outbreakSpecifics[reportedMarketExposure]] invalid value %s',
-            id, reported_market_exposure)
+    except ValueError as e:
+        warn(
+            id, 'outbreakSpecifics.reportedMarketExposure',
+            reported_market_exposure, e)
 
     try:
-        normalized = convert_bool(lives_in_wuhan)
+        normalized = parse_bool(lives_in_wuhan)
         if normalized is not None:
             outbreak_specifics['livesInWuhan'] = normalized
-    except ValueError:
-        logging.warning(
-            '[%s] [outbreakSpecifics[livesInWuhan]] invalid value %s', id,
-            lives_in_wuhan)
+    except ValueError as e:
+        warn(id, 'outbreakSpecifics.livesInWuhan', lives_in_wuhan, e)
 
     return outbreak_specifics if outbreak_specifics else None
 
 
-def convert_location_string(location_str: str) -> Dict[str, Any]:
-    if pd.isna(location_str) or location_str.lower() == 'no' or location_str.lower() == 'none':
-        return None
-    if type(location_str) is not str:
-        raise ValueError('location is not a string')
-    if ';' in location_str or ':' in location_str or location_str.count(',') > 1:
-        raise ValueError('location is a list')
-
-    # Remove common prefixes 'travelled to' and 'traveled to' and lowercase it.
-    normalized_location = re.sub(
-        r'(travelled|traveled)\sto\s(the\s*)?',
-        '', location_str.lower())
-
-    # First try to look up the location in a hard-coded map that accounts for
-    # most popular locations that the lookup (below) misses.
-    location = LOCATIONS.get(normalized_location)
-    if location is not None:
-        return location
-
-    # Next, attempt to look up the location in a countries database.
-    try:
-        country = pycountry.countries.lookup(normalized_location)
-        return {
-            'country': country.name
-        }
-    except LookupError:
-        pass
-
-    # If the format is ${CITY}, ${COUNTRY}, we want to keep the more specific
-    # piece. If not, look it up as is. We do this split after checking for the
-    # country to avoid false positives in the case where it's actually a
-    # comma-separated list of countries ("China, Brazil")
-    normalized_subdivision = normalized_location.split(',')[0]
-
-    # Well, if it's not a country, maybe it's a subdivision. And if not, it will
-    # throw!
-    subdivision = pycountry.subdivisions.lookup(normalized_subdivision)
-    return {
-        'administrativeAreaLevel1': subdivision.name,
-        'country': subdivision.country.name
-    }
-
-
-def convert_travel_history(id: str, date_str: str, location_str: str) -> Dict[str, Any]:
+def convert_travel_history(id: str, dates: str, location: str) -> Dict[
+        str, Any]:
     '''
-    Converts the travel history date and location fields to the new
-    travelHistory document.
+    Converts the travel history date and location fields to a new travelHistory
+    object.
+
+    Parameters:
+      id: The id of the input row for logging a failed conversion.
+
+    Returns:
+      None: When the input is empty.
+      Dict[str, Any]: When the input is nonempty. The dictionary is in the
+        format:
+        {
+          'location': {...},
+          'dateRange': {...}
+        }
     '''
     travel_history = {}
 
     try:
-        location = convert_location_string(location_str)
-        if not location:
+        parsed_location = parse_location(location)
+        if not parsed_location:
+            # It's invalid to have dates without a location; only convert the
+            # rest of the field (i.e. the dates) if location was successful.
             return None
 
-        travel_history['location'] = location
-
-        # It's invalid to have dates without a location; only convert the date
-        # if location was successful.
-        try:
-            date_range = convert_date_range(date_str)
-            if date_range:
-                travel_history['dateRange'] = date_range
-        except (TypeError, ValueError):
-            logging.warning(
-                '[%s] [travelHistory.dateRange] invalid value %s', id,
-                date_str)
+        travel_history['location'] = parsed_location
     except (LookupError, ValueError) as e:
-        logging.warning(
-            '[%s] [travelHistory.location] invalid value "%s" (%s)', id,
-            location_str, e)
+        warn(id, 'travelHistory.location', location, e)
+
+    try:
+        date_range = convert_date_range(dates)
+        if date_range:
+            travel_history['dateRange'] = date_range
+    except (TypeError, ValueError) as e:
+        warn(id, 'travelHistory.dateRange', dates, e)
 
     return [travel_history] if travel_history else None
 
@@ -435,6 +494,10 @@ def convert_imported_case(values_to_archive: Series) -> Dict[str, Any]:
     '''
     Converts original field names and values to the importedCase archival
     object.
+
+    Returns:
+      Dict[str, Any]: Always. Dictionary keys are the names of the original
+        fields, and the values are the values of the original fields.
     '''
     return {k: str(v) for k, v in values_to_archive.iteritems()
             if pd.notna(v)}

--- a/data-serving/scripts/parsers.py
+++ b/data-serving/scripts/parsers.py
@@ -1,0 +1,319 @@
+'''
+Library of functions that parse a typed value from a string, e.g. bool, numeric,
+list, or enum.
+
+The convention is for each of these parsers to return None when the value is
+absent, or effectively absent (i.e. the string "na" or "none"). The parsers will
+throw if the input value cannot be succesfully parsed, given the output type and
+other constraints.
+
+These parsers should have no notion of the input or output document format, nor
+should they log errors; they should raise exceptions for the converters to
+handle.
+'''
+
+import re
+import pycountry
+import pandas as pd
+import numbers
+import math
+import datetime
+from typing import Any, Callable, Dict, List, Tuple
+from constants import LOCATIONS, VALID_SEXES
+from utils import trim_string_list
+
+
+def parse_bool(value: Any) -> bool:
+    '''
+    Parses the input into a bool.
+
+    Parameters:
+      value: A bool or string representing a boolean value, which may include:
+        true, false, yes, no, or na.
+
+    Raises:
+      ValueError if the value is not a valid bool.
+    Returns:
+      None: When the input value is empty or a string indicating n/a.
+      bool: When the value is present and successfully parsed.
+    '''
+    if pd.isna(value) or value == 'na':
+        return None
+
+    # Throw an error if the value can't be converted to a boolean.
+    if not re.match(r'\b(true|yes|false|no)\b', value, re.IGNORECASE):
+        raise ValueError('not a valid bool')
+
+    # If it can be converted to a boolean, return whether it's True or False.
+    return True if re.match(r'\b(true|yes)\b', value, re.IGNORECASE) else False
+
+
+def parse_range(
+        value: Any,
+        parse_fn: Callable[[str], Any]) -> Tuple[Any, Any]:
+    '''
+    Converts either a string representation of a single value or a range of
+    values into a range object. The values can be of any types using the custom
+    parse and format functions.
+
+    Parameters:
+      value: A value to be parsed into a range.
+      parse_fn: The parser to apply to the start and end values of the range.
+
+    Returns:
+      Tuple[Any, Any]: Always. The tuple is in the format (start, end).
+    '''
+    if pd.isna(value):
+        return (None, None)
+
+    # First check if the value is represented as a range.
+    if type(value) is str and value.find('-') >= 0:
+        value_range = trim_string_list(value.split('-'))
+
+        # Handle open ranges (i.e. missing start or end).
+        first_val = parse_fn(value_range[0])
+        if len(value_range) == 1:
+            return (None, first_val) if value.startswith('-') else (first_val, None)
+
+        # Handle cases with a start and end.
+        second_val = parse_fn(value_range[1])
+        return (first_val, second_val)
+
+    # We have a specific value. We create a range with identical start and end
+    # values.
+    parsed_value = parse_fn(value)
+    return (parsed_value, parsed_value)
+
+
+def parse_age(value: Any) -> float:
+    '''
+    Parses a numeric age from the given value. Handles strings and numeric
+    inputs, including some age-specific string reoresebtatuibs such as "x
+    months" or "y weeks."
+
+    Parameters:
+      value: String or numeric value representing an age.
+
+    Raises:
+      ValueError: If the value can't be parsed into a valid age.
+    Returns:
+      None: When the value is empty.
+      float: When the value is present and successfully parsed.
+    '''
+    if pd.isna(value):
+        return None
+
+    if type(value) is str:
+        # Convert ages in the format of "x month(s)" to floats
+        num_months = re.findall(r'(\d+)\smonth', value)
+        if num_months:
+            return int(num_months[0]) / 12
+
+        # Convert ages in the format "x week(s)" to floats
+        num_weeks = re.findall(r'(\d+)\sweek', value)
+        if num_weeks:
+            return int(num_weeks[0]) / 52
+
+    value = float(value)
+
+    # Check that the age is within the valid range.
+    if value < -1 or value > 300:
+        raise ValueError('age outside of valid range')
+
+    return float(value)
+
+
+def parse_date(value: str) -> datetime:
+    '''
+    Parses dates into datetime objects.
+
+    Parameters:
+      value: Date string expected to be in the format dd.mm.YY.
+
+    Raises:
+        ValueError if the value can't be successfully parsed into a datetime.
+    Returns:
+      None: When the value is empty.
+      datetime: When the value is present and successfully parsed.
+    '''
+    if pd.isna(value):
+        return None
+
+    return datetime.datetime.strptime(value, '%d.%m.%Y')
+
+
+def parse_location(value: Any) -> Dict[str, Any]:
+    '''
+    Parses a location from a string. Locations are dictionaries of location
+    properties in the format:
+
+    Parameters:
+        value: Value representing a location, expected to be in the format:
+          - "$city, $country"
+          - "$country"
+          - "traveled to (the) ($city,) $country"
+          - "travelled to (the) ($city,) $country"
+
+    Raises:
+        ValueError: If the location does not conform to the expected format.
+        LookupError: If the location conforms to the expected format but cannot
+          be found in the pycountry database.
+    Returns:
+      None: When the input value is empty or a string indicating n/a.
+      Dict[str, Any]: When the value is present and successfully parsed. The
+        dictionary is in the format:
+        {
+          'country': str,
+          'administrativeAreaLevel1': str,
+          'administrativeAreaLevel2': str,
+          'locality': str,
+          'geometry': {
+          'latitude': float,
+          'longitude': float
+          }
+        }
+    '''
+    if pd.isna(value) or value.lower() in ['no', 'none']:
+        return None
+    if type(value) is not str:
+        raise ValueError('location is not a string')
+    if ';' in value or ':' in value or value.count(',') > 1:
+        raise ValueError('location is a list')
+
+    # Remove common prefixes 'travelled to' and 'traveled to' and lowercase it.
+    normalized_location = re.sub(
+        r'(travelled|traveled)\sto\s(the\s*)?',
+        '', value.lower())
+
+    # First try to look up the location in a hard-coded map that accounts for
+    # most popular locations that the lookup (below) misses.
+    location = LOCATIONS.get(normalized_location)
+    if location is not None:
+        return location
+
+    # Next, attempt to look up the location in a countries database.
+    try:
+        country = pycountry.countries.lookup(normalized_location)
+        return {
+            'country': country.name
+        }
+    except LookupError:
+        pass
+
+    # If the format is ${CITY}, ${COUNTRY}, we want to keep the more specific
+    # piece. If not, look it up as is. We do this split after checking for the
+    # country to avoid false positives in the case where it's actually a
+    # comma-separated list of countries ("China, Brazil")
+    normalized_subdivision = normalized_location.split(',')[0]
+
+    # Well, if it's not a country, maybe it's a subdivision. And if not, it will
+    # throw!
+    subdivision = pycountry.subdivisions.lookup(normalized_subdivision)
+    return {
+        'administrativeAreaLevel1': subdivision.name,
+        'country': subdivision.country.name
+    }
+
+
+def parse_sex(value: Any) -> str:
+    '''
+    Parses a sex enum value from the input.
+
+    Parameters:
+      value: Value representing a sex expected to be one of "male", "female."
+
+    Raises:
+      ValueError: The value is not in the sex enum.
+    Returns:
+      None: When the input value is empty or a string indicating n/a.
+      str: When the value is present and successfully parsed.
+    '''
+    if pd.isna(value):
+        return None
+
+    if str(value).lower() not in VALID_SEXES:
+        raise ValueError('sex not in enum')
+
+    return str(value).capitalize()
+
+
+def parse_latitude(value: Any) -> float:
+    '''
+    Parses latitude from the input.
+
+    Parameters:
+      value: Value representing a latitude.
+
+    Raises:
+      ValueError: The value is not a float within [-90, 90].
+    Returns:
+      None: When the input value is empty.
+      float: When the value is present and successfully parsed.
+    '''
+    if pd.isna(value):
+        return None
+
+    latitude = float(value)
+
+    if latitude < -90 or latitude > 90:
+        raise ValueError('latitude outside of valid range')
+
+    return latitude
+
+
+def parse_longitude(value: Any) -> float:
+    '''
+    Parses longitude from the input.
+
+    Parameters:
+      value: Value representing a longitude.
+
+    Raises:
+      ValueError: The value is not a float within [-180, 180].
+    Returns:
+      None: When the input value is empty.
+      float: When the value is present and successfully parsed.
+    '''
+    if pd.isna(value):
+        return None
+
+    longitude = float(value)
+
+    if longitude < -180 or longitude > 180:
+        raise ValueError('longitude outside of valid range')
+
+    return longitude
+
+
+def parse_string_list(value: Any) -> List[str]:
+    '''
+    Parses a list of strings from the input.
+
+    Parameters:
+      value: Value representing a list of strings. The value is expected to be a
+        comma- or colon-separated string.
+
+    Raises:
+      ValueError: The value does not conform to the expected format.
+    Returns:
+      None: When the input value is empty.
+      List[str]: When the value is present and successfully parsed.
+    '''
+    if pd.isna(value):
+        return None
+    if type(value) is not str:
+        raise ValueError('not a string')
+
+    is_comma_delimited = value.find(',') >= 0
+    is_colon_delimited = value.find(':') >= 0
+
+    if is_comma_delimited:
+        if is_colon_delimited:
+            raise ValueError('two delimiters detected')
+
+        return trim_string_list(value.split(','))
+    if is_colon_delimited:
+        return trim_string_list(value.split(':'))
+
+    # Assuming this wasn't a list, but a singular value.
+    return [value]

--- a/data-serving/scripts/utils.py
+++ b/data-serving/scripts/utils.py
@@ -1,0 +1,37 @@
+'''Utilities for the parsers and converters.'''
+
+import logging
+from typing import List
+from urllib.parse import urlparse
+
+
+def is_url(value: str) -> bool:
+    '''Returns whether the string is a URL.'''
+    try:
+        parts = urlparse(value)
+        return parts.scheme and parts.netloc
+    except:
+        return False
+
+
+def trim_string_list(values: List[str]) -> List[str]:
+    '''
+    Removes extra whitespace, duplicates, and empty string values from a
+    list of strings.
+    '''
+    # Remove whitespace that might surround the delimiter ('cough, fever').
+    values = [x.strip() for x in values]
+
+    # Remove empty strings that can result from trailing delimiters ('cough,').
+    values = [str(i) for i in values if i]
+
+    # Remove duplicate values.
+    return list(set(values))
+
+
+def format_iso_8601_date(value: str) -> str:
+    return value.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def warn(id: str, field_name: str, value: str, error: Exception) -> None:
+    logging.warning('[%s] [%s] "%s": %s', id, field_name, value, error)

--- a/data-serving/scripts/utils.py
+++ b/data-serving/scripts/utils.py
@@ -25,8 +25,10 @@ def trim_string_list(values: List[str]) -> List[str]:
     # Remove empty strings that can result from trailing delimiters ('cough,').
     values = [str(i) for i in values if i]
 
-    # Remove duplicate values.
-    return list(set(values))
+    # Remove duplicate values (stable).
+    deduped = []
+    [deduped.append(x) for x in values if x not in deduped]
+    return deduped
 
 
 def format_iso_8601_date(value: str) -> str:

--- a/data-serving/scripts/utils.py
+++ b/data-serving/scripts/utils.py
@@ -1,5 +1,6 @@
 '''Utilities for the parsers and converters.'''
 
+import datetime
 import logging
 from typing import List
 from urllib.parse import urlparse
@@ -31,7 +32,8 @@ def trim_string_list(values: List[str]) -> List[str]:
     return deduped
 
 
-def format_iso_8601_date(value: str) -> str:
+def format_iso_8601_date(value: datetime) -> str:
+    '''Formats a datetime into an ISO 8601 string.'''
     return value.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 

--- a/data-serving/scripts/utils.py
+++ b/data-serving/scripts/utils.py
@@ -1,6 +1,5 @@
 '''Utilities for the parsers and converters.'''
 
-import datetime
 import logging
 from typing import List
 from urllib.parse import urlparse
@@ -30,11 +29,6 @@ def trim_string_list(values: List[str]) -> List[str]:
     deduped = []
     [deduped.append(x) for x in values if x not in deduped]
     return deduped
-
-
-def format_iso_8601_date(value: datetime) -> str:
-    '''Formats a datetime into an ISO 8601 string.'''
-    return value.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
 def warn(id: str, field_name: str, value: str, error: Exception) -> None:


### PR DESCRIPTION
I know this looks like an enormous diff... because it is... but it's actually a no-op, aside from one bug fix* (aside from the bug fix, the diff between the exported cases at head and here is empty).

It's a big change because:
- I added a lot of **documentation**
- I **refactored** converters.py into 3 files: converters, parsers, and utils.

The breakdown is:
- **Converters** are the format-aware pieces that transform input format into output format.
- **Parsers** take a single value and parse it into the correct type/perform validation appropriate for that field.
- **Utils** are the not-those-things functions.

Now all of the logging is done in the converters, and exceptions are only raised in the parsers.

Since it's a reasonable-size refactor, I recommend ignoring the diff and focusing on the function comments and whether it generally makes sense how the functions were split up; no need to review logic since it hasn't changed.

This should make it a lot more testable and maintainable. I'll probably add some basic tests soon to prevent regressions.


*would you believe this related to start/end of ranges? OK