### PR TITLE
fix docker build with new context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# verification/curation/(ui|api)
+*/*/*/.env
+*/*/*/coverage
+*/*/*/dist
+*/*/*/node_modules
+*/*/*/npm-debug.log
+
+# data-serving/data-service
+*/*/.env
+*/*/coverage
+*/*/dist
+*/*/node_modules
+*/*/npm-debug.log
+
+.git

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
     branches: [master]
     paths:
-    - '.github/workflows/docker.yml'
-    - 'data-serving/data-service/**'
-    - 'verification/curator-service/**'
+      - ".github/workflows/docker.yml"
+      - "data-serving/data-service/**"
+      - "verification/curator-service/**"
 
 jobs:
   test:
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Stack
-        run: docker-compose -f dev/docker-compose.yml up --build -d -V
+        run: docker-compose -f dev/docker-compose.yml -f dev/docker-compose.ci.yml up --build -d -V
       # Containers are run detached above, which means we have to wait until they are up to produce meaningful logs.
       - name: Sleep for 30 seconds
         uses: jakejarvis/wait-action@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Local AWS testing and deployment artifacts.
 .aws
+# Never submit .env files that might contain secrets.
+.env

--- a/data-serving/data-service/.dockerignore
+++ b/data-serving/data-service/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-dist
-npm-debug.log

--- a/dev/README.md
+++ b/dev/README.md
@@ -11,6 +11,14 @@ GOOGLE_OAUTH_CLIENT_ID=<oauth client id to enable OAuth>
 GOOGLE_OAUTH_CLIENT_SECRET=<oauth client secret>
 ```
 
+## Environemnt variables
+
+All services require specific environement variables to be set when running.
+
+Specific .env files in each service directory are used when you run `npm run dev` from the service directory directly.
+
+If you run the docker-compose script described below to run the whole stack, environment variables should be passed in the docker-compose.dev.yml environement overrides or in the docker-compose .env file itself in this directory. No service-specific .env files are included in the docker compose build as we shouldn't put secrets into (soon-to-be) images.
+
 ## Docker
 
 During development, you can run each service individually using `docker` or plug them together using `docker-compose`.

--- a/dev/README.md
+++ b/dev/README.md
@@ -2,6 +2,15 @@
 
 This directory contains the docker compose file to run an isolated environment of the full stack during development.
 
+## Prerequisite
+
+**Important** running the full stack correctly requires having access to a few secrets: you should have a .env file at the top of your repository (where you run the `docker-compose` command) that looks like this:
+
+```
+GOOGLE_OAUTH_CLIENT_ID=<oauth client id to enable OAuth>
+GOOGLE_OAUTH_CLIENT_SECRET=<oauth client secret>
+```
+
 ## Docker
 
 During development, you can run each service individually using `docker` or plug them together using `docker-compose`.
@@ -10,11 +19,7 @@ During development, you can run each service individually using `docker` or plug
 
 ### All services composed with hot reload
 
-Just run `./dev/run_stack.sh` from anywhere or from this folder run:
-
-```
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
-```
+Just run `./dev/run_stack.sh` from anywhere.
 
 Services will be accessible and connected to each other.
 
@@ -48,36 +53,6 @@ By default docker wil persist the container data unless you rm it, to remove dat
 use covid19
 db.cases.remove({})
 ```
-
-#### Data service
-
-From the `data-service` directory where the `Dockerfile` is located, run:
-
-```
-docker build . -t epid/dataservice
-```
-
-then run it with:
-
-```
-docker run --network=host epid/dataservice
-```
-
-#### Curator service
-
-From the `curator-service` directory where the `Dockerfile` is located, run:
-
-```
-docker build . -t epid/curatorservice
-```
-
-then run it with:
-
-```
-docker run --network=host epid/curatorservice
-```
-
-This will connect to the default mongo db exposed by the docker container if run as explained in the _Mongo_ section above.
 
 ## IDE setup
 

--- a/dev/docker-compose.ci.yml
+++ b/dev/docker-compose.ci.yml
@@ -1,0 +1,6 @@
+version: "3.7"
+services:
+  curator:
+    environment:
+      GOOGLE_OAUTH_CLIENT_ID: "foo"
+      GOOGLE_OAUTH_CLIENT_SECRET: "bar"

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -4,6 +4,8 @@ services:
     command: "npm run-script dev"
     volumes:
       - ../verification/curator-service/api/src:/usr/src/app/src
+    environment:
+      AFTER_LOGIN_REDIRECT_URL: "http://localhost:3002"
   data:
     command: "npm run-script dev"
     volumes:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -10,8 +10,8 @@ services:
             MONGO_INITDB_DATABASE: "covid19"
     curator:
         build:
-          context: ../.
-          dockerfile: verification/curator-service/api/Dockerfile
+            context: ../.
+            dockerfile: verification/curator-service/api/Dockerfile
         init: true
         ports:
             - "3001:3001"
@@ -21,10 +21,12 @@ services:
         environment:
             DB_CONNECTION_STRING: "mongodb://mongo:27017/covid19"
             DATASERVER_URL: "http://data:3000"
+            GOOGLE_OAUTH_CLIENT_ID: "${GOOGLE_OAUTH_CLIENT_ID}"
+            GOOGLE_OAUTH_CLIENT_SECRET: "${GOOGLE_OAUTH_CLIENT_SECRET}"
     data:
         build:
-          context: ../.
-          dockerfile: data-serving/data-service/Dockerfile
+            context: ../.
+            dockerfile: data-serving/data-service/Dockerfile
         init: true
         ports:
             - "3000:3000"
@@ -34,8 +36,8 @@ services:
             DB_CONNECTION_STRING: "mongodb://mongo:27017/covid19"
     curatorui:
         build:
-          context: ../.
-          dockerfile: verification/curator-service/ui/Dockerfile
+            context: ../.
+            dockerfile: verification/curator-service/ui/Dockerfile
         init: true
         ports:
             - "3002:3002"

--- a/dev/run_stack.sh
+++ b/dev/run_stack.sh
@@ -2,8 +2,9 @@
 set -e
 # Store current directory.
 pushd `pwd`
+# We have to run docker-compose from this directory for it to pick up the .env file.
 cd `dirname "$0"`
-# We have to run docker-compose from the root directory for it to pick up the .env file.
 docker-compose -f docker-compose.yml config
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+# Restore directory.
 popd

--- a/dev/run_stack.sh
+++ b/dev/run_stack.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 set -e
-docker-compose -f `dirname "$0"`/docker-compose.yml -f `dirname "$0"`/docker-compose.dev.yml up --build
+# Store current directory.
+pushd `pwd`
+cd `dirname "$0"`
+# We have to run docker-compose from the root directory for it to pick up the .env file.
+docker-compose -f docker-compose.yml config
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+popd

--- a/verification/curator-service/api/.dockerignore
+++ b/verification/curator-service/api/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-build
-npm-debug.log

--- a/verification/curator-service/ui/.dockerignore
+++ b/verification/curator-service/ui/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-build
-npm-debug.log


### PR DESCRIPTION
I noticed the build was *SLLLOOOOWWWW* this morning on my computer, it turns out that .dockerignore files are read from the build context, not from where the Dockerfile is. So we would send all node_modules/ directories to the docker builder daemon for each build which was gigs of data for nothing, now we only send a dozen mb ax and builds are fast again.

I also used a .env which is supported natively by docker-compose to store oauth secrets, I'll send you the secrets so that you can enable login once Gaurav send them to me.