### PR TITLE
Add a private global module for mongo-cli types

### DIFF
--- a/data-serving/scripts/import-data/mongo-cli/index.d.ts
+++ b/data-serving/scripts/import-data/mongo-cli/index.d.ts
@@ -1,0 +1,74 @@
+// Type definitions for mongo-cli.
+
+/**
+ * MongoDB's main connection-type object, which can be coerced into the
+ * `Connection` interface in usage.
+ */
+declare let Mongo: any;
+
+/** Mongo CLI has its own print and read functions. OK, I guess! */
+declare function print(message: string): void;
+declare function printjson(message: number): void;
+declare function cat(path: string): string;
+
+/**
+ * The main connection object, representing the connection to the instance
+ * specified arguments to `mongo`. Provides access to databases.
+ */
+interface Connection {
+    host: string;
+    getDB: (name: string) => Promise<Database>;
+}
+
+/**
+ * An object representing a database in the instance. The database may have
+ * collections, and can have commands run on it.
+ */
+interface Database {
+    createCollection: (
+        name: string,
+        options?: CreateCollectionOptions,
+    ) => Promise<CommandResult>;
+
+    getCollectionNames: () => Promise<[string]>;
+
+    runCommand: (
+        command: InsertCommand | CollModCommand,
+    ) => Promise<CommandResult>;
+}
+
+/** A command to modify a collection, as an arg to `runCommand`. */
+interface CollModCommand {
+    collMod: string;
+    validator: JSON;
+}
+
+/**
+ * A command to insert documents into a collection, as an arg to `runCommand`.
+ */
+interface InsertCommand {
+    insert: string;
+    documents: JSON;
+}
+
+/** Options to pass with the command to create a collection. */
+interface CreateCollectionOptions {
+    validator: JSON;
+}
+
+/** The result of a call to `runCommand.` */
+interface CommandResult {
+    ok: number;
+}
+
+/** The result of a call to `runCommand` with an `InsertCommand.` */
+interface InsertDataCommandResult extends CommandResult {
+    n: number;
+    writeErrors: [
+        {
+            index: number;
+            code: number;
+            errmsg: string;
+        },
+    ];
+}

--- a/data-serving/scripts/import-data/mongo-cli/package.json
+++ b/data-serving/scripts/import-data/mongo-cli/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "@types/mongo-cli",
+    "private": true,
+    "types": "index.d.ts"
+}


### PR DESCRIPTION
This allows the import-data script, developed in ts, to understand the types from the mongo CLI.

Used these references for building it:

- https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html#global-libraries
- https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-d-ts.html

And these references for the types:

- https://docs.mongodb.com/manual/tutorial/write-scripts-for-the-mongo-shell/
- https://docs.mongodb.com/manual/reference/method/
