### PR TITLE
Raise docker-compose build context dir to allow file sharing

### DIFF
--- a/data-serving/data-service/Dockerfile
+++ b/data-serving/data-service/Dockerfile
@@ -1,18 +1,18 @@
 FROM node:12
 
 # Create app directory
-WORKDIR /usr/src/app
+WORKDIR /usr/src/app/data-serving/data-service
 
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
-COPY package*.json ./
+COPY data-serving/data-service/package*.json ./
 
 # RUN npm clean install
 RUN npm ci
 
 # Bundle app source
-COPY . .
+COPY data-serving/data-service/. .
 
 # Build the app
 RUN npm run-script build

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -9,7 +9,9 @@ services:
         environment:
             MONGO_INITDB_DATABASE: "covid19"
     curator:
-        build: ../verification/curator-service/api
+        build:
+          context: ../.
+          dockerfile: verification/curator-service/api/Dockerfile
         init: true
         ports:
             - "3001:3001"
@@ -20,7 +22,9 @@ services:
             DB_CONNECTION_STRING: "mongodb://mongo:27017/covid19"
             DATASERVER_URL: "http://data:3000"
     data:
-        build: ../data-serving/data-service
+        build:
+          context: ../.
+          dockerfile: data-serving/data-service/Dockerfile
         init: true
         ports:
             - "3000:3000"
@@ -29,7 +33,9 @@ services:
         environment:
             DB_CONNECTION_STRING: "mongodb://mongo:27017/covid19"
     curatorui:
-        build: ../verification/curator-service/ui
+        build:
+          context: ../.
+          dockerfile: verification/curator-service/ui/Dockerfile
         init: true
         ports:
             - "3002:3002"

--- a/verification/curator-service/api/Dockerfile
+++ b/verification/curator-service/api/Dockerfile
@@ -1,18 +1,18 @@
 FROM node:12
 
 # Create app directory
-WORKDIR /usr/src/app
+WORKDIR /usr/src/app/verification/curator-service/api
 
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
-COPY package*.json ./
+COPY verification/curator-service/api/package*.json ./
 
 # RUN npm clean install
 RUN npm ci
 
 # Bundle app source
-COPY . .
+COPY verification/curator-service/api/. .
 
 # Build the app
 RUN npm run-script build

--- a/verification/curator-service/ui/Dockerfile
+++ b/verification/curator-service/ui/Dockerfile
@@ -1,18 +1,18 @@
 FROM node:12
 
 # Create app directory
-WORKDIR /usr/src/app
+WORKDIR /usr/src/app/verification/curator-service/ui
 
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
-COPY package*.json ./
+COPY verification/curator-service/ui/package*.json ./
 
 # RUN npm clean install
 RUN npm ci
 
 # Bundle app source
-COPY . .
+COPY verification/curator-service/ui/. .
 
 # Expose service on port 3002.
 EXPOSE 3002


### PR DESCRIPTION
Specify services build context and dockerfile separately. Define the context as the epid root dir, allowing use to use shared files (e.g. #109).

There are two downsides here, which are:

- Forced compartmentalization can be a good thing at times (though Node TS provides this, to an extent).
- Slightly more cognitive overhead in our docker config.

Happy to revert if we don't want this, though I'm leaning "worth" right now.