### PR TITLE
Store session info in Mongo

### DIFF
--- a/verification/curator-service/api/package-lock.json
+++ b/verification/curator-service/api/package-lock.json
@@ -993,6 +993,15 @@
         "@types/node": "*"
       }
     },
+    "@types/connect-mongo": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/connect-mongo/-/connect-mongo-3.1.3.tgz",
+      "integrity": "sha512-h162kWzfphobvJOttkYKLXEQQmZuOlOSA1IszOusQhguCGf+/B8k4H373SJ0BtVv+qkXP/lziEuUfZDNfzZ1tw==",
+      "dev": true,
+      "requires": {
+        "connect-mongo": "*"
+      }
+    },
     "@types/cookie-parser": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.2.tgz",
@@ -2404,6 +2413,14 @@
         "unique-string": "^2.0.0",
         "write-file-atomic": "^3.0.0",
         "xdg-basedir": "^4.0.0"
+      }
+    },
+    "connect-mongo": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-3.2.0.tgz",
+      "integrity": "sha512-0Mx88079Z20CG909wCFlR3UxhMYGg6Ibn1hkIje1hwsqOLWtL9HJV+XD0DAjUvQScK6WqY/FA8tSVQM9rR64Rw==",
+      "requires": {
+        "mongodb": "^3.1.0"
       }
     },
     "content-disposition": {

--- a/verification/curator-service/api/package.json
+++ b/verification/curator-service/api/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@shelf/jest-mongodb": "^1.1.5",
     "@types/chai": "^4.2.11",
+    "@types/connect-mongo": "^3.1.3",
     "@types/cookie-parser": "^1.4.2",
     "@types/dotenv": "^8.2.0",
     "@types/eslint": "^6.8.0",
@@ -50,6 +51,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "connect-mongo": "^3.2.0",
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",
     "envalid": "^6.0.1",

--- a/verification/curator-service/api/test/auth.test.ts
+++ b/verification/curator-service/api/test/auth.test.ts
@@ -1,5 +1,23 @@
 import app from '../src/index';
+import mongoose from 'mongoose';
 import request from 'supertest';
+
+beforeAll(() => {
+    return mongoose.connect(
+        // This is provided by jest-mongodb.
+        // The `else testurl` is to appease Typescript.
+        process.env.MONGO_URL || 'testurl',
+        {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+            useFindAndModify: false,
+        },
+    );
+});
+
+afterAll(() => {
+    return mongoose.disconnect();
+});
 
 describe('auth', () => {
     it('login with google', (done) => {

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -1,5 +1,6 @@
 import app from '../src/index';
 import axios from 'axios';
+import mongoose from 'mongoose';
 import request from 'supertest';
 
 jest.mock('axios');
@@ -7,6 +8,23 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 afterEach(() => {
     jest.clearAllMocks();
+});
+
+beforeAll(() => {
+    return mongoose.connect(
+        // This is provided by jest-mongodb.
+        // The `else testurl` is to appease Typescript.
+        process.env.MONGO_URL || 'testurl',
+        {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+            useFindAndModify: false,
+        },
+    );
+});
+
+afterAll(() => {
+    return mongoose.disconnect();
 });
 
 const emptyAxiosResponse = {

--- a/verification/curator-service/api/test/home.test.ts
+++ b/verification/curator-service/api/test/home.test.ts
@@ -1,5 +1,23 @@
 import app from '../src/index';
+import mongoose from 'mongoose';
 import request from 'supertest';
+
+beforeAll(() => {
+    return mongoose.connect(
+        // This is provided by jest-mongodb.
+        // The `else testurl` is to appease Typescript.
+        process.env.MONGO_URL || 'testurl',
+        {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+            useFindAndModify: false,
+        },
+    );
+});
+
+afterAll(() => {
+    return mongoose.disconnect();
+});
 
 describe('GET /', () => {
     it('should return 200 OK', (done) => {

--- a/verification/curator-service/api/test/index.test.ts
+++ b/verification/curator-service/api/test/index.test.ts
@@ -1,5 +1,23 @@
 import app from '../src/index';
+import mongoose from 'mongoose';
 import request from 'supertest';
+
+beforeAll(() => {
+    return mongoose.connect(
+        // This is provided by jest-mongodb.
+        // The `else testurl` is to appease Typescript.
+        process.env.MONGO_URL || 'testurl',
+        {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+            useFindAndModify: false,
+        },
+    );
+});
+
+afterAll(() => {
+    return mongoose.disconnect();
+});
 
 describe('GET /random-url', () => {
     it('should return 404', (done) => {

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -8,7 +8,11 @@ beforeAll(() => {
         // This is provided by jest-mongodb.
         // The `else testurl` is to appease Typescript.
         process.env.MONGO_URL || 'testurl',
-        { useNewUrlParser: true, useUnifiedTopology: true },
+        {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+            useFindAndModify: false,
+        },
     );
 });
 


### PR DESCRIPTION
Otherwise each time the server reloads when we change something the default "in-memory" store gets killed and we have to re-login that's annoying.

All tests importing the top-level app object now require a mongoose connection, so I've mocked them all up.