### PR TITLE
add login/logout buttons to navbar

### DIFF
--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -43,16 +43,13 @@ export const configurePassport = (
 ): void => {
     passport.serializeUser<UserDocument, string>((user, done) => {
         // Serializes the user id in the cookie, no user info should be in there, just the id.
-        console.log('serializing user id in cookie');
         done(null, user.id);
     });
 
     passport.deserializeUser<UserDocument, string>((id, done) => {
-        console.log('deserializing user id from cookie');
         // Find the user based on its id in the cookie.
         User.findById(id)
             .then((user) => {
-                console.log('Got user:', user);
                 if (user) {
                     done(null, user);
                 } else {

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -1,5 +1,4 @@
 import {
-  BrowserRouter,
   Link,
   Route,
   Switch
@@ -27,20 +26,18 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <div className="App">
-        <BrowserRouter>
-          <EpidNavbar />
-          <Switch>
-            <Route path="/cases/new">
-              <NewEntry />
-            </Route>
-            <Route path="/cases">
-              <Linelist />
-            </Route>
-            <Route exact path="/">
-              <Home />
-            </Route>
-          </Switch>
-        </BrowserRouter>
+        <EpidNavbar />
+        <Switch>
+          <Route path="/cases/new">
+            <NewEntry />
+          </Route>
+          <Route path="/cases">
+            <Linelist />
+          </Route>
+          <Route exact path="/">
+            <Home />
+          </Route>
+        </Switch>
       </div>
     </ThemeProvider>
   );

--- a/verification/curator-service/ui/src/components/EpidNavbar.test.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.test.tsx
@@ -1,25 +1,81 @@
-import { MemoryRouter, Router } from 'react-router-dom';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import EpidNavbar from './EpidNavbar';
+import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
+import axios from 'axios';
 import { createMemoryHistory } from 'history';
 
-test('renders epid brand', () => {
-    const { getByText } = render(
-        <MemoryRouter>
-            <EpidNavbar />
-        </MemoryRouter>);
-    const brandName = getByText(/epid/i);
-    expect(brandName).toBeInTheDocument();
+jest.mock('axios');
+let mockedAxios = axios as jest.Mocked<typeof axios>;
+
+beforeEach(() => {
+    // Provide a default response for the profile fetch
+    // when the component mounts.
+    const axiosResponse = {
+        data: {},
+        status: 403,
+        statusText: 'Forbidden',
+        config: {},
+        headers: {},
+    };
+    mockedAxios.get.mockResolvedValue(axiosResponse);
 });
 
-test('redirects to home on click', () => {
+afterEach(() => {
+    jest.clearAllMocks();
+})
+
+test('renders epid brand', async () => {
+    await act(async () => {
+        render(
+            <MemoryRouter>
+                <EpidNavbar />
+            </MemoryRouter>);
+    });
+    expect(screen.getByText(/epid/i)).toBeInTheDocument();
+});
+
+test('renders login button when not logged in', async () => {
+    await act(async () => {
+        render(
+            <MemoryRouter>
+                <EpidNavbar />
+            </MemoryRouter>);
+    });
+    expect(screen.getByText(/Login/i)).toBeInTheDocument();
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/auth/profile');
+});
+
+test('renders logout button when logged in', async () => {
+    const axiosResponse = {
+        data: { email: "foo@bar.com" },
+        status: 200,
+        statusText: 'Forbidden',
+        config: {},
+        headers: {},
+    };
+    mockedAxios.get.mockResolvedValueOnce(axiosResponse);
+    await act(async () => {
+        render(
+            <MemoryRouter>
+                <EpidNavbar />
+            </MemoryRouter>);
+    });
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/auth/profile');
+    expect(screen.getByText(/foo@bar.com/i)).toBeInTheDocument();
+});
+
+test('redirects to home on click', async () => {
     const history = createMemoryHistory()
-    const { getByTestId } = render(
-        <Router history={history}>
-            <EpidNavbar />
-        </Router>);
-    fireEvent.click(getByTestId('home-btn'))
+    await act(async () => {
+        render(
+            <MemoryRouter>
+                <EpidNavbar />
+            </MemoryRouter>);
+    });
+    fireEvent.click(screen.getByTestId('home-btn'));
     expect(history.location.pathname).toBe("/");
 });  

--- a/verification/curator-service/ui/src/components/EpidNavbar.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.tsx
@@ -1,52 +1,84 @@
-import React, { useEffect } from "react";
-import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
+import { Button, withStyles } from "@material-ui/core";
+import { Theme, createStyles } from '@material-ui/core/styles';
 
 import AppBar from '@material-ui/core/AppBar';
 import HomeIcon from '@material-ui/icons/Home';
 import IconButton from '@material-ui/core/IconButton';
 import { Link } from "react-router-dom";
+import React from "react";
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
+import { WithStyles } from "@material-ui/core/styles/withStyles";
+import axios from 'axios';
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            flexGrow: 1,
-        },
-        menuButton: {
-            marginRight: theme.spacing(2),
-        },
-        title: {
-            flexGrow: 1,
-        },
-    }),
-);
+const styles = (theme: Theme) => createStyles({
+    root: {
+        flexGrow: 1,
+    },
+    menuButton: {
+        marginRight: theme.spacing(2),
+    },
+    title: {
+        flexGrow: 1,
+    },
+});
 
-export default function EpidNavbar() {
-    const classes = useStyles();
-
-    useEffect(() => {
-        // TODO: Fetch /api/profile and display user info in navbar.
-    });
-
-    return (
-        <div className={classes.root}>
-            <AppBar position="static">
-                <Toolbar>
-                    <Link to="/">
-                        <IconButton
-                            data-testid="home-btn"
-                            edge="start"
-                            className={classes.menuButton}
-                            aria-label="menu">
-                            <HomeIcon />
-                        </IconButton>
-                    </Link>
-                    <Typography variant="h6" className={classes.title}>
-                        epid
-                    </Typography>
-                </Toolbar>
-            </AppBar>
-        </div>
-    );
+interface User {
+    email: string;
 }
+
+// Cf. https://material-ui.com/guides/typescript/#augmenting-your-props-using-withstyles
+interface Props extends WithStyles<typeof styles> { }
+
+class EpidNavbar extends React.Component<Props, User> {
+    constructor(props: any) {
+        super(props);
+        this.state = {
+            email: "",
+        };
+    }
+
+    componentDidMount() {
+        axios.get<User>('/auth/profile')
+            .then((resp) => {
+                this.setState({ email: resp.data.email });
+            }).catch((e) => {
+                this.setState({ email: "" });
+                console.error(e);
+            });
+    }
+
+    render() {
+        const { classes } = this.props;
+        return (
+            <div className={classes.root} >
+                <AppBar position="static">
+                    <Toolbar>
+                        <Link to="/">
+                            <IconButton
+                                data-testid="home-btn"
+                                edge="start"
+                                className={classes.menuButton}
+                                aria-label="menu">
+                                <HomeIcon />
+                            </IconButton>
+                        </Link>
+                        <Typography variant="h6" className={classes.title}>
+                            epid
+                    </Typography>
+                        {this.state.email ?
+                            <Button variant="contained" color="primary" href="/auth/logout">
+                                Logout {this.state.email}
+                            </Button> :
+                            <Button variant="contained" color="secondary" href="/auth/google">
+                                Login
+                            </Button>}
+                    </Toolbar>
+                </AppBar>
+            </div>
+        );
+    }
+}
+
+
+export default withStyles(styles, { withTheme: true })(EpidNavbar);

--- a/verification/curator-service/ui/src/components/EpidNavbar.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.tsx
@@ -65,7 +65,7 @@ class EpidNavbar extends React.Component<Props, User> {
                         </Link>
                         <Typography variant="h6" className={classes.title}>
                             epid
-                    </Typography>
+                        </Typography>
                         {this.state.email ?
                             <Button variant="contained" color="primary" href="/auth/logout">
                                 Logout {this.state.email}

--- a/verification/curator-service/ui/src/index.tsx
+++ b/verification/curator-service/ui/src/index.tsx
@@ -4,12 +4,15 @@ import 'typeface-roboto';
 import * as serviceWorker from './serviceWorker';
 
 import App from './components/App';
+import { BrowserRouter } from 'react-router-dom';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/verification/curator-service/ui/src/setupProxy.js
+++ b/verification/curator-service/ui/src/setupProxy.js
@@ -1,7 +1,7 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 module.exports = function (app) {
     app.use(
-        '/api',
+        /\/(api|auth)/,
         createProxyMiddleware({
             // Proxy API requests to curator service.
             target: process.env.REACT_APP_PROXY_URL || "http://localhost:3001",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1255432/81543062-e0313780-9375-11ea-95ae-b456bc89498e.png)

After login:
![image](https://user-images.githubusercontent.com/1255432/81543099-ec1cf980-9375-11ea-9941-03d14d24e3fb.png)

Steps to try out locally:
```
# set ENV secret and client id from cloud project (I'm using a personal one for now until Gaurav gives us one)
./dev/run_stack.sh
Then go to http://localhost:3001/auth/google, accept the oauth prompt.
Then go to http://localhost:3002 to access the UI.
```

Because we run the server and the UI on different ports, clicking the login button doesn't work and you have to go to the localhost:3001/auth/google manually now , it will work in prod because they will be served from the same domain but until I find a better solution this manual step is needed.

Logout works as expected.