### PR TITLE
Update schema to work with documents created by dataserver

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -10,10 +10,16 @@
         "bsonType": "object",
         "additionalProperties": false,
         "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
           "ageRange": {
             "bsonType": "object",
             "additionalProperties": false,
             "properties": {
+              "_id": {
+                "bsonType": "objectId"
+              },
               "start": {
                 "bsonType": "double",
                 "minimum": -1,
@@ -44,6 +50,9 @@
         "bsonType": "object",
         "additionalProperties": false,
         "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
           "id": {
             "bsonType": "string"
           },
@@ -67,6 +76,9 @@
               "longitude"
             ],
             "properties": {
+              "_id": {
+                "bsonType": "objectId"
+              },
               "latitude": {
                 "bsonType": "double",
                 "minimum": -90.0,
@@ -88,6 +100,9 @@
           "bsonType": "object",
           "additionalProperties": false,
           "properties": {
+            "_id": {
+              "bsonType": "objectId"
+            },
             "name": {
               "bsonType": "string"
             },
@@ -95,6 +110,9 @@
               "bsonType": "object",
               "additionalProperties": false,
               "properties": {
+                "_id": {
+                  "bsonType": "objectId"
+                },
                 "start": {
                   "bsonType": "date"
                 },
@@ -110,6 +128,9 @@
         "bsonType": "object",
         "additionalProperties": false,
         "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
           "provided": {
             "bsonType": "array",
             "uniqueItems": true,
@@ -130,6 +151,9 @@
         "bsonType": "object",
         "additionalProperties": false,
         "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
           "provided": {
             "bsonType": "array",
             "uniqueItems": true,
@@ -156,10 +180,16 @@
             "location"
           ],
           "properties": {
+            "_id": {
+              "bsonType": "objectId"
+            },
             "location": {
               "bsonType": "object",
               "additionalProperties": false,
               "properties": {
+                "_id": {
+                  "bsonType": "objectId"
+                },
                 "id": {
                   "bsonType": "string"
                 },
@@ -183,6 +213,9 @@
                     "longitude"
                   ],
                   "properties": {
+                    "_id": {
+                      "bsonType": "objectId"
+                    },
                     "latitude": {
                       "bsonType": "double",
                       "minimum": -90.0,
@@ -201,6 +234,9 @@
               "bsonType": "object",
               "additionalProperties": false,
               "properties": {
+                "_id": {
+                  "bsonType": "objectId"
+                },
                 "start": {
                   "bsonType": "date"
                 },
@@ -222,6 +258,9 @@
         "bsonType": "object",
         "additionalProperties": false,
         "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
           "id": {
             "bsonType": "string"
           },
@@ -237,6 +276,9 @@
         "bsonType": "object",
         "additionalProperties": false,
         "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
           "livesInWuhan": {
             "bsonType": "bool"
           },
@@ -255,6 +297,9 @@
             "name"
           ],
           "properties": {
+            "_id": {
+              "bsonType": "objectId"
+            },
             "name": {
               "bsonType": "string"
             },
@@ -262,6 +307,9 @@
               "bsonType": "object",
               "additionalProperties": false,
               "properties": {
+                "_id": {
+                  "bsonType": "objectId"
+                },
                 "id": {
                   "bsonType": "string"
                 },
@@ -289,6 +337,9 @@
           "id"
         ],
         "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
           "id": {
             "bsonType": "int"
           },
@@ -307,6 +358,9 @@
         "bsonType": "object",
         "additionalProperties": false,
         "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
           "ID": {
             "bsonType": "string"
           },

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -6,6 +6,9 @@
       "_id": {
         "bsonType": "objectId"
       },
+      "__v": {
+        "bsonType": "int"
+      },
       "demographics": {
         "bsonType": "object",
         "additionalProperties": false,


### PR DESCRIPTION
Was debugging why the validator on mongoose was rejecting documents created from curator UI -- turns out our server is adding fun new fields I didn't expect, and the additionalProperties field was getting angry.

TL;DR: Sub-documents have their own _id fields, and the case doc gets a version key field: https://mongoosejs.com/docs/guide.html#versionKey

Now if I run:

`dev/run_stack.sh`
`dev/setup_db.sh`

and insert/update a row via the curator CRUD UI, it works!