### PR TITLE
Return the created source from the Source API.

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -86,7 +86,7 @@ export const create = async (req: Request, res: Response): Promise<void> => {
         // storage.
         const c = new Case(req.body);
         const result = await c.save();
-        res.json(result);
+        res.status(201).json(result);
     } catch (err) {
         if (err.name === 'ValidationError') {
             res.status(422).json(err.message);

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -110,12 +110,12 @@ describe('POST', () => {
     it('create with invalid input should return 422', () => {
         return request(app).post('/api/cases').send({}).expect(422);
     });
-    it('create with valid input should return 200 OK', async () => {
+    it('create with valid input should return 201 OK', async () => {
         return request(app)
             .post('/api/cases')
             .send(minimalCase)
             .expect('Content-Type', /json/)
-            .expect(200);
+            .expect(201);
     });
 });
 

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -91,8 +91,9 @@ export const update = async (req: Request, res: Response): Promise<void> => {
  */
 export const create = async (req: Request, res: Response): Promise<void> => {
     try {
-        const source = await Source.create(req.body);
-        res.location(`/sources/${source.id}`);
+        const source = new Source(req.body);
+        const result = await source.save();
+        res.json(result);
     } catch (err) {
         if (err.name === 'ValidationError') {
             res.status(422).json(err.message);

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -93,7 +93,7 @@ export const create = async (req: Request, res: Response): Promise<void> => {
     try {
         const source = new Source(req.body);
         const result = await source.save();
-        res.json(result);
+        res.status(201).json(result);
     } catch (err) {
         if (err.name === 'ValidationError') {
             res.status(422).json(err.message);

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -138,7 +138,7 @@ describe('POST', () => {
             .post('/api/sources')
             .send(source)
             .expect('Content-Type', /json/)
-            .expect(200);
+            .expect(201);
         expect(res.body.name).toEqual(source.name);
     });
     it('should not create invalid source', async () => {

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -130,10 +130,16 @@ describe('PUT', () => {
 
 describe('POST', () => {
     it('should return the created source', async () => {
-        request(app)
+        const source = {
+            name: 'some name',
+            origin: { url: 'http://what.ever' },
+        };
+        const res = await request(app)
             .post('/api/sources')
-            .send({ name: 'some name', origin: { url: 'http://what.ever' } })
-            .expect(201);
+            .send(source)
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(res.body.name).toEqual(source.name);
     });
     it('should not create invalid source', async () => {
         const res = await request(app).post('/api/sources').expect(422);


### PR DESCRIPTION
Making this behavior analogous to the Case API, until we decide on a different standard (to simplify/commonize handling of responses in the UI). Mostly:

- Return the resource from `POST /api/sources`.
- Return 201 from `POST /api/cases` on the data service.
- Test the same behaviors.