### PR TITLE
Add a simple profile page

### DIFF
--- a/verification/curator-service/ui/src/components/App.test.tsx
+++ b/verification/curator-service/ui/src/components/App.test.tsx
@@ -2,8 +2,24 @@ import App from './App';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import axios from 'axios';
 
-it('renders without crashing', () => {
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+it('renders without crashing when logged in', () => {
+    const axiosResponse = {
+        data: { name: 'Alice Smith', email: 'foo@bar.com' },
+        status: 200,
+        statusText: 'Forbidden',
+        config: {},
+        headers: {},
+    };
+    mockedAxios.get.mockResolvedValueOnce(axiosResponse);
     const div = document.createElement('div');
     ReactDOM.render(
         <MemoryRouter>
@@ -12,4 +28,27 @@ it('renders without crashing', () => {
         div,
     );
     expect(div.textContent).toContain('epid');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/auth/profile');
+});
+
+it('renders without crashing when logged out', () => {
+    const axiosResponse = {
+        data: {},
+        status: 403,
+        statusText: 'Forbidden',
+        config: {},
+        headers: {},
+    };
+    mockedAxios.get.mockResolvedValue(axiosResponse);
+    const div = document.createElement('div');
+    ReactDOM.render(
+        <MemoryRouter>
+            <App />
+        </MemoryRouter>,
+        div,
+    );
+    expect(div.textContent).toContain('epid');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/auth/profile');
 });

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -4,8 +4,10 @@ import EpidNavbar from './EpidNavbar';
 import LinelistTable from './LinelistTable';
 import React from 'react';
 import SourceTable from './SourceTable';
+import Profile from './Profile';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { createMuiTheme } from '@material-ui/core/styles';
+import axios from 'axios';
 
 const theme = createMuiTheme({
     palette: {
@@ -18,25 +20,55 @@ const theme = createMuiTheme({
     },
 });
 
-function App(): JSX.Element {
-    return (
-        <ThemeProvider theme={theme}>
-            <div className="App">
-                <EpidNavbar />
-                <Switch>
-                    <Route path="/cases">
-                        <Linelist />
-                    </Route>
-                    <Route path="/sources">
-                        <Sources />
-                    </Route>
-                    <Route exact path="/">
-                        <Home />
-                    </Route>
-                </Switch>
-            </div>
-        </ThemeProvider>
-    );
+interface User {
+    name: string;
+    email: string;
+}
+
+class App extends React.Component<{}, User> {
+    constructor(props: {}) {
+        super(props);
+        this.state = {
+            name: '',
+            email: '',
+        };
+    }
+
+    componentDidMount(): void {
+        axios
+            .get<User>('/auth/profile')
+            .then((resp) => {
+                this.setState({ name: resp.data.name, email: resp.data.email });
+            })
+            .catch((e) => {
+                this.setState({ name: '', email: '' });
+                console.error(e);
+            });
+    }
+
+    render(): JSX.Element {
+        return (
+            <ThemeProvider theme={theme}>
+                <div className="App">
+                    <EpidNavbar user={this.state} />
+                    <Switch>
+                        <Route path="/cases">
+                            <Linelist />
+                        </Route>
+                        <Route path="/sources">
+                            <Sources />
+                        </Route>
+                        <Route path="/profile">
+                            <Profile user={this.state} />
+                        </Route>
+                        <Route exact path="/">
+                            <Home />
+                        </Route>
+                    </Switch>
+                </div>
+            </ThemeProvider>
+        );
+    }
 }
 
 function Linelist(): JSX.Element {
@@ -53,6 +85,8 @@ function Home(): JSX.Element {
             <Link to="/cases">Linelist</Link>
             <br />
             <Link to="/sources">Sources</Link>
+            <br />
+            <Link to="/profile">Profile</Link>
             <br />
             <Link to="/privacy-policy">Privacy policy</Link>
             <br />

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -58,11 +58,12 @@ class App extends React.Component<{}, User> {
                         <Route path="/sources">
                             <Sources />
                         </Route>
-                        <Route path="/profile">
-                            <Profile user={this.state} />
-                        </Route>
+                        {this.state.email &&
+                            (<Route path="/profile">
+                                <Profile user={this.state} />
+                            </Route>)}
                         <Route exact path="/">
-                            <Home />
+                            <Home user={this.state} />
                         </Route>
                     </Switch>
                 </div>
@@ -79,21 +80,29 @@ function Sources(): JSX.Element {
     return <SourceTable />;
 }
 
-function Home(): JSX.Element {
-    return (
-        <nav>
-            <Link to="/cases">Linelist</Link>
-            <br />
-            <Link to="/sources">Sources</Link>
-            <br />
-            <Link to="/profile">Profile</Link>
-            <br />
-            <Link to="/privacy-policy">Privacy policy</Link>
-            <br />
-            <Link to="/terms">Terms of service</Link>
-            <br />
-        </nav>
-    );
+interface HomeProps {
+    user: User;
+}
+class Home extends React.Component<HomeProps, {}> {
+    render(): JSX.Element {
+        return (
+            <nav>
+                <Link to="/cases">Linelist</Link>
+                <br />
+                <Link to="/sources">Sources</Link>
+                <br />
+                {this.props.user.email &&
+                    (<div>
+                        <Link to="/profile">Profile</Link>
+                        <br />
+                    </div>)}
+                <Link to="/privacy-policy">Privacy policy</Link>
+                <br />
+                <Link to="/terms">Terms of service</Link>
+                <br />
+            </nav>
+        )
+    };
 }
 
 export default App;

--- a/verification/curator-service/ui/src/components/EpidNavbar.test.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.test.tsx
@@ -3,71 +3,38 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import EpidNavbar from './EpidNavbar';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
-import axios from 'axios';
 import { createMemoryHistory } from 'history';
-
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
-
-beforeEach(() => {
-    // Provide a default response for the profile fetch
-    // when the component mounts.
-    const axiosResponse = {
-        data: {},
-        status: 403,
-        statusText: 'Forbidden',
-        config: {},
-        headers: {},
-    };
-    mockedAxios.get.mockResolvedValue(axiosResponse);
-});
-
-afterEach(() => {
-    jest.clearAllMocks();
-});
 
 test('renders epid brand', async () => {
     await act(async () => {
         render(
             <MemoryRouter>
-                <EpidNavbar />
+                <EpidNavbar user={{ name: 'Alice Smith', email: 'foo@bar.com' }} />
             </MemoryRouter>,
         );
     });
     expect(screen.getByText(/epid/i)).toBeInTheDocument();
 });
 
-test('renders login button when not logged in', async () => {
+test('renders login button when not passed user information', async () => {
     await act(async () => {
         render(
             <MemoryRouter>
-                <EpidNavbar />
+                <EpidNavbar user={{ name: '', email: '' }} />
             </MemoryRouter>,
         );
     });
     expect(screen.getByText(/Login/i)).toBeInTheDocument();
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
-    expect(mockedAxios.get).toHaveBeenCalledWith('/auth/profile');
 });
 
-test('renders logout button when logged in', async () => {
-    const axiosResponse = {
-        data: { email: 'foo@bar.com' },
-        status: 200,
-        statusText: 'Forbidden',
-        config: {},
-        headers: {},
-    };
-    mockedAxios.get.mockResolvedValueOnce(axiosResponse);
+test('renders logout button when passed user information', async () => {
     await act(async () => {
         render(
             <MemoryRouter>
-                <EpidNavbar />
+                <EpidNavbar user={{ name: 'Alice Smith', email: 'foo@bar.com' }} />
             </MemoryRouter>,
         );
     });
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
-    expect(mockedAxios.get).toHaveBeenCalledWith('/auth/profile');
     expect(screen.getByText(/foo@bar.com/i)).toBeInTheDocument();
 });
 
@@ -76,7 +43,7 @@ test('redirects to home on click', async () => {
     await act(async () => {
         render(
             <MemoryRouter>
-                <EpidNavbar />
+                <EpidNavbar user={{ name: 'Alice Smith', email: 'foo@bar.com' }} />
             </MemoryRouter>,
         );
     });

--- a/verification/curator-service/ui/src/components/EpidNavbar.tsx
+++ b/verification/curator-service/ui/src/components/EpidNavbar.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import { WithStyles } from '@material-ui/core/styles/withStyles';
-import axios from 'axios';
 
 // Return type isn't meaningful.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -27,32 +26,16 @@ const styles = (theme: Theme) =>
     });
 
 interface User {
+    name: string;
     email: string;
 }
 
 // Cf. https://material-ui.com/guides/typescript/#augmenting-your-props-using-withstyles
-type Props = WithStyles<typeof styles>;
+interface Props extends WithStyles<typeof styles> {
+    user: User;
+}
 
-class EpidNavbar extends React.Component<Props, User> {
-    constructor(props: Props) {
-        super(props);
-        this.state = {
-            email: '',
-        };
-    }
-
-    componentDidMount(): void {
-        axios
-            .get<User>('/auth/profile')
-            .then((resp) => {
-                this.setState({ email: resp.data.email });
-            })
-            .catch((e) => {
-                this.setState({ email: '' });
-                console.error(e);
-            });
-    }
-
+class EpidNavbar extends React.Component<Props, {}> {
     render(): JSX.Element {
         const { classes } = this.props;
         return (
@@ -72,23 +55,23 @@ class EpidNavbar extends React.Component<Props, User> {
                         <Typography variant="h6" className={classes.title}>
                             epid
                         </Typography>
-                        {this.state.email ? (
+                        {this.props.user.email ? (
                             <Button
                                 variant="contained"
                                 color="primary"
                                 href="/auth/logout"
                             >
-                                Logout {this.state.email}
+                                Logout {this.props.user.email}
                             </Button>
                         ) : (
-                            <Button
-                                variant="contained"
-                                color="secondary"
-                                href={process.env.REACT_APP_LOGIN_URL}
-                            >
-                                Login
-                            </Button>
-                        )}
+                                <Button
+                                    variant="contained"
+                                    color="secondary"
+                                    href={process.env.REACT_APP_LOGIN_URL}
+                                >
+                                    Login
+                                </Button>
+                            )}
                     </Toolbar>
                 </AppBar>
             </div>

--- a/verification/curator-service/ui/src/components/Profile.test.tsx
+++ b/verification/curator-service/ui/src/components/Profile.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import Profile from './Profile';
+import React from 'react';
+
+test('shows profile when passed user information', async () => {
+    render(<Profile user={{ name: 'Alice Smith', email: 'foo@bar.com' }} />);
+    expect(screen.getByText(/Alice Smith/i)).toBeInTheDocument();
+    expect(screen.getByText(/foo@bar.com/i)).toBeInTheDocument();
+});
+
+test('shows login message when not passed user information', async () => {
+    render(<Profile user={{ name: '', email: '' }} />);
+    expect(screen.getByText(/Login required to view this page/i))
+        .toBeInTheDocument();
+});

--- a/verification/curator-service/ui/src/components/Profile.tsx
+++ b/verification/curator-service/ui/src/components/Profile.tsx
@@ -1,0 +1,57 @@
+import { withStyles } from '@material-ui/core';
+import { Theme, createStyles } from '@material-ui/core/styles';
+
+import React from 'react';
+import { WithStyles } from '@material-ui/core/styles/withStyles';
+
+const styles = (theme: Theme) =>
+    createStyles({
+        root: {
+            textAlign: 'center',
+        },
+        login: {
+            marginTop: theme.spacing(10),
+        },
+        name: {
+            marginTop: theme.spacing(10),
+        },
+        email: {
+            marginTop: theme.spacing(2),
+        },
+    });
+
+interface User {
+    name: string;
+    email: string;
+}
+
+// Cf. https://material-ui.com/guides/typescript/#augmenting-your-props-using-withstyles
+interface Props extends WithStyles<typeof styles> {
+    user: User;
+}
+
+class Profile extends React.Component<Props, {}> {
+    render(): JSX.Element {
+        const { classes } = this.props;
+        return (
+            <div className={classes.root}>
+                {!this.props.user.email && (
+                    <div className={classes.login}>
+                        Login required to view this page
+                    </div>)}
+
+                {this.props.user.name && (
+                    <div className={classes.name}>
+                        {this.props.user.name}
+                    </div>)}
+
+                {this.props.user.email && (
+                    <div className={classes.email}>
+                        {this.props.user.email}
+                    </div>)}
+            </div>
+        );
+    }
+}
+
+export default withStyles(styles, { withTheme: true })(Profile);


### PR DESCRIPTION
I pulled the `axios.get<User>('/auth/profile')` out into the App file because the User information was now being used in EpidNavbar and Profile.

Logged in:
![Screen Shot 2020-05-20 at 3 48 01 PM](https://user-images.githubusercontent.com/30459667/82471042-10877d00-9abe-11ea-8380-9e06dc29c22d.png)

logged out: 
![Screen Shot 2020-05-20 at 3 47 41 PM](https://user-images.githubusercontent.com/30459667/82471030-09606f00-9abe-11ea-907d-8091316a70bb.png)
