### PR TITLE
Run integration tests in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Integration Tests CI
 
 on:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,19 +18,17 @@ on:
       - "data-serving/data-service/**"
 
 jobs:
-  build:
+  integration-tests:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
+      - name: Build stack
+        run: docker-compose -f dev/docker-compose.yml -f dev/docker-compose.ci.yml up --build -d -V
       - name: Cypress integration tests
         run: |
           npm ci
-          npm run cypress-ci-test
+          npm run cypress-run
         working-directory: verification/curator-service/ui
         env:
           CI: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,34 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Integration Tests CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/integration-tests.yml"
+      - "verification/curator-service/**"
+      - "data-serving/data-service/**"
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/integration-tests.yml"
+      - "verification/curator-service/**"
+      - "data-serving/data-service/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+    - name: Cypress integration tests
+        run: npm run cypress-ci-test
+        working-directory: verification/curator-service/ui
+        env:
+          CI: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "12.x"
-    - name: Cypress integration tests
+      - name: Cypress integration tests
         run: npm run cypress-ci-test
         working-directory: verification/curator-service/ui
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           node-version: "12.x"
       - name: Cypress integration tests
-        run: npm run cypress-ci-test
+        run: |
+          npm ci
+          npm run cypress-ci-test
         working-directory: verification/curator-service/ui
         env:
           CI: true

--- a/dev/test_all.sh
+++ b/dev/test_all.sh
@@ -3,4 +3,5 @@ set -e
 npm --prefix=`dirname "$0"`/../verification/curator-service/api/ run-script test-silent
 npm --prefix=`dirname "$0"`/../data-serving/data-service/ run-script test-silent
 npm --prefix=`dirname "$0"`/../verification/curator-service/ui/ run-script test-silent
-npm --prefix=`dirname "$0"`/../verification/curator-service/ui/ run-script cypress-ci-test
+# cypress-run requires having a local stack running
+npm --prefix=`dirname "$0"`/../verification/curator-service/ui/ run-script cypress-run

--- a/dev/test_all.sh
+++ b/dev/test_all.sh
@@ -3,3 +3,4 @@ set -e
 npm --prefix=`dirname "$0"`/../verification/curator-service/api/ run-script test-silent
 npm --prefix=`dirname "$0"`/../data-serving/data-service/ run-script test-silent
 npm --prefix=`dirname "$0"`/../verification/curator-service/ui/ run-script test-silent
+npm --prefix=`dirname "$0"`/../verification/curator-service/ui/ run-script cypress-ci-test

--- a/verification/curator-service/api/src/util/validate-env.ts
+++ b/verification/curator-service/api/src/util/validate-env.ts
@@ -26,10 +26,12 @@ export default function validateEnv(): Readonly<{
         PORT: port({ default: 3001 }),
         GOOGLE_OAUTH_CLIENT_ID: str({
             desc: 'OAuth client ID from the Google developer console',
+            default: 'replace to enable auth',
             devDefault: 'replace to enable auth',
         }),
         GOOGLE_OAUTH_CLIENT_SECRET: str({
             desc: 'OAuth client secret from the Google developer console',
+            default: 'replace to enable auth',
             devDefault: 'replace to enable auth',
         }),
         SESSION_COOKIE_KEY: str({

--- a/verification/curator-service/api/src/util/validate-env.ts
+++ b/verification/curator-service/api/src/util/validate-env.ts
@@ -26,12 +26,10 @@ export default function validateEnv(): Readonly<{
         PORT: port({ default: 3001 }),
         GOOGLE_OAUTH_CLIENT_ID: str({
             desc: 'OAuth client ID from the Google developer console',
-            default: 'replace to enable auth',
             devDefault: 'replace to enable auth',
         }),
         GOOGLE_OAUTH_CLIENT_SECRET: str({
             desc: 'OAuth client secret from the Google developer console',
-            default: 'replace to enable auth',
             devDefault: 'replace to enable auth',
         }),
         SESSION_COOKIE_KEY: str({

--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -1,9 +1,13 @@
 describe('Linelist table', function () {
-    it('Can edit a case', function () {
+    it('Can add a case', function () {
         cy.visit('/cases');
-        cy.get('button[title="Edit"]').first().click();
-        cy.get('input[placeholder="Notes"]').clear().type('edited text');
+        cy.get('button[title="Add"]').first().click();
+        cy.get('input[placeholder="Country"]').clear().type('France');
+        cy.get('input[placeholder="Notes"]').clear().type('test notes');
+        cy.get('input[placeholder="Source URL"]').clear().type('www.example.com');
         cy.get('button[title="Save"]').click();
-        cy.contains('edited text');
+        // Assert the added row is present once we have cleared the DB before
+        // the test. If the database hasn't been cleared, we don't know if
+        // the element is on this page or not.
     })
 }) 

--- a/verification/curator-service/ui/package-lock.json
+++ b/verification/curator-service/ui/package-lock.json
@@ -1288,12 +1288,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
-    "@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
-      "dev": true
-    },
     "@hapi/hoek": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
@@ -1309,12 +1303,6 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/topo": "3.x.x"
       }
-    },
-    "@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
-      "dev": true
     },
     "@hapi/topo": {
       "version": "3.1.6",
@@ -6151,21 +6139,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
     "eventemitter2": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
@@ -7006,12 +6979,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
-    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -7678,12 +7645,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
-    },
-    "human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true
     },
     "hyphenate-style-name": {
       "version": "1.0.3",
@@ -9931,12 +9892,6 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -11044,15 +10999,6 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
         "pify": "^3.0.0"
-      }
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -12233,15 +12179,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-    },
-    "ps-tree": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
-      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
-      "dev": true,
-      "requires": {
-        "event-stream": "=3.3.4"
-      }
     },
     "psl": {
       "version": "1.8.0",
@@ -14108,15 +14045,6 @@
         }
       }
     },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -14164,127 +14092,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
-    },
-    "start-server-and-test": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.11.0.tgz",
-      "integrity": "sha512-FhkJFYL/lvbd0tKWvbxWNWjtFtq3Zpa09QDjA8EUH88AsgNL4hkAAKYNmbac+fFM8/GIZoJ1Mj4mm3SMI0X1bA==",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.7.2",
-        "check-more-types": "2.24.0",
-        "debug": "4.1.1",
-        "execa": "3.4.0",
-        "lazy-ass": "1.6.0",
-        "ps-tree": "1.2.0",
-        "wait-on": "4.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "execa": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-          "dev": true
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -14351,15 +14158,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1"
       }
     },
     "stream-each": {
@@ -14580,12 +14378,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
     },
     "strip-indent": {
       "version": "3.0.0",
@@ -15389,35 +15181,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
       "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag=="
-    },
-    "wait-on": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-4.0.0.tgz",
-      "integrity": "sha512-QrW3J8LzS5ADPfD9Rx5S6KJck66xkqyiFKQs9jmUTkIhiEOmkzU7WRZc+MjsnmkrgjitS2xQ4bb13hnlQnKBUQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/joi": "^16.1.8",
-        "lodash": "^4.17.15",
-        "minimist": "^1.2.0",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.8",
-        "rxjs": "^6.5.4"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "dev": true,
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
-      }
     },
     "walker": {
       "version": "1.0.7",

--- a/verification/curator-service/ui/package.json
+++ b/verification/curator-service/ui/package.json
@@ -26,11 +26,14 @@
   "scripts": {
     "start-noenv": "react-scripts start",
     "start": "PORT=3002 react-scripts start",
+    "start-full-stack": "./../../../dev/run_stack.sh",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test-silent": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
-    "cypress": "cypress open"
+    "cypress-open": "cypress open",
+    "cypress-run": "cypress run",
+    "cypress-ci-test": "WAIT_ON_TIMEOUT=600000 start-server-and-test start-full-stack http://localhost:3002 cypress-run"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/verification/curator-service/ui/package.json
+++ b/verification/curator-service/ui/package.json
@@ -26,14 +26,12 @@
   "scripts": {
     "start-noenv": "react-scripts start",
     "start": "PORT=3002 react-scripts start",
-    "start-full-stack": "./../../../dev/run_stack.sh",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test-silent": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
     "cypress-open": "cypress open",
-    "cypress-run": "cypress run",
-    "cypress-ci-test": "WAIT_ON_TIMEOUT=600000 start-server-and-test start-full-stack http://localhost:3002 cypress-run"
+    "cypress-run": "cypress run"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -51,7 +49,6 @@
     ]
   },
   "devDependencies": {
-    "cypress": "^4.5.0",
-    "start-server-and-test": "^1.11.0"
+    "cypress": "^4.5.0"
   }
 }


### PR DESCRIPTION
Requires changing the test to an add rather than edit test, because the stack that's brought up with docker-compose doesn't have any existing rows in the table. Will clean up this discrepancy between local / CI in a future PR.  

Will also remove the docker.yaml file once we add an integration test for /sources.