### PR TITLE
Make source.automation.schedule.awsRuleArn optional

### DIFF
--- a/verification/curator-service/api/src/model/schedule.ts
+++ b/verification/curator-service/api/src/model/schedule.ts
@@ -1,9 +1,12 @@
 import mongoose from 'mongoose';
 
 export const scheduleSchema = new mongoose.Schema({
+    // Non-required for now. This is semantically required in the data layer,
+    // but until we can replace Mongoose validation of API requests with
+    // something like OpenAPI spec validation, this must be non-required to
+    // facilitate validating create requests (which don't yet have an ARN).
     awsRuleArn: {
         type: String,
-        required: 'Enter a CloudWatch schedule rule AWS Lambda ARN',
         match: [/^arn\:aws\:events\:.+\:.+\:rule\/.+/],
     },
     awsScheduleExpression: {

--- a/verification/curator-service/api/test/model/data/schedule.minimal.json
+++ b/verification/curator-service/api/test/model/data/schedule.minimal.json
@@ -1,0 +1,3 @@
+{
+    "awsScheduleExpression": "rate(1 hour)"
+}

--- a/verification/curator-service/api/test/model/schedule.test.ts
+++ b/verification/curator-service/api/test/model/schedule.test.ts
@@ -2,20 +2,12 @@ import { ScheduleDocument, scheduleSchema } from '../../src/model/schedule';
 
 import { Error } from 'mongoose';
 import fullModel from './data/schedule.full.json';
+import minimalModel from './data/schedule.minimal.json';
 import mongoose from 'mongoose';
 
 const Schedule = mongoose.model<ScheduleDocument>('Schedule', scheduleSchema);
 
 describe('validate', () => {
-    it('a schedule without an AWS rule ARN is invalid', async () => {
-        const missingArn = { ...fullModel };
-        delete missingArn.awsRuleArn;
-
-        return new Schedule(missingArn).validate((e) => {
-            expect(e.name).toBe(Error.ValidationError.name);
-        });
-    });
-
     it('a schedule with a misformatted AWS rule ARN is invalid', async () => {
         const badArn = { ...fullModel };
         badArn.awsRuleArn = 'invalid:arn:aws:events:region:rule/field';
@@ -41,6 +33,10 @@ describe('validate', () => {
         return new Schedule(badSchedule).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });
+    });
+
+    it('a minimal schedule is valid', async () => {
+        return new Schedule(minimalModel).validate();
     });
 
     it('a fully specified schedule is valid', async () => {


### PR DESCRIPTION
See comment in the model file. Open to suggestions, if there's a better way to facilitate this pattern with Mongoose et al.