### PR TITLE
Barebones /sources curator UI page

### DIFF
--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -7,6 +7,7 @@ import {
 import EpidNavbar from './EpidNavbar';
 import LinelistTable from './LinelistTable';
 import React from 'react';
+import SourceTable from './SourceTable';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { createMuiTheme } from '@material-ui/core/styles';
 
@@ -30,6 +31,9 @@ function App() {
           <Route path="/cases">
             <Linelist />
           </Route>
+          <Route path="/sources">
+            <Sources />
+          </Route>
           <Route exact path="/">
             <Home />
           </Route>
@@ -42,6 +46,12 @@ function App() {
 function Linelist() {
   return (
     <LinelistTable />
+  )
+}
+
+function Sources() {
+  return (
+    <SourceTable />
   )
 }
 

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -60,6 +60,7 @@ function Home() {
   return (
     <nav>
       <Link to="/cases">Linelist</Link><br />
+      <Link to="/sources">Sources</Link><br />
       <Link to="/privacy-policy">Privacy policy</Link><br />
       <Link to="/terms">Terms of service</Link><br />
     </nav>

--- a/verification/curator-service/ui/src/components/SourceTable.test.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.test.tsx
@@ -1,0 +1,57 @@
+import '@testing-library/jest-dom/extend-expect';
+
+import SourceTable from './SourceTable';
+import React from 'react';
+import axios from 'axios';
+import { render } from '@testing-library/react';
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+afterEach(() => {
+  mockedAxios.get.mockClear();
+  mockedAxios.delete.mockClear();
+  mockedAxios.post.mockClear();
+  mockedAxios.put.mockClear();
+});
+
+it('loads and displays sources', async () => {
+  const sources = [
+    {
+      _id: 'abc123',
+      name: 'source name',
+      format: 'format',
+      origin: {
+        url: "origin url",
+        license: "origin license",
+      },
+      automation: {
+        name: 'automation name',
+        tag: 'automation tag',
+        active: true,
+        scheduleExpression: "automation schedule",
+        parsing: {
+          fields: [{ name: "field name", regexp: "field regexp" }]
+        }
+      }
+    },
+  ];
+  const axiosResponse = {
+    data: {
+      sources: sources,
+      total: 15,
+    },
+    status: 200,
+    statusText: 'OK',
+    config: {},
+    headers: {},
+  };
+  mockedAxios.get.mockResolvedValueOnce(axiosResponse);
+
+  const { findByText } = render(<SourceTable />)
+
+  expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  expect(mockedAxios.get).toHaveBeenCalledWith('/api/sources/?limit=10&page=1');
+  const items = await findByText(/abc123/);
+  expect(items).toBeInTheDocument();
+})

--- a/verification/curator-service/ui/src/components/SourceTable.test.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.test.tsx
@@ -8,13 +8,6 @@ import { render } from '@testing-library/react';
 jest.mock('axios')
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-afterEach(() => {
-  mockedAxios.get.mockClear();
-  mockedAxios.delete.mockClear();
-  mockedAxios.post.mockClear();
-  mockedAxios.put.mockClear();
-});
-
 it('loads and displays sources', async () => {
   const sources = [
     {

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -40,7 +40,6 @@ interface Source {
 }
 
 interface SourceTableState {
-    tableRef: any,
     url: string,
 }
 
@@ -48,7 +47,6 @@ export default class SourceTable extends React.Component<{}, SourceTableState> {
     constructor(props: any) {
         super(props);
         this.state = {
-            tableRef: React.createRef(),
             url: '/api/sources/',
         }
     }
@@ -57,7 +55,6 @@ export default class SourceTable extends React.Component<{}, SourceTableState> {
         return (
             <Paper>
                 <MaterialTable
-                    tableRef={this.state.tableRef}
                     columns={[
                         { title: 'ID', field: '_id' },
                         { title: 'Name', field: 'name' },

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -1,0 +1,96 @@
+import MaterialTable from 'material-table';
+import Paper from '@material-ui/core/Paper';
+import React from 'react';
+import axios from 'axios';
+
+interface ListResponse {
+    sources: Source[],
+    nextPage: number,
+    total: number,
+}
+
+interface Origin {
+    url: string;
+    license: string;
+}
+
+interface Field {
+    name: string;
+    regexp: string;
+}
+
+interface Parsing {
+    fields: Array<Field>;
+}
+
+interface Automation {
+    name: string;
+    tag: string;
+    active: boolean;
+    scheduleExpression: string;
+    parsing: Parsing;
+}
+
+interface Source {
+    _id: string;
+    name: string;
+    origin: Origin;
+    format: string;
+    automation: Automation;
+}
+
+interface SourceTableState {
+    tableRef: any,
+    url: string,
+}
+
+export default class SourceTable extends React.Component<{}, SourceTableState> {
+    constructor(props: any) {
+        super(props);
+        this.state = {
+            tableRef: React.createRef(),
+            url: '/api/sources/',
+        }
+    }
+
+    render() {
+        return (
+            <Paper>
+                <MaterialTable
+                    tableRef={this.state.tableRef}
+                    columns={[
+                        { title: 'ID', field: '_id' },
+                        { title: 'Name', field: 'name' },
+                    ]}
+
+                    data={query =>
+                        new Promise((resolve, reject) => {
+                            let listUrl = this.state.url;
+                            listUrl += '?limit=' + query.pageSize;
+                            listUrl += '&page=' + (query.page + 1);
+                            const response = axios.get<ListResponse>(listUrl);
+                            response.then(result => {
+                                resolve({
+                                    data: result.data.sources,
+                                    page: query.page,
+                                    totalCount: result.data.total,
+                                });
+                            }).catch((e) => {
+                                reject(e);
+                            });
+                        })
+                    }
+                    title="Ingestion sources"
+                    options={{
+                        // TODO: Create text indexes and support search queries.
+                        // https://docs.mongodb.com/manual/text-search/
+                        search: false,
+                        filtering: false,
+                        pageSize: 10,
+                        pageSizeOptions: [5, 10, 20, 50, 100],
+                    }}
+                />
+            </Paper>
+        )
+    }
+}


### PR DESCRIPTION
Breaking this story up to keep PR length sane. For now, just adding a minimal `/sources` page and `SourceTable` component; largely analogous to a simplified `LinelistTable`. The existing `Source` model isn't exactly what Tim and I landed on, but I'll address that after the bulk of the interface boilerplate is taken care of. Still adding the types to the component file to be "correct," though we could technically get away with just defining `_id`/`name`.