### PR TITLE
Integrate the Source API update method with AWS CloudWatch Events

### DIFF
--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -76,7 +76,7 @@ export default class SourcesController {
                 return;
             }
             await source.set(req.body).validate();
-            await this.updateSourceAwsProperties(req, source);
+            await this.updateSourceAwsProperties(source);
             const result = await source.save();
             res.json(result);
         } catch (err) {
@@ -90,7 +90,6 @@ export default class SourcesController {
     };
 
     private async updateSourceAwsProperties(
-        req: Request,
         source: SourceDocument,
     ): Promise<void> {
         if (source.isModified('automation.schedule.awsScheduleExpression')) {

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -94,7 +94,7 @@ export default class SourcesController {
     ): Promise<void> {
         if (source.isModified('automation.schedule.awsScheduleExpression')) {
             const awsRuleArn = await this.awsEventsClient.putRule(
-                source._id,
+                source._id.toString(),
                 source.automation.schedule.awsScheduleExpression,
             );
             source.set('automation.schedule.awsRuleArn', awsRuleArn);
@@ -110,7 +110,7 @@ export default class SourcesController {
             await source.validate();
             if (source.automation?.schedule) {
                 const createdRuleArn = await this.awsEventsClient.putRule(
-                    source._id,
+                    source._id.toString(),
                     source.automation.schedule.awsScheduleExpression,
                 );
                 source.set('automation.schedule.awsRuleArn', createdRuleArn);

--- a/verification/curator-service/api/src/model/source.ts
+++ b/verification/curator-service/api/src/model/source.ts
@@ -23,7 +23,7 @@ const sourceSchema = new mongoose.Schema({
     },
 });
 
-type SourceDocument = mongoose.Document & {
+export type SourceDocument = mongoose.Document & {
     name: string;
     origin: OriginDocument;
     format: string;

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -146,6 +146,22 @@ describe('PUT', () => {
         // Check stuff that didn't change.
         expect(res.body.origin.url).toEqual('http://foo.bar');
     });
+    it('should create an AWS rule if provided schedule expression', async () => {
+        const source = await new Source({
+            name: 'test-source',
+            origin: { url: 'http://foo.bar' },
+        }).save();
+        const res = await curatorRequest
+            .put(`/api/sources/${source.id}`)
+            .send({
+                automation: {
+                    schedule: { awsScheduleExpression: 'rate(1 hour)' },
+                },
+            })
+            .expect(200)
+            .expect('Content-Type', /json/);
+        expect(res.body.automation.schedule.awsRuleArn).toBeDefined();
+    });
     it('cannot update an inexistent source', (done) => {
         curatorRequest
             .put('/api/sources/424242424242424242424242')

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -193,6 +193,19 @@ describe('POST', () => {
             .expect(201);
         expect(res.body.name).toEqual(source.name);
     });
+    it('should create an AWS rule if provided schedule expression', async () => {
+        const source = {
+            name: 'some_name',
+            origin: { url: 'http://what.ever' },
+            automation: { schedule: { awsScheduleExpression: 'rate(1 hour)' } },
+        };
+        const res = await curatorRequest
+            .post('/api/sources')
+            .send(source)
+            .expect('Content-Type', /json/)
+            .expect(201);
+        expect(res.body.automation.schedule.awsRuleArn).toBeDefined();
+    });
     it('should not create invalid source', async () => {
         const res = await curatorRequest.post('/api/sources').expect(422);
         expect(res.body).toMatch('Enter a name');


### PR DESCRIPTION
NB: This doesn't include deleting a rule in an update. The client library doesn't include delete yet; I'll add this with/after Source delete integration.

I'm also including a small change to rule naming, using `source._id` in lieu of `source.name`. It' not human readable, but avoids issues with formatting restrictions (e.g. can't include spaces) and uniqueness. Can swing around to re-UX this later if it's important.

![source-updates](https://user-images.githubusercontent.com/63060924/83293457-d2731300-a1b9-11ea-85bd-380b4f4b88e7.gif)
