### PR TITLE
exit process when DB can't connect

### DIFF
--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -45,6 +45,7 @@ app.use('/api', apiRouter);
         console.log('Connected to the database!');
     } catch (e) {
         console.error('Failed to connect to the database. :(', e);
+        process.exit(1);
     }
 })();
 

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -43,6 +43,7 @@ mongoose
     })
     .catch((e) => {
         console.error('Failed to connect to DB', e);
+        process.exit(1);
     });
 
 // Configure authentication.


### PR DESCRIPTION
Otherwise we're left with a non-connected mongoose that makes for a useless server.
Mongoose apparently doesn't have an indefinite retry mechanism built-in.
We could build our own retry mechanism within index.ts for each service but I think for now we're fine with relying on kubernetes or ECS orchestrator to restart containers automatically.