### PR TITLE
Change routes in frontend so that / can be a simple explanation page and not require auth

### DIFF
--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -63,7 +63,7 @@ function Home() {
     <nav>
       <Link to="/cases">Linelist</Link><br />
       <Link to="/cases/new">Enter new case</Link><br />
-      <Link to="/privacypolicy">Privacy policy</Link><br />
+      <Link to="/privacy-policy">Privacy policy</Link><br />
       <Link to="/terms">Terms of service</Link><br />
     </nav>
   )

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -1,5 +1,6 @@
 import {
   BrowserRouter,
+  Link,
   Route,
   Switch
 } from "react-router-dom";
@@ -29,11 +30,14 @@ function App() {
         <BrowserRouter>
           <EpidNavbar />
           <Switch>
-            <Route path="/new">
+            <Route path="/cases/new">
               <NewEntry />
             </Route>
-            <Route exact path="/">
+            <Route path="/cases">
               <Linelist />
+            </Route>
+            <Route exact path="/">
+              <Home />
             </Route>
           </Switch>
         </BrowserRouter>
@@ -52,6 +56,17 @@ function NewEntry() {
   return (
     <NewCaseForm />
   );
+}
+
+function Home() {
+  return (
+    <nav>
+      <Link to="/cases">Linelist</Link><br />
+      <Link to="/cases/new">Enter new case</Link><br />
+      <Link to="/privacypolicy">Privacy policy</Link><br />
+      <Link to="/terms">Terms of service</Link><br />
+    </nav>
+  )
 }
 
 export default App;

--- a/verification/curator-service/ui/src/components/EpidNavbar.test.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.test.tsx
@@ -14,12 +14,12 @@ test('renders epid brand', () => {
     expect(brandName).toBeInTheDocument();
 });
 
-test('redirects to new case on click', () => {
+test('redirects to home on click', () => {
     const history = createMemoryHistory()
-    const { getByText } = render(
+    const { getByTestId } = render(
         <Router history={history}>
             <EpidNavbar />
         </Router>);
-    fireEvent.click(getByText(/Add a new case/))
-    expect(history.location.pathname).toBe("/new");
+    fireEvent.click(getByTestId('home-btn'))
+    expect(history.location.pathname).toBe("/");
 });  

--- a/verification/curator-service/ui/src/components/EpidNavbar.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.tsx
@@ -23,19 +23,12 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-
-
-
 export default function EpidNavbar() {
     let history = useHistory();
     const classes = useStyles();
 
     const handleHomeClick = () => {
         history.push('/');
-    };
-
-    const handleAddCase = () => {
-        history.push('/new');
     };
 
     return (
@@ -48,9 +41,6 @@ export default function EpidNavbar() {
                     <Typography variant="h6" className={classes.title}>
                         epid
                     </Typography>
-                    <Button color="inherit" onClick={handleAddCase}>
-                        Add a new case
-                    </Button>
                 </Toolbar>
             </AppBar>
         </div>

--- a/verification/curator-service/ui/src/components/EpidNavbar.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.tsx
@@ -35,7 +35,7 @@ export default function EpidNavbar() {
         <div className={classes.root}>
             <AppBar position="static">
                 <Toolbar>
-                    <IconButton onClick={handleHomeClick} edge="start" className={classes.menuButton} color="inherit" aria-label="menu">
+                    <IconButton data-testid="home-btn" onClick={handleHomeClick} edge="start" className={classes.menuButton} color="inherit" aria-label="menu">
                         <HomeIcon />
                     </IconButton>
                     <Typography variant="h6" className={classes.title}>

--- a/verification/curator-service/ui/src/components/EpidNavbar.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.tsx
@@ -1,7 +1,6 @@
 import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 
 import AppBar from '@material-ui/core/AppBar';
-import Button from '@material-ui/core/Button';
 import HomeIcon from '@material-ui/icons/Home';
 import IconButton from '@material-ui/core/IconButton';
 import React from "react";

--- a/verification/curator-service/ui/src/components/EpidNavbar.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.tsx
@@ -34,7 +34,13 @@ export default function EpidNavbar() {
         <div className={classes.root}>
             <AppBar position="static">
                 <Toolbar>
-                    <IconButton data-testid="home-btn" onClick={handleHomeClick} edge="start" className={classes.menuButton} color="inherit" aria-label="menu">
+                    <IconButton
+                        data-testid="home-btn"
+                        onClick={handleHomeClick}
+                        edge="start"
+                        className={classes.menuButton}
+                        color="inherit"
+                        aria-label="menu">
                         <HomeIcon />
                     </IconButton>
                     <Typography variant="h6" className={classes.title}>


### PR DESCRIPTION
/ will be used as an explanation page about the website and not require authentication, other subpages like /cases or /scrapers, etc will require auth.

![image](https://user-images.githubusercontent.com/1255432/81273927-e494e200-904f-11ea-8298-8f8adafd5d1f.png)