### PR TITLE
Setup prod/dev instances on EKS and document release process

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -6,10 +6,12 @@ This directory contains the configuration files for the production infrastructur
 
 Install `eksctl` and `kubectl` to interact with Amazon EKS and the Kubernetes control plane.
 
-To configure kubectl to talk to the epid cluster, do:
+You can learn more about `eksctl` [here](https://eksctl.io/).
 
-```
-aws eks --region us-east-1 update-kubeconfig --name epid
+To configure kubectl to talk to the healthmapidha cluster, do:
+
+```shell
+aws eks --region us-east-1 update-kubeconfig --name healthmapidha
 ```
 
 ## Kubernetes setup
@@ -21,7 +23,7 @@ You can also list them with `eksctl get cluster`.
 The cluster was originally created with the command:
 
 ```shell
-eksctl create cluster --name=epid --region=us-east-1 --fargate --version=1.16
+eksctl create cluster --name=healthmapidha --region=us-east-1 --fargate --version=1.16
 ```
 
 The basic deployment/pods/services configuration looks like:
@@ -47,11 +49,11 @@ kubernetes   ClusterIP   10.100.0.1      <none>        443/TCP    86m
 ```
 
 
-We use a deployment file for the data-service and for the curator-service, check out data.yaml and TODO:curator.yaml.
+We use a deployment file for the data-service and for the curator-service, check out data.yaml and curator.yaml.
 
 To update the deployments use:
 
-```
+```shell
 kubectl apply -f data.yaml -f curator.yaml
 ```
 
@@ -83,24 +85,39 @@ Deployments require secrets to connect to MongoDB for example or set up OAuth, w
 
 When you want to generate a new secret, follow the [official instructions](https://kubernetes.io/docs/concepts/configuration/secret/) using a kustomization.yaml file that looks like this:
 
-```
+```yaml
 secretGenerator:
-  - name: data
+  - name: data-dev
     literals:
       - some_secret_for_data=foo
-  - name: curator
+  - name: curator-dev
     literals:
       - some_secret_for_curator=bar
+      - another_secret_for_curator=baz
+  - name: data-prod
+    literals:
+      - some_secret_for_data=foo
+  - name: curator-prod
+    literals:
+      - some_secret_for_curator=foo
       - another_secret_for_curator=baz
 ```
 
 Apply with `kubectl apply -k .`.
 
+If you generated a new secret, you need to set it in the appropriate deployment files.
+
 To get a list of existing secrets, you can do `kubectl get secrets`.
 
-### Namespaces
+## Labels
 
-For simplicity we are currently in the default namespace, it will be a good idea to move to a more specific namespace in the future if the cluster becomes more complex (with dev, preprod, prod envs for example).
+We use labels to differentiate between prod and dev instances of the containers.
+
+Curator service has the labels `app=curator` and `environment=prod|dev`.
+
+Data service has the labels `app=data` and `environment=prod|dev`.
+
+Services exposed contain the environment in their names to avoid mistakenly taking to a different service, for example use `http://data-dev` to talk to dev data service and `http://data-prod` to talk to the prod data service.
 
 ## Docker-hub
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -125,4 +125,42 @@ Images used in deployments are pulled from docker hub where automated builds hav
 
 Check out the repos for the [curator service](https://hub.docker.com/repository/docker/healthmapidha/curatorservice) and [data service](https://hub.docker.com/repository/docker/healthmapidha/dataservice).
 
-Automated builds create a new image with the _latest_ tag upon every push to the master branch on this github repo.
+Automated builds create a new image with the _latest_ tag upon every push to the master branch on this github repo. More specialized tags are described below.
+
+## Releases
+
+We follow [semantic versioning](https://semver.org/) which is basically:
+
+    Given a version number MAJOR.MINOR.PATCH, increment the:
+
+    MAJOR version when you make incompatible API changes,
+    MINOR version when you add functionality in a backwards compatible manner, and
+    PATCH version when you make backwards compatible bug fixes.
+
+Docker-hub has automated builds setup that extract the semantic version from tags in the master branch.
+
+To push a new release of the curator service:
+
+Tag master with the `curator-0.1.2` tag:
+
+`git tag curator-0.1.2`
+
+the push it to the repo:
+
+`git push origin curator-0.1.2`
+
+Docker hub will automatically build the image: `docker.io/healthmapidha/curatorservice:0.1.2`.
+
+This tag can then be referenced in the deployment files, change the current image version to the new one and apply the change: `kubectl apply -f curator.yaml`.
+
+To push a new release of the data service, follow the same procedure but change `curator` to `data` in the tag.
+
+You can list the existing tags/versions with `git tag` or on the [github repo](https://github.com/open-covid-data/healthmap-gdo-temp/releases).
+
+### Rollback
+
+Just change the image tag referenced in the deployment file to an earlier version and apply the change.
+
+### Deleting a release
+
+If for some reason you need to delete a tag, you can do it with `git tag -d curator-1.2.3` then `git push origin :refs/tags/curator-0.1.2` to delete it remotely.

--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -2,18 +2,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: curator
+  name: curator-dev
   labels:
     environment: dev
     app: curator
 spec:
   selector:
     matchLabels:
+      environment: dev
       app: curator
   replicas: 1
   template:
     metadata:
       labels:
+        environment: dev
         app: curator
     spec:
       containers:
@@ -23,27 +25,102 @@ spec:
             - containerPort: 3001
           env:
             - name: DATASERVER_URL
-              value: "http://data"
+              value: "http://data-dev"
             - name: DB_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:
-                  name: curator-kkhd8mbt65
+                  name: curator-dev-287t4897k8
                   key: db_connection_string
             - name: SESSION_COOKIE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: curator-kkhd8mbt65
+                  name: curator-dev-287t4897k8
                   key: session_cookie_key
             - name: GOOGLE_OAUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: curator-kkhd8mbt65
+                  name: curator-dev-287t4897k8
                   key: google_oauth_client_secret
             - name: GOOGLE_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: curator-kkhd8mbt65
+                  name: curator-dev-287t4897k8
                   key: google_oauth_client_id
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: curator-dev-287t4897k8
+                  key: aws_access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: curator-dev-287t4897k8
+                  key: aws_secret_access_key
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: curator-prod
+  labels:
+    environment: prod
+    app: curator
+spec:
+  selector:
+    matchLabels:
+      environment: prod
+      app: curator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        environment: prod
+        app: curator
+    spec:
+      containers:
+        - name: curator
+          image: docker.io/healthmapidha/curatorservice:latest
+          ports:
+            - containerPort: 3001
+          env:
+            - name: DATASERVER_URL
+              value: "http://data-prod"
+            - name: DB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: curator-prod-ktf295kbg4
+                  key: db_connection_string
+            - name: SESSION_COOKIE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: curator-prod-ktf295kbg4
+                  key: session_cookie_key
+            - name: GOOGLE_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: curator-prod-ktf295kbg4
+                  key: google_oauth_client_secret
+            - name: GOOGLE_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: curator-prod-ktf295kbg4
+                  key: google_oauth_client_id
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: curator-prod-ktf295kbg4
+                  key: aws_access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: curator-prod-ktf295kbg4
+                  key: aws_secret_access_key
           resources:
             requests:
               memory: "256Mi"
@@ -55,10 +132,24 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: curator
+  name: curator-dev
 spec:
   selector:
     app: curator
+    environment: dev
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: curator-prod
+spec:
+  selector:
+    app: curator
+    environment: dev
   ports:
     - protocol: TCP
       port: 80

--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: curator
-          image: docker.io/healthmapidha/curatorservice:0.0.1
+          image: docker.io/healthmapidha/curatorservice:0.0.3
           ports:
             - containerPort: 3001
           env:
@@ -85,7 +85,7 @@ spec:
     spec:
       containers:
         - name: curator
-          image: docker.io/healthmapidha/curatorservice:0.0.1
+          image: docker.io/healthmapidha/curatorservice:0.0.3
           ports:
             - containerPort: 3001
           env:

--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: curator
-          image: docker.io/healthmapidha/curatorservice:latest
+          image: docker.io/healthmapidha/curatorservice:0.0.1
           ports:
             - containerPort: 3001
           env:
@@ -85,7 +85,7 @@ spec:
     spec:
       containers:
         - name: curator
-          image: docker.io/healthmapidha/curatorservice:latest
+          image: docker.io/healthmapidha/curatorservice:0.0.1
           ports:
             - containerPort: 3001
           env:

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: data
-          image: docker.io/healthmapidha/dataservice:latest
+          image: docker.io/healthmapidha/dataservice:0.0.1
           ports:
             - containerPort: 3000
           env:
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
         - name: data
-          image: docker.io/healthmapidha/dataservice:latest
+          image: docker.io/healthmapidha/dataservice:0.0.1
           ports:
             - containerPort: 3000
           env:

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: data
-          image: docker.io/healthmapidha/dataservice:0.0.1
+          image: docker.io/healthmapidha/dataservice:0.0.3
           ports:
             - containerPort: 3000
           env:
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
         - name: data
-          image: docker.io/healthmapidha/dataservice:0.0.1
+          image: docker.io/healthmapidha/dataservice:0.0.3
           ports:
             - containerPort: 3000
           env:

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -2,18 +2,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: data
+  name: data-dev
   labels:
     environment: dev
     app: data
 spec:
   selector:
     matchLabels:
+      environment: dev
       app: data
   replicas: 1
   template:
     metadata:
       labels:
+        environment: dev
         app: data
     spec:
       containers:
@@ -25,7 +27,45 @@ spec:
             - name: DB_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:
-                  name: data-878ckgc42b
+                  name: data-dev-ddhhd4mmhf
+                  key: db_connection_string
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-prod
+  labels:
+    environment: prod
+    app: data
+spec:
+  selector:
+    matchLabels:
+      environment: prod
+      app: data
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        environment: prod
+        app: data
+    spec:
+      containers:
+        - name: data
+          image: docker.io/healthmapidha/dataservice:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: DB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: data-prod-84t6gt4hhc
                   key: db_connection_string
           resources:
             requests:
@@ -38,10 +78,24 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: data
+  name: data-dev
 spec:
   selector:
     app: data
+    environment: dev
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-prod
+spec:
+  selector:
+    app: data
+    environment: prod
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
- Renamed the cluster `healthmapidha` for consistency in what Gaurav created for us (docker hub for example) and that makes this cluster less epid-specific if Spencer wants to reuse it for other apps.

- current version is 0.0.3 because it took me 3 attemps to get the docker hub regexp right /sigh