### PR TITLE
Don't include lossless fields in the importedCases field to save disk space

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -370,9 +370,6 @@
           "province": {
             "bsonType": "string"
           },
-          "country": {
-            "bsonType": "string"
-          },
           "geo_resolution": {
             "bsonType": "string"
           },
@@ -404,6 +401,9 @@
             "bsonType": "string"
           },
           "admin3": {
+            "bsonType": "string"
+          },
+          "country_new": {
             "bsonType": "string"
           },
           "admin_id": {

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -367,25 +367,10 @@
           "ID": {
             "bsonType": "string"
           },
-          "age": {
-            "bsonType": "string"
-          },
-          "sex": {
-            "bsonType": "string"
-          },
-          "city": {
-            "bsonType": "string"
-          },
           "province": {
             "bsonType": "string"
           },
           "country": {
-            "bsonType": "string"
-          },
-          "latitude": {
-            "bsonType": "string"
-          },
-          "longitude": {
             "bsonType": "string"
           },
           "geo_resolution": {
@@ -400,12 +385,6 @@
           "date_confirmation": {
             "bsonType": "string"
           },
-          "symptoms": {
-            "bsonType": "string"
-          },
-          "lives_in_Wuhan": {
-            "bsonType": "string"
-          },
           "travel_history_dates": {
             "bsonType": "string"
           },
@@ -415,28 +394,10 @@
           "reported_market_exposure": {
             "bsonType": "string"
           },
-          "additional_information": {
-            "bsonType": "string"
-          },
           "chronic_disease_binary": {
             "bsonType": "string"
           },
-          "chronic_disease": {
-            "bsonType": "string"
-          },
-          "source": {
-            "bsonType": "string"
-          },
-          "sequence_available": {
-            "bsonType": "string"
-          },
           "outcome": {
-            "bsonType": "string"
-          },
-          "date_death_or_discharge": {
-            "bsonType": "string"
-          },
-          "notes_for_discussion": {
             "bsonType": "string"
           },
           "location": {
@@ -445,19 +406,7 @@
           "admin3": {
             "bsonType": "string"
           },
-          "admin2": {
-            "bsonType": "string"
-          },
-          "admin1": {
-            "bsonType": "string"
-          },
-          "country_new": {
-            "bsonType": "string"
-          },
           "admin_id": {
-            "bsonType": "string"
-          },
-          "data_moderator_initials": {
             "bsonType": "string"
           },
           "travel_history_binary": {

--- a/data-serving/scripts/convert-data/README.md
+++ b/data-serving/scripts/convert-data/README.md
@@ -42,8 +42,7 @@ The following fields are lossy:
 
 > **Open question:** Where on the ROC curve do we want to be? Are we optimizing for precision or recall?
 
-The following fields are *not* lossy, although they require conversion to a new type, because their data is properly
-normalized in the source (as of writing):
+The following fields are *not* lossy, although they require conversion to a new type:
 
 - `sex`
 - `outbreakSpecifics.livesInWuhan`
@@ -73,8 +72,8 @@ normalized in the source (as of writing):
 - Use Sheets or GitHub history to infer `revision.date`.
 
 - De-duplicate events populated from the original outcome field with the others; ex. in some cases we have
-  `events[name="deathOrDischarge"]`, from the `date_death_or_discharge` field, plus `events[name="death"]` from the
-  `outcome` field.
+  `events[name="deathOrDischarge"]`, from the `date_death_or_discharge` field, plus `events[name="death"]`
+  from the `outcome` field.
 
 - Manually review `symptoms` and `chronicDisease` fields to confirm that we're supporting all possible list delimiters
   (currently colon and comma).

--- a/data-serving/scripts/convert-data/constants.py
+++ b/data-serving/scripts/convert-data/constants.py
@@ -1,6 +1,14 @@
 ''' Valid values for sex field. '''
 VALID_SEXES = ['female', 'male', 'other']
 
+# TODO(khmoran): Include 'outcome' once the curator UI transitions to using the
+# new events-based outcome field.
+LOSSLESS_FIELDS = [
+    'additional_information', 'admin1', 'admin2', 'age', 'chronic_disease',
+    'city', 'country_new', 'data_moderator_initials', 'date_death_or_discharge',
+    'latitude', 'lives_in_Wuhan', 'longitude', 'notes_for_discussion',
+    'sequence_available', 'sex', 'source', 'symptoms']
+
 LOCATIONS = {
     'wuhan': {
         'country': 'China',

--- a/data-serving/scripts/convert-data/constants.py
+++ b/data-serving/scripts/convert-data/constants.py
@@ -5,7 +5,7 @@ VALID_SEXES = ['female', 'male', 'other']
 # new events-based outcome field.
 LOSSLESS_FIELDS = [
     'additional_information', 'admin1', 'admin2', 'age', 'chronic_disease',
-    'city', 'country_new', 'data_moderator_initials', 'date_death_or_discharge',
+    'city', 'country', 'data_moderator_initials', 'date_death_or_discharge',
     'latitude', 'lives_in_Wuhan', 'longitude', 'notes_for_discussion',
     'sequence_available', 'sex', 'source', 'symptoms']
 

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -73,7 +73,7 @@ def convert(df_import: DataFrame) -> DataFrame:
         x:
         convert_location(
             x['ID'],
-            x['country_new'],
+            x['country'],
             x['admin1'],
             x['admin2'],
             x['city'],

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -16,6 +16,7 @@ from converters import (
     convert_outbreak_specifics, convert_travel_history)
 from pandas import DataFrame
 from typing import Any
+from constants import LOSSLESS_FIELDS
 
 
 def main():
@@ -72,7 +73,7 @@ def convert(df_import: DataFrame) -> DataFrame:
         x:
         convert_location(
             x['ID'],
-            x['country'],
+            x['country_new'],
             x['admin1'],
             x['admin2'],
             x['city'],
@@ -133,7 +134,7 @@ def convert(df_import: DataFrame) -> DataFrame:
 
     # Archive the original fields.
     df_export['importedCase'] = df_import.apply(lambda x: convert_imported_case(
-        x), axis=1)
+        x.drop(LOSSLESS_FIELDS)), axis=1)
 
     return df_export
 

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -235,9 +235,7 @@ def convert_demographics(id: str, age: Any, sex: str) -> Dict[str, Any]:
     except ValueError as e:
         warn(id, 'demographics.sex', age, e)
 
-    demographics['species'] = 'Homo sapien'
-
-    return demographics
+    return demographics or None
 
 
 def convert_location(id: str, country: str, adminL1: str,

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -395,15 +395,11 @@ def convert_pathogens_field(sequence: str) -> List[Dict[str, Any]]:
           }
         }]
     '''
-    cov_pathogen = {
-        'name': 'sars-cov-2'
-    }
-
     source = convert_source_field(sequence)
-    if source:
-        cov_pathogen['sequenceSource'] = source
-
-    return [cov_pathogen]
+    return [{
+        'name': 'sars-cov-2',
+        'sequenceSource': source
+    }] if source else None
 
 
 def convert_outbreak_specifics(id: str, reported_market_exposure: str,


### PR DESCRIPTION
Removes some redundant data and saves some space.

Also to reduce bloat (would've done in a separate PR but too annoying):

- Removes the species field (I'm guessing we can assume human unless otherwise specified -- on the fence about whether to explicitly include)
- Only populates the pathogens field when there's sequence source data (i.e. not just the name of the covid pathogen)

We're still over quota by a bit after the latest cases are published; should figure out what to do there separately (start using prod?)

TESTED: Applied the new schema and data imported without validation errors.

```
2020-05-18T22:06:06.613-0400    Failed: (AtlasError) you are over your space quota, using 516 MB of 512 MB
2020-05-18T22:06:06.613-0400    777000 document(s) imported successfully. 0 document(s) failed to import.
```