### PR TITLE
proxy requests from 3002 to 3001 so that the UI only talks to itself

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -39,6 +39,4 @@ services:
         stdin_open: true
         environment:
             PORT: "3002"
-            # Can't use http://curator:3001 here because we open the browser
-            # outside of the container so it wouldn't work.
-            REACT_APP_API_ENDPOINT: "http://localhost:3001"
+            REACT_APP_PROXY_URL: "http://curator:3001"

--- a/verification/curator-service/ui/Dockerfile
+++ b/verification/curator-service/ui/Dockerfile
@@ -20,4 +20,5 @@ EXPOSE 3002
 # Start service, will trigger a build.
 # Environment variables must be passed, notably:
 # - PORT
+# - REACT_APP_PROXY_URL
 CMD [ "npm", "run-script", "start-noenv" ]

--- a/verification/curator-service/ui/Dockerfile
+++ b/verification/curator-service/ui/Dockerfile
@@ -20,5 +20,4 @@ EXPOSE 3002
 # Start service, will trigger a build.
 # Environment variables must be passed, notably:
 # - PORT
-# - REACT_APP_API_ENDPOINT
 CMD [ "npm", "run-script", "start-noenv" ]

--- a/verification/curator-service/ui/package-lock.json
+++ b/verification/curator-service/ui/package-lock.json
@@ -1762,6 +1762,14 @@
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
       "integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw=="
     },
+    "@types/http-proxy": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
+      "integrity": "sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -6604,14 +6612,55 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
-      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.3.tgz",
+      "integrity": "sha512-GHvPeBD+A357zS5tHjzj6ISrVOjjCiy0I92bdyTJz0pNmIjFxO0NX/bX+xkGgnclKQE/5hHAB9JEQ7u9Pw4olg==",
       "requires": {
-        "http-proxy": "^1.17.0",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10"
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "http-signature": {
@@ -15181,6 +15230,17 @@
                 "is-extglob": "^2.1.0"
               }
             }
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+          "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+          "requires": {
+            "http-proxy": "^1.17.0",
+            "is-glob": "^4.0.0",
+            "lodash": "^4.17.11",
+            "micromatch": "^3.1.10"
           }
         },
         "is-absolute-url": {

--- a/verification/curator-service/ui/package.json
+++ b/verification/curator-service/ui/package.json
@@ -16,6 +16,7 @@
     "axios": "^0.19.2",
     "formik": "^2.1.4",
     "formik-material-ui": "^2.0.0-beta.1",
+    "http-proxy-middleware": "^1.0.3",
     "material-table": "^1.57.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -26,7 +27,7 @@
   },
   "scripts": {
     "start-noenv": "react-scripts start",
-    "start": "PORT=3002 REACT_APP_API_ENDPOINT=http://localhost:3001 react-scripts start",
+    "start": "PORT=3002 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test-silent": "react-scripts test --watchAll=false",

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -59,7 +59,7 @@ export default class LinelistTable extends React.Component<{}, LinelistTableStat
         super(props);
         this.state = {
             tableRef: React.createRef(),
-            url: (process.env.REACT_APP_API_ENDPOINT || "") + '/api/cases/',
+            url: '/api/cases/',
         }
     }
 

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -25,7 +25,7 @@ export default function NewCaseForm() {
             onSubmit={async (values, errors) => {
                 try {
                     await axios.post(
-                        (process.env.REACT_APP_API_ENDPOINT || "") + '/api/cases',
+                        '/api/cases',
                         {
                             demographics: {
                                 sex: values.sex,

--- a/verification/curator-service/ui/src/setupProxy.js
+++ b/verification/curator-service/ui/src/setupProxy.js
@@ -1,0 +1,11 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+module.exports = function (app) {
+    app.use(
+        '/api',
+        createProxyMiddleware({
+            // Proxy API requests to curator service.
+            target: process.env.REACT_APP_PROXY_URL || "http://localhost:3001",
+            changeOrigin: true,
+        })
+    );
+};


### PR DESCRIPTION
Yes I lied when I said I was out for today, couldn't let that one go sorry.

This is great, this means all /api calls are now made to the same origin. It will make auth much simpler.

I had to customize the proxy as described in https://create-react-app.dev/docs/proxying-api-requests-in-development/#configuring-the-proxy-manually because one cannot use "localhost" in docker composed networks (https://docs.docker.com/compose/networking/).