### PR TITLE
close DB after clearDB task run

### DIFF
--- a/verification/curator-service/ui/cypress/plugins/index.ts
+++ b/verification/curator-service/ui/cypress/plugins/index.ts
@@ -6,17 +6,18 @@ const url = 'mongodb://localhost:27017/';
 module.exports = (on: any, config: any) => {
     on('task', {
         clearDB() {
-            return new Promise((resolve) => {
+            return new Promise((resolve, reject) => {
                 MongoClient.connect(
                     url,
                     { useUnifiedTopology: true },
-                    function (error, db) {
-                        if (error) throw error;
+                    async (error, db) => {
+                        if (error) reject(error);
                         const covid19db = db.db('covid19');
-                        covid19db.collection('cases').deleteMany({});
+                        await covid19db.collection('cases').deleteMany({});
+                        db.close();
+                        resolve(null);
                     },
                 );
-                resolve(null);
             });
         },
     });


### PR DESCRIPTION
There were two issues with this code:
- resolve wasn't called in the callback so the promise would be resolved even tough the db hadn't been cleared yet
- db.close() wasn't called so dangling connections were left open

https://mongodb.github.io/node-mongodb-native/api-generated/mongoclient.html