### PR TITLE
Add automation details to the ingestion sources UI

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -7,6 +7,8 @@ This directory contains the docker compose file to run an isolated environment o
 **Important** running the full stack correctly requires having access to a few secrets: you should have a .env file at the top of your repository (where you run the `docker-compose` command) that looks like this:
 
 ```
+AWS_ACCESS_KEY_ID=<AWS access key ID>
+AWS_SECRET_ACCESS_KEY=<AWS secret access key to authenticate AWS API calls>
 GOOGLE_OAUTH_CLIENT_ID=<oauth client id to enable OAuth>
 GOOGLE_OAUTH_CLIENT_SECRET=<oauth client secret>
 ```

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -19,6 +19,8 @@ services:
             - mongo
             - data
         environment:
+            AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
+            AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY"
             DB_CONNECTION_STRING: "mongodb://mongo:27017/covid19"
             DATASERVER_URL: "http://data:3000"
             GOOGLE_OAUTH_CLIENT_ID: "${GOOGLE_OAUTH_CLIENT_ID}"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -20,7 +20,7 @@ services:
             - data
         environment:
             AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
-            AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY"
+            AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
             DB_CONNECTION_STRING: "mongodb://mongo:27017/covid19"
             DATASERVER_URL: "http://data:3000"
             GOOGLE_OAUTH_CLIENT_ID: "${GOOGLE_OAUTH_CLIENT_ID}"

--- a/verification/curator-service/ui/src/components/SourceTable.test.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.test.tsx
@@ -18,13 +18,14 @@ afterEach(() => {
 
 it('loads and displays sources', async () => {
     const sourceId = 'abc123';
+    const sourceName = 'source_name';
     const originUrl = 'origin url';
     const awsRuleArn = 'arn:aws:events:a:b:rule/c';
     const awsScheduleExpression = 'rate(2 hours)';
     const sources = [
         {
             _id: sourceId,
-            name: 'source_name',
+            name: sourceName,
             format: 'format',
             origin: {
                 url: originUrl,
@@ -63,6 +64,7 @@ it('loads and displays sources', async () => {
 
     // Verify display content.
     expect(await findByText(new RegExp(sourceId))).toBeInTheDocument();
+    expect(await findByText(new RegExp(sourceName))).toBeInTheDocument();
     expect(await findByText(new RegExp(originUrl))).toBeInTheDocument();
     expect(await findByText(new RegExp(awsRuleArn))).toBeInTheDocument();
     expect(

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -61,8 +61,7 @@ interface TableRow {
     name: string;
     // origin
     url: string;
-    // automation
-    // schedule
+    // automation.schedule
     awsRuleArn?: string;
     awsScheduleExpression?: string;
 }

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -152,6 +152,14 @@ class SourceTable extends React.Component<Props, SourceTableState> {
         });
     }
 
+    /**
+     * Creates a source from the provided table row data.
+     *
+     * For new sources, an AWS rule ARN won't be defined (instead, it's created
+     * by the server upon receiveing the create request). A schedule expression
+     * may be supplied, and indicates the intent to create a corresponding AWS
+     * scheduled event rule to automate source ingestion.
+     */
     createSourceFromRowData(rowData: TableRow): Source {
         return {
             _id: rowData._id,
@@ -161,14 +169,20 @@ class SourceTable extends React.Component<Props, SourceTableState> {
             },
             automation: rowData.awsScheduleExpression
                 ? {
-                      schedule: {
-                          awsScheduleExpression: rowData.awsScheduleExpression,
-                      },
-                  }
+                    schedule: {
+                        awsScheduleExpression: rowData.awsScheduleExpression,
+                    },
+                }
                 : undefined,
         };
     }
 
+    /**
+     * Updates a source from the provided table row data.
+     *
+     * Unlike for creation, an AWS rule ARN may be supplied alongside a
+     * schedule expression.
+     */
     updateSourceFromRowData(rowData: TableRow): Source {
         return {
             _id: rowData._id,
@@ -178,15 +192,22 @@ class SourceTable extends React.Component<Props, SourceTableState> {
             },
             automation: rowData.awsScheduleExpression
                 ? {
-                      schedule: {
-                          awsRuleArn: rowData.awsRuleArn,
-                          awsScheduleExpression: rowData.awsScheduleExpression,
-                      },
-                  }
+                    schedule: {
+                        awsRuleArn: rowData.awsRuleArn,
+                        awsScheduleExpression: rowData.awsScheduleExpression,
+                    },
+                }
                 : undefined,
         };
     }
 
+    /**
+     * Validates fields comprising the source.automation object.
+     *
+     * Rule ARN isn't necessarily present, because it isn't supplied in create
+     * requests. It might be present for updates, and if so, the schedule
+     * expression field must be present.
+     */
     validateAutomationFields(rowData: TableRow): boolean {
         return (
             !rowData.awsRuleArn ||

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -156,7 +156,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
      * Creates a source from the provided table row data.
      *
      * For new sources, an AWS rule ARN won't be defined (instead, it's created
-     * by the server upon receiveing the create request). A schedule expression
+     * by the server upon receiving the create request). A schedule expression
      * may be supplied, and indicates the intent to create a corresponding AWS
      * scheduled event rule to automate source ingestion.
      */


### PR DESCRIPTION
Couple notes:

- Considered doing something with "better" UX around schedule expression, but ended up reversing that. For lack of a bit more thought on the UX, we should probably punt on this for now.
- Not including AWS-esque validation on the schedule. There's a medium-sized regex in the Curator API data layer we can share here, but wasn't totally happy with just copy-pasta'ing that. Can revisit this later on.
- Excuse the inclusion of Docker changes, which I've added to locally E2E test.