### PR TITLE
Add deletion to the AWS CWE client API; integrate this with the Sources API

### DIFF
--- a/verification/curator-service/api/src/clients/aws-events-client.ts
+++ b/verification/curator-service/api/src/clients/aws-events-client.ts
@@ -57,4 +57,24 @@ export default class AwsEventsClient {
                 message: 'AWS PutRule response missing RuleArn.',
             });
     }
+
+    /**
+     * Proxies a DeleteRule request to the AWS CloudWatch API.
+     *
+     * For the full API definition, see:
+     *   https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteRule.html
+     */
+    deleteRule = async (ruleName: string): Promise<void> => {
+        try {
+            await this.cloudWatchEventsClient
+                .deleteRule({ Name: ruleName })
+                .promise();
+        } catch (err) {
+            console.warn(
+                `Unable to delete AWS CloudWatch Events rule with:
+                name: ${ruleName}`,
+            );
+            throw err;
+        }
+    };
 }

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -124,11 +124,15 @@ export default class SourcesController {
      * Delete a single source.
      */
     del = async (req: Request, res: Response): Promise<void> => {
-        const source = await Source.findByIdAndDelete(req.params.id);
+        const source = await Source.findById(req.params.id);
         if (!source) {
             res.sendStatus(404);
             return;
         }
+        if (source.automation?.schedule?.awsRuleArn) {
+            await this.awsEventsClient.deleteRule(source._id.toString());
+        }
+        source.remove();
         res.json(source);
         return;
     };

--- a/verification/curator-service/api/test/clients/aws-events-clients.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-clients.test.ts
@@ -57,3 +57,30 @@ describe('putRule', () => {
             .catch((e) => expect(e.message).toContain('missing RuleArn'));
     });
 });
+
+describe('deleteRule', () => {
+    it('deletes the AWS CloudWatch Event rule via the SDK', async () => {
+        const deleteRuleSpy = jest.fn().mockResolvedValueOnce({});
+        AWSMock.mock('CloudWatchEvents', 'deleteRule', deleteRuleSpy);
+        const client = new AwsEventsClient('us-east-1');
+
+        await expect(client.deleteRule('passingRule')).resolves.not.toThrow();
+        expect(deleteRuleSpy).toHaveBeenCalledTimes(1);
+    });
+    it('throws errors from AWS', async () => {
+        const expectedError = new Error('AWS error');
+        AWSMock.mock(
+            'CloudWatchEvents',
+            'deleteRule',
+            (params: any, callback: Function) => {
+                callback(expectedError, null);
+            },
+        );
+        const client = new AwsEventsClient('us-east-1');
+
+        expect.assertions(1);
+        return client
+            .deleteRule('awsErrorRule')
+            .catch((e) => expect(e).toEqual(expectedError));
+    });
+});

--- a/verification/curator-service/api/test/clients/aws-events-clients.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-clients.test.ts
@@ -37,9 +37,9 @@ describe('putRule', () => {
         const client = new AwsEventsClient('us-east-1');
 
         expect.assertions(1);
-        return client
-            .putRule('awsErrorRule', 'rate(1 hour)')
-            .catch((e) => expect(e).toEqual(expectedError));
+        return expect(
+            client.putRule('awsErrorRule', 'rate(1 hour)'),
+        ).rejects.toThrow(expectedError);
     });
     it('throws error if AWS response somehow lacks RuleArn', async () => {
         AWSMock.mock(
@@ -52,9 +52,9 @@ describe('putRule', () => {
         const client = new AwsEventsClient('us-east-1');
 
         expect.assertions(1);
-        return client
-            .putRule('noResponseArnRule', 'rate(1 hour)')
-            .catch((e) => expect(e.message).toContain('missing RuleArn'));
+        return expect(
+            client.putRule('noResponseArnRule', 'rate(1 hour'),
+        ).rejects.toThrow('missing RuleArn');
     });
 });
 
@@ -79,8 +79,8 @@ describe('deleteRule', () => {
         const client = new AwsEventsClient('us-east-1');
 
         expect.assertions(1);
-        return client
-            .deleteRule('awsErrorRule')
-            .catch((e) => expect(e).toEqual(expectedError));
+        return expect(client.deleteRule('awsErrorRule')).rejects.toThrow(
+            expectedError,
+        );
     });
 });


### PR DESCRIPTION
Doesn't include delete-as-update -- that'll be subsequent.

![delete-source](https://user-images.githubusercontent.com/63060924/83429066-7d294280-a401-11ea-852f-eea24d4dfee2.gif)
