### PR TITLE
Prep Source schema for AWS API integration

### DIFF
--- a/verification/curator-service/api/src/model/automation.ts
+++ b/verification/curator-service/api/src/model/automation.ts
@@ -4,7 +4,7 @@ import { RegexParsingDocument, regexParsingSchema } from './regex-parsing';
 import { ScheduleDocument, scheduleSchema } from './schedule';
 
 export const automationParsingValidator = {
-    validator: function (automation: AutomationDocument): boolean {
+    validator: (automation: AutomationDocument): boolean => {
         return (
             (automation.parser != null || automation.regexParsing != null) &&
             !(automation.parser != null && automation.regexParsing != null)

--- a/verification/curator-service/api/src/model/automation.ts
+++ b/verification/curator-service/api/src/model/automation.ts
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+import { ParserDocument, parserSchema } from './parser';
+import { RegexParsingDocument, regexParsingSchema } from './regex-parsing';
+import { ScheduleDocument, scheduleSchema } from './schedule';
+
+export const automationParsingValidator = {
+    validator: function (automation: AutomationDocument): boolean {
+        return (
+            (automation.parser != null || automation.regexParsing != null) &&
+            !(automation.parser != null && automation.regexParsing != null)
+        );
+    },
+    message: 'Exactly one of either parser or regexParsing must be supplied.',
+};
+
+export const automationSchema = new mongoose.Schema({
+    parser: parserSchema,
+    regexParsing: regexParsingSchema,
+    schedule: {
+        type: scheduleSchema,
+        required: true,
+    },
+});
+
+export type AutomationDocument = mongoose.Document & {
+    parser: ParserDocument;
+    regexParsing: RegexParsingDocument;
+    schedule: ScheduleDocument;
+};

--- a/verification/curator-service/api/src/model/parser.ts
+++ b/verification/curator-service/api/src/model/parser.ts
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+export const parserSchema = new mongoose.Schema({
+    awsLambdaArn: {
+        type: String,
+        required: 'Enter a parser AWS Lambda ARN',
+        match: [/^arn\:aws\:lambda\:.+\:.+\:function\:.+/],
+    },
+});
+
+export type ParserDocument = mongoose.Document & {
+    awsLambdaArn: string;
+};

--- a/verification/curator-service/api/src/model/regex-parsing.ts
+++ b/verification/curator-service/api/src/model/regex-parsing.ts
@@ -1,0 +1,32 @@
+import mongoose from 'mongoose';
+
+interface Field {
+    name: string;
+    regex: string;
+}
+
+const fieldSchema = new mongoose.Schema({
+    name: {
+        type: String,
+        required: 'Enter a dotted.field.name',
+    },
+    regex: {
+        type: String,
+        required: 'Enter a field extraction regex',
+    },
+});
+
+export const regexParsingSchema = new mongoose.Schema({
+    fields: {
+        type: [fieldSchema],
+        required: true,
+        validate: {
+            validator: (fields: [Field]): boolean => fields.length > 0,
+            message: 'Must include one or more fields',
+        },
+    },
+});
+
+export type RegexParsingDocument = mongoose.Document & {
+    fields: [Field];
+};

--- a/verification/curator-service/api/src/model/schedule.ts
+++ b/verification/curator-service/api/src/model/schedule.ts
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+export const scheduleSchema = new mongoose.Schema({
+    awsRuleArn: {
+        type: String,
+        required: 'Enter a CloudWatch schedule rule AWS Lambda ARN',
+        match: [/^arn\:aws\:events\:.+\:.+\:rule\/.+/],
+    },
+});
+
+export type ScheduleDocument = mongoose.Document & {
+    awsRuleArn: string;
+};

--- a/verification/curator-service/api/src/model/source.ts
+++ b/verification/curator-service/api/src/model/source.ts
@@ -1,63 +1,10 @@
 import mongoose from 'mongoose';
+import {
+    AutomationDocument,
+    automationParsingValidator,
+    automationSchema,
+} from './automation';
 import { OriginDocument, originSchema } from './origin';
-
-interface Field {
-    name: string;
-    regex: string;
-}
-
-const fieldSchema = new mongoose.Schema({
-    name: {
-        type: String,
-        required: 'Enter a dotted.field.name',
-    },
-    regex: {
-        type: String,
-        required: 'Enter a field extraction regex',
-    },
-});
-
-interface RegexParsing {
-    fields: [Field];
-}
-
-const regexParsingSchema = new mongoose.Schema({
-    fields: [fieldSchema],
-});
-
-interface Parser {
-    awsLambdaArn: string;
-}
-
-const parserSchema = new mongoose.Schema({
-    awsLambdaArn: {
-        type: String,
-        required: 'Enter a parser AWS Lambda ARN',
-    },
-});
-
-interface Schedule {
-    awsRuleArn: string;
-}
-
-const scheduleSchema = new mongoose.Schema({
-    awsRuleArn: {
-        type: String,
-        required: 'Enter a CloudWatch schedule rule AWS Lambda ARN',
-    },
-});
-
-interface Automation {
-    parser: Parser;
-    schedule: Schedule;
-    regexParsing: RegexParsing;
-}
-
-const automationSchema = new mongoose.Schema({
-    parser: parserSchema,
-    schedule: scheduleSchema,
-    regexParsing: regexParsingSchema,
-});
 
 const sourceSchema = new mongoose.Schema({
     name: {
@@ -69,14 +16,17 @@ const sourceSchema = new mongoose.Schema({
         required: 'Enter an origin',
     },
     format: String,
-    automation: automationSchema,
+    automation: {
+        type: automationSchema,
+        validate: automationParsingValidator,
+    },
 });
 
 type SourceDocument = mongoose.Document & {
     name: string;
     origin: OriginDocument;
     format: string;
-    automation: Automation;
+    automation: AutomationDocument;
 };
 
 export const Source = mongoose.model<SourceDocument>('Source', sourceSchema);

--- a/verification/curator-service/api/test/model/automation.test.ts
+++ b/verification/curator-service/api/test/model/automation.test.ts
@@ -1,0 +1,59 @@
+import {
+    AutomationDocument,
+    automationParsingValidator,
+    automationSchema,
+} from '../../src/model/automation';
+
+import { Error } from 'mongoose';
+import fullModel from './data/automation.full.json';
+import regexParsingModel from './data/regex-parsing.full.json';
+import mongoose from 'mongoose';
+
+const Automation = mongoose.model<AutomationDocument>(
+    'Automation',
+    automationSchema,
+);
+
+// Used to test automationParsingValidator.
+const wrapperSchema = new mongoose.Schema({
+    automation: {
+        type: automationSchema,
+        validate: automationParsingValidator,
+    },
+});
+type WrapperDocument = mongoose.Document & { automation: AutomationDocument };
+const Wrapper = mongoose.model<WrapperDocument>('Wrapper', wrapperSchema);
+
+describe('validate', () => {
+    it('an automation without a schedule is invalid', async () => {
+        const missingSchedule = { ...fullModel };
+        delete missingSchedule.schedule;
+
+        return new Automation(missingSchedule).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('an automation without either a parser or regexParsing is invalid', async () => {
+        const noParsing = { ...fullModel };
+        delete noParsing.parser;
+        const wrapper = { automation: noParsing };
+
+        return new Wrapper(wrapper).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('an automation with both a parser and regexParsing is invalid', async () => {
+        const bothParsing = { ...fullModel, regexParsing: regexParsingModel };
+        const wrapper = { automation: bothParsing };
+
+        return new Wrapper(wrapper).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('a fully specified automation is valid', async () => {
+        return new Automation(fullModel).validate();
+    });
+});

--- a/verification/curator-service/api/test/model/automation.test.ts
+++ b/verification/curator-service/api/test/model/automation.test.ts
@@ -53,7 +53,17 @@ describe('validate', () => {
         });
     });
 
-    it('a fully specified automation is valid', async () => {
+    it('a fully specified automation with parser is valid', async () => {
         return new Automation(fullModel).validate();
+    });
+
+    it('a fully specified automation with regexParsing is valid', async () => {
+        const justRegexParsing = {
+            ...fullModel,
+            regexParsing: regexParsingModel,
+        };
+        delete justRegexParsing.parser;
+
+        return new Automation(justRegexParsing).validate();
     });
 });

--- a/verification/curator-service/api/test/model/data/automation.full.json
+++ b/verification/curator-service/api/test/model/data/automation.full.json
@@ -1,0 +1,8 @@
+{
+    "parser": {
+        "awsLambdaArn": "arn:aws:lambda:region:id:function:name"
+    },
+    "schedule": {
+        "awsRuleArn": "arn:aws:events:region:id:rule/name"
+    }
+}

--- a/verification/curator-service/api/test/model/data/parser.full.json
+++ b/verification/curator-service/api/test/model/data/parser.full.json
@@ -1,0 +1,3 @@
+{
+    "awsLambdaArn": "arn:aws:lambda:region:id:function:name"
+}

--- a/verification/curator-service/api/test/model/data/regex-parsing.full.json
+++ b/verification/curator-service/api/test/model/data/regex-parsing.full.json
@@ -1,0 +1,8 @@
+{
+    "fields": [
+        {
+            "name": "name_field",
+            "regex": "regex_field"
+        }
+    ]
+}

--- a/verification/curator-service/api/test/model/data/schedule.full.json
+++ b/verification/curator-service/api/test/model/data/schedule.full.json
@@ -1,0 +1,3 @@
+{
+    "awsRuleArn": "arn:aws:events:region:id:rule/name"
+}

--- a/verification/curator-service/api/test/model/data/source.full.json
+++ b/verification/curator-service/api/test/model/data/source.full.json
@@ -7,10 +7,10 @@
     "format": "PDF",
     "automation": {
         "parser": {
-            "awsLambdaArn": "arn-parser"
+            "awsLambdaArn": "arn:aws:lambda:region:id:function:name"
         },
         "schedule": {
-            "awsRuleArn": "arn-rule"
+            "awsRuleArn": "arn:aws:events:region:id:rule/name"
         }
     }
 }

--- a/verification/curator-service/api/test/model/parser.test.ts
+++ b/verification/curator-service/api/test/model/parser.test.ts
@@ -1,0 +1,31 @@
+import { ParserDocument, parserSchema } from '../../src/model/parser';
+
+import { Error } from 'mongoose';
+import fullModel from './data/parser.full.json';
+import mongoose from 'mongoose';
+
+const Parser = mongoose.model<ParserDocument>('Parser', parserSchema);
+
+describe('validate', () => {
+    it('a parser without an AWS lambda ARN is invalid', async () => {
+        const missingArn = { ...fullModel };
+        delete missingArn.awsLambdaArn;
+
+        return new Parser(missingArn).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('a parser with a misformated AWS lambda ARN is invalid', async () => {
+        const badArn = { ...fullModel };
+        badArn.awsLambdaArn = 'invalid:arn:aws:lambda:region:function:field';
+
+        return new Parser(badArn).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('a fully specified parser is valid', async () => {
+        return new Parser(fullModel).validate();
+    });
+});

--- a/verification/curator-service/api/test/model/parser.test.ts
+++ b/verification/curator-service/api/test/model/parser.test.ts
@@ -16,9 +16,11 @@ describe('validate', () => {
         });
     });
 
-    it('a parser with a misformated AWS lambda ARN is invalid', async () => {
-        const badArn = { ...fullModel };
-        badArn.awsLambdaArn = 'invalid:arn:aws:lambda:region:function:field';
+    it('a parser with a misformatted AWS lambda ARN is invalid', async () => {
+        const badArn = {
+            ...fullModel,
+            awsLambdaArn: 'invalid:arn:aws:lambda:region:function:field',
+        };
 
         return new Parser(badArn).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);

--- a/verification/curator-service/api/test/model/regex-parsing.ts
+++ b/verification/curator-service/api/test/model/regex-parsing.ts
@@ -1,0 +1,43 @@
+import {
+    RegexParsingDocument,
+    regexParsingSchema,
+} from '../../src/model/regex-parsing';
+
+import { Error } from 'mongoose';
+import fullModel from './data/regex-parsing.full.json';
+import mongoose from 'mongoose';
+
+const RegexPasing = mongoose.model<RegexParsingDocument>(
+    'RegexParsing',
+    regexParsingSchema,
+);
+
+describe('validate', () => {
+    it('a regex-parsing without any fields is invalid', async () => {
+        return new RegexPasing({}).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('a regex-parsing with fields missing a name is invalid', async () => {
+        const missingName = { ...fullModel };
+        delete missingName.fields[0].name;
+
+        return new RegexPasing(missingName).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('a regex-parsing with fields missing a regex is invalid', async () => {
+        const missingRegex = { ...fullModel };
+        delete missingRegex.fields[0].regex;
+
+        return new RegexPasing(missingRegex).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('a fully specified regex-parsing is valid', async () => {
+        return new RegexPasing(fullModel).validate();
+    });
+});

--- a/verification/curator-service/api/test/model/schedule.test.ts
+++ b/verification/curator-service/api/test/model/schedule.test.ts
@@ -1,0 +1,31 @@
+import { ScheduleDocument, scheduleSchema } from '../../src/model/schedule';
+
+import { Error } from 'mongoose';
+import fullModel from './data/schedule.full.json';
+import mongoose from 'mongoose';
+
+const Schedule = mongoose.model<ScheduleDocument>('Schedule', scheduleSchema);
+
+describe('validate', () => {
+    it('a schedule without an AWS rule ARN is invalid', async () => {
+        const missingArn = { ...fullModel };
+        delete missingArn.awsRuleArn;
+
+        return new Schedule(missingArn).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('a schedule with a misformated AWS rule ARN is invalid', async () => {
+        const badArn = { ...fullModel };
+        badArn.awsRuleArn = 'invalid:arn:aws:events:region:rule/field';
+
+        return new Schedule(badArn).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('a fully specified schedule is valid', async () => {
+        return new Schedule(fullModel).validate();
+    });
+});


### PR DESCRIPTION
Need to get a handful of validations and protections in place before we hit the AWS API from our Sources API. This is the bulk of doing so, less one last change for the inclusion of a schedule expression that I'll send subsequently.

Apologies for lumping these together; in this case seemed the lesser evil.