### PR TITLE
example test using local auth

### DIFF
--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -13,7 +13,7 @@ export const mustBeAuthenticated = (
     res: Response,
     next: NextFunction,
 ): void => {
-    if (req.user) {
+    if (req.isAuthenticated()) {
         next();
         return;
     }
@@ -55,6 +55,31 @@ export class AuthController {
             mustBeAuthenticated,
             (req: Request, res: Response): void => {
                 res.json(req.user);
+            },
+        );
+    }
+
+    // configureLocalAuth will get or create the user present in the request.
+    configureLocalAuth(): void {
+        console.log('Configuring local auth for tests');
+        // /register creates a user if necessary and log them in.
+        this.router.post(
+            '/register',
+            async (req: Request, res: Response): Promise<void> => {
+                const user = await User.create({
+                    name: req.body.name,
+                    email: req.body.email,
+                    // Necessary to pass mongoose validation.
+                    googleID: 42,
+                });
+                req.login(user, (err: Error) => {
+                    if (!err) {
+                        res.json(user);
+                        return;
+                    }
+                    console.log(err);
+                    res.sendStatus(500);
+                });
             },
         );
     }

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -67,7 +67,7 @@ authController.configurePassport(
     env.GOOGLE_OAUTH_CLIENT_ID,
     env.GOOGLE_OAUTH_CLIENT_SECRET,
 );
-if (env.AUTH_STRATEGY == 'local') {
+if (env.ENABLE_LOCAL_AUTH) {
     authController.configureLocalAuth();
 }
 app.use(passport.initialize());

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -67,6 +67,9 @@ authController.configurePassport(
     env.GOOGLE_OAUTH_CLIENT_ID,
     env.GOOGLE_OAUTH_CLIENT_SECRET,
 );
+if (env.AUTH_STRATEGY == 'local') {
+    authController.configureLocalAuth();
+}
 app.use(passport.initialize());
 app.use(passport.session());
 app.use('/auth', authController.router);

--- a/verification/curator-service/api/src/util/validate-env.ts
+++ b/verification/curator-service/api/src/util/validate-env.ts
@@ -9,6 +9,7 @@ export default function validateEnv(): Readonly<{
     SESSION_COOKIE_KEY: string;
     AFTER_LOGIN_REDIRECT_URL: string;
     STATIC_DIR: string;
+    AUTH_STRATEGY: string;
 }> &
     CleanEnv & {
         readonly [varName: string]: string | undefined;
@@ -43,6 +44,11 @@ export default function validateEnv(): Readonly<{
         STATIC_DIR: str({
             desc: 'directory to serve static files from',
             devDefault: '',
+        }),
+        AUTH_STRATEGY: str({
+            desc: 'authentication strategy to use, local or oauth',
+            devDefault: 'local',
+            default: 'oauth',
         }),
     });
 }

--- a/verification/curator-service/api/src/util/validate-env.ts
+++ b/verification/curator-service/api/src/util/validate-env.ts
@@ -9,7 +9,7 @@ export default function validateEnv(): Readonly<{
     SESSION_COOKIE_KEY: string;
     AFTER_LOGIN_REDIRECT_URL: string;
     STATIC_DIR: string;
-    AUTH_STRATEGY: string;
+    ENABLE_LOCAL_AUTH: string;
 }> &
     CleanEnv & {
         readonly [varName: string]: string | undefined;
@@ -42,13 +42,13 @@ export default function validateEnv(): Readonly<{
             devDefault: 'http://localhost:3002/',
         }),
         STATIC_DIR: str({
-            desc: 'directory to serve static files from',
+            desc: 'Directory to serve static files from',
             devDefault: '',
         }),
-        AUTH_STRATEGY: str({
-            desc: 'authentication strategy to use, local or oauth',
-            devDefault: 'local',
-            default: 'oauth',
+        ENABLE_LOCAL_AUTH: str({
+            desc: 'Whether to enable local auth strategy for testing',
+            devDefault: 'yes-for-testing',
+            default: '',
         }),
     });
 }

--- a/verification/curator-service/api/test/auth.test.ts
+++ b/verification/curator-service/api/test/auth.test.ts
@@ -1,6 +1,7 @@
 import app from '../src/index';
 import mongoose from 'mongoose';
 import request from 'supertest';
+import supertest from 'supertest';
 
 beforeAll(() => {
     return mongoose.connect(
@@ -35,6 +36,21 @@ describe('auth', () => {
     it('handles redirect from google', (done) => {
         // Redirects to consent screen because not authenticated.
         request(app).get('/auth/google/redirect').expect(302, done);
+    });
+});
+
+describe('local auth', () => {
+    it('can access authenticated pages', async () => {
+        // Create a user.
+        const request = supertest.agent(app);
+        await request
+            .post('/auth/register')
+            .send({
+                name: 'test-user',
+                email: 'foo@bar.com',
+            })
+            .expect(200, /test-user/);
+        request.get('/auth/profile').expect(200, /test-user/);
     });
 });
 


### PR DESCRIPTION
Exposes a /auth/register handler to create users when node_env != production to enable easy testing of logged in handlers.