### PR TITLE
Add endpoint definition for create case

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -13,6 +13,7 @@ paths:
   /cases:
     get:
       summary: Lists cases
+      operationId: listCases
       parameters:
         - name: page
           in: query
@@ -46,6 +47,8 @@ paths:
           $ref: "#/components/responses/401"
         "422":
           $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
   /cases/{id}:
     parameters:
       - name: id
@@ -57,6 +60,7 @@ paths:
           format: uuid
     get:
       summary: Gets a specific case
+      operationId: getCase
       responses:
         "200":
           description: OK
@@ -72,6 +76,8 @@ paths:
           $ref: "#/components/responses/404"
         "422":
           $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
 components:
   schemas:
     Case:
@@ -89,6 +95,8 @@ components:
       description: Not found
     "422":
       description: Unprocessable entity
+    "500":
+      description: Internal server error
 servers:
-  - url: "http://localhost:3000/api"
+  - url: http://localhost:3000/api
     description: Local server

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -49,6 +49,31 @@ paths:
           $ref: "#/components/responses/422"
         "500":
           $ref: "#/components/responses/500"
+    post:
+      summary: Creates a new case
+      operationId: createCase
+      requestBody:
+        description: Case to add
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewCase"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Case"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "422":
+          $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
   /cases/{id}:
     parameters:
       - name: id
@@ -81,11 +106,17 @@ paths:
 components:
   schemas:
     Case:
-      type: object
+      description: A complete case; a superset of "#/components/schemas/NewCase" with server-added fields
+      allOf:
+        - $ref: "#/components/schemas/NewCase"
+        - type: object
     CaseArray:
       type: array
       items:
         $ref: "#/components/schemas/Case"
+    NewCase:
+      description: The subset of "#/components/schemas/Case" required to create the entity
+      type: object
   responses:
     "400":
       description: Malformed request


### PR DESCRIPTION
(Note: first commit is minor cleanup)

Following the inheritance pattern for the entities, since I expect that the case that we POST will be a strict subset of what we GET/LIST, although both are just {} right now:

- Docs: https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
- Example: https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/petstore-expanded.yaml

Screencast:
![FmkmFGjnrZJ](https://user-images.githubusercontent.com/3913264/83057600-26002800-a025-11ea-95f6-de7d92677347.png)

