### PR TITLE
Converter: Geocode the travelHistory with the same system as the location field

### DIFF
--- a/data-serving/scripts/convert-data/README.md
+++ b/data-serving/scripts/convert-data/README.md
@@ -8,15 +8,15 @@ This directory contains scripts for converting, ingesting, and otherwise munging
 schema-compliant json format.
 
 ```console
-python3 convert_data.py --infile="latestdata.csv" [--outfile="cases.json"]
+python3 convert_data.py --ncov2019_path=/path/to/nCoV2019 [--sample_rate=.1] [--outfile=cases.json]
 ```
 
 Logs will be written to `convert_data.log`.
 
 ### Current stats
 
-- 99.2% of rows from the CSV file convert entirely successfully to JSON. For those with errors, only the failed fields
-  are ommitted.
+- 99.8% of rows from the CSV file convert entirely successfully to JSON. For those with errors, only the failed fields
+  are omitted.
 - 100% of rows from `cases.json` validate and import successfully into mongodb.
 
 ### Lossy fields
@@ -50,11 +50,6 @@ The following fields are *not* lossy, although they require conversion to a new 
 - `events[name='admissionHospital']`, `events[name='confirmed']`, `events[name='deathOrDischarge']`
 
 ### Future improvements
-
-- Add geocoding for `travelHistory.location` -- specifically, adding lat/long where locations are present.
-
-- Improve parsing of the `travelHistory.location` field. We lose ~40% of the data as of today because it's highly
-  unstructured.
 
 - Improve disambiguation of `travelHistory.location`. For example, if the person lives in Florida and has traveled to
   Georgia, it's more likely to be the state than the country.

--- a/data-serving/scripts/convert-data/constants.py
+++ b/data-serving/scripts/convert-data/constants.py
@@ -1,5 +1,20 @@
-''' Valid values for sex field. '''
-VALID_SEXES = ['female', 'male', 'other']
+''' The filename of the CSV file containing the case data. '''
+DATA_CSV_FILENAME = 'latestdata.csv'
+
+''' The path to the latest data gzip in the nCoV2019 repo. '''
+DATA_GZIP_FILENAME = 'latestdata.tar.gz'
+
+''' The path to the latest data gzip in the nCoV2019 repo. '''
+DATA_REPO_PATH = 'latest_data'
+
+''' The filename of the geocoding database. '''
+GEOCODER_DB_FILENAME = 'geo_admin.tsv'
+
+''' The name of the imported geocoder module. '''
+GEOCODER_MODULE = 'csv_geocoder'
+
+''' The path to the geocoding script in the nCoV2019 repo. '''
+GEOCODER_REPO_PATH = 'code/sheet_cleaner/geocoding'
 
 # TODO(khmoran): Include 'outcome' once the curator UI transitions to using the
 # new events-based outcome field.
@@ -9,22 +24,70 @@ LOSSLESS_FIELDS = [
     'latitude', 'lives_in_Wuhan', 'longitude', 'notes_for_discussion',
     'sequence_available', 'sex', 'source', 'symptoms']
 
-LOCATIONS = {
-    'wuhan': {
-        'country': 'China',
-        'administrativeAreaLevel1': 'Hubei',
-        'administrativeAreaLevel2': 'Wuhan City',
-        'locality': 'Wuhan City',
-        'geometry': {
-            'latitude': 30.62506,
-            'longitude': 114.3421
-        }
-    },
-    'iran': {
-        'country': 'Iran',
-        'geometry': {
-            'latitude': 32.427908,
-            'longitude': 53.688046
-        },
-    }
+COMMON_LOCATION_ABBREVIATIONS = {
+    'wuhan': 'wuhan city',
+    'usa': 'united states',
+    'uk': 'united kingdom',
+    'al': 'alabama',
+    'ak': 'alaska',
+    'as': 'american samoa',
+    'az': 'arizona',
+    'ar': 'arkansas',
+    'ca': 'california',
+    'co': 'colorado',
+    'ct': 'connecticut',
+    'de': 'delaware',
+    'dc': 'district of columbia',
+    'fm': 'federated states of micronesia',
+    'fl': 'florida',
+    'ga': 'georgia',
+    'gu': 'guam',
+    'hi': 'hawaii',
+    'id': 'idaho',
+    'il': 'illinois',
+    'in': 'indiana',
+    'ia': 'iowa',
+    'ks': 'kansas',
+    'ky': 'kentucky',
+    'la': 'louisiana',
+    'me': 'maine',
+    'mh': 'marshall islands',
+    'md': 'maryland',
+    'ma': 'massachusetts',
+    'mi': 'michigan',
+    'mn': 'minnesota',
+    'ms': 'mississippi',
+    'mo': 'missouri',
+    'mt': 'montana',
+    'ne': 'nebraska',
+    'nv': 'nevada',
+    'nh': 'new hampshire',
+    'nj': 'new jersey',
+    'nm': 'new mexico',
+    'ny': 'new york',
+    'nc': 'north carolina',
+    'nd': 'north dakota',
+    'mp': 'northern mariana islands',
+    'oh': 'ohio',
+    'ok': 'oklahoma',
+    'or': 'oregon',
+    'pw': 'palau',
+    'pa': 'pennsylvania',
+    'pr': 'puerto rico',
+    'ri': 'rhode island',
+    'sc': 'south carolina',
+    'sd': 'south dakota',
+    'tn': 'tennessee',
+    'tx': 'texas',
+    'ut': 'utah',
+    'vt': 'vermont',
+    'vi': 'virgin islands',
+    'va': 'virginia',
+    'wa': 'washington',
+    'wv': 'west virginia',
+    'wi': 'wisconsin',
+    'wy': 'wyoming',
 }
+
+''' Valid values for sex field. '''
+VALID_SEXES = ['female', 'male', 'other']

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -79,8 +79,7 @@ def extract_csv(repo_path: str) -> str:
     latest_data_gzip.extract(DATA_CSV_FILENAME)
     latest_data_gzip.close()
 
-    return os.path.join(
-        repo_path, DATA_REPO_PATH, DATA_CSV_FILENAME)
+    return DATA_CSV_FILENAME
 
 
 def read_csv(infile: str) -> DataFrame:

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -6,6 +6,7 @@ schema.
 import argparse
 import csv
 import logging
+import imp
 import json
 import pandas as pd
 import sys
@@ -16,7 +17,11 @@ from converters import (
     convert_outbreak_specifics, convert_travel_history)
 from pandas import DataFrame
 from typing import Any
-from constants import LOSSLESS_FIELDS
+from constants import (
+    DATA_CSV_FILENAME, DATA_GZIP_FILENAME, DATA_REPO_PATH, GEOCODER_DB_FILENAME,
+    GEOCODER_MODULE, GEOCODER_REPO_PATH, LOSSLESS_FIELDS)
+import tarfile
+import os
 
 
 def main():
@@ -26,7 +31,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Convert CSV line-list data into json compliant with the '
         'MongoDB schema.')
-    parser.add_argument('--infile', type=argparse.FileType('r'))
+    parser.add_argument('--ncov2019_path', type=str, required=True)
     parser.add_argument('--outfile',
                         nargs='?',
                         type=argparse.FileType('w', encoding='UTF-8'),
@@ -35,8 +40,27 @@ def main():
 
     args = parser.parse_args()
 
-    print('Reading data from', args.infile.name)
-    original_cases = read_csv(args.infile)
+    # Load the geocoder.
+    geocoder_path = os.path.join(args.ncov2019_path, GEOCODER_REPO_PATH)
+    geocodes_path = os.path.join(geocoder_path, GEOCODER_DB_FILENAME)
+    f, path, desc = imp.find_module(GEOCODER_MODULE, [geocoder_path])
+    geocoder_module = imp.load_module(GEOCODER_MODULE, f, path, desc)
+    geocoder = geocoder_module.CSVGeocoder(geocodes_path, lambda x: None)
+
+    # Load the case data.
+    gzip_path = os.path.join(
+        args.ncov2019_path, DATA_REPO_PATH,
+        DATA_GZIP_FILENAME)
+    csv_path = os.path.join(
+        args.ncov2019_path, DATA_REPO_PATH, DATA_CSV_FILENAME)
+
+    print('Unzipping', gzip_path)
+    latest_data_gzip = tarfile.open(gzip_path)
+    latest_data_gzip.extract(DATA_CSV_FILENAME)
+    latest_data_gzip.close()
+
+    print('Reading data from', csv_path)
+    original_cases = read_csv(csv_path)
 
     if args.sample_rate < 1.0:
         original_rows = original_cases.shape[0]
@@ -46,7 +70,7 @@ def main():
             f'{original_rows} to {original_cases.shape[0]} rows')
 
     print('Converting data to new schema')
-    converted_cases = convert(original_cases)
+    converted_cases = convert(original_cases, geocoder)
 
     print('Writing results to', args.outfile.name)
     write_json(converted_cases, args.outfile)
@@ -58,7 +82,7 @@ def read_csv(infile: str) -> DataFrame:
     return pd.read_csv(infile, header=0, low_memory=False, encoding='utf-8')
 
 
-def convert(df_import: DataFrame) -> DataFrame:
+def convert(df_import: DataFrame, geocoder: Any) -> DataFrame:
     # Operate on a separate output dataframe so we don't clobber or mutate the
     # original data.
     df_export = pd.DataFrame(columns={})
@@ -130,7 +154,7 @@ def convert(df_import: DataFrame) -> DataFrame:
 
     # Generate new travel history column.
     df_export['travelHistory'] = df_import.apply(lambda x: convert_travel_history(
-        x['ID'], x['travel_history_dates'], x['travel_history_location']), axis=1)
+        geocoder, x['ID'], x['travel_history_dates'], x['travel_history_location']), axis=1)
 
     # Archive the original fields.
     df_export['importedCase'] = df_import.apply(lambda x: convert_imported_case(

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -444,8 +444,8 @@ def convert_outbreak_specifics(id: str, reported_market_exposure: str,
     return outbreak_specifics or None
 
 
-def convert_travel_history(id: str, dates: str, location: str) -> Dict[
-        str, Any]:
+def convert_travel_history(geocoder: Any, id: str, dates: str,
+                           location: str) -> Dict[str, Any]:
     '''
     Converts the travel history date and location fields to a new travelHistory
     object.
@@ -464,7 +464,7 @@ def convert_travel_history(id: str, dates: str, location: str) -> Dict[
     '''
     location_list = None
     try:
-        location_list = parse_location_list(location)
+        location_list = parse_location_list(geocoder, location)
     except (LookupError, ValueError) as e:
         warn(id, 'travelHistory.location', location, e)
 

--- a/data-serving/scripts/convert-data/geocode_util.py
+++ b/data-serving/scripts/convert-data/geocode_util.py
@@ -77,9 +77,8 @@ def lookup_two_part_location(
         lower_res_location_token: str) -> [Geocode]:
     '''
     Attempts to match the two location tokens against known locations,
-    trying two-token pairs from broadest to most specific resolution. First we
-    check if it's a province and province pair; then city and country; then city
-    and province.
+    trying two-token pairs, including (country, province), (city, country), and
+    (city, province).
 
     Parameters:
         higher_res_location_token: The token representing the more specific part
@@ -111,8 +110,8 @@ def lookup_two_part_location(
 
 def lookup_single_part_location(geocoder: Any, value: str) -> [Geocode]:
     '''
-    Attempts to match the location token against known locations, beginning from
-    lowest resolution and moving to higher resolutions if no match is found.
+    Attempts to match the location token against known locations, ranging from
+    country to specific point locations.
 
     Returns:
       [Geocode] A list of possible geocode matches.
@@ -130,7 +129,7 @@ def lookup_single_part_location(geocoder: Any, value: str) -> [Geocode]:
         # admin3
         lookup(geocoder, lambda location: value ==
                location.admin3.lower() and location.geo_resolution == 'admin3'),
-        # location
+        # point location
         lookup(geocoder, lambda location: value ==
                location.location.lower() and location.geo_resolution == 'point')
     ]
@@ -139,10 +138,9 @@ def lookup_single_part_location(geocoder: Any, value: str) -> [Geocode]:
 
 def lookup(geocoder: Any, predicate: Callable[[str], bool]) -> [Geocode]:
     '''
-    Finds a single geocode match given a predicate. The predicate could, for
-    example, require that the result match a given string and a given
-    resolution. If more than one match is found for the predicate, an error is
-    thrown.
+    Finds a geocode match given a predicate. The predicate could, for example,
+    require that the result match a given string and a given geographical
+    resolution.
 
     Returns:
       [Geocode] A list of possible geocode matches.

--- a/data-serving/scripts/convert-data/geocode_util.py
+++ b/data-serving/scripts/convert-data/geocode_util.py
@@ -1,0 +1,200 @@
+from typing import Any, Callable
+from constants import COMMON_LOCATION_ABBREVIATIONS
+
+
+def lookup_location(geocoder: Any, location_tokens: [str]) -> Any:
+    '''
+    Attempts to match the provided location tokens against known locations using
+    the provided geocoder.
+
+    Parameters:
+        location_tokens: One or more tokens representing a location, which 
+          may represent a part or whole of a location of any resolution.
+          Examples: ['NY'], ['Paris, France'], ['Wuhan City, Hubei, China'],
+          ['China']
+
+    Raises:
+        ValueError: When the location consists of more than 3 tokens.
+    Returns:
+      None: When no location tokens are passed in or no geocoding match is
+        found.
+      [Dict[str, Any]]: Location data of the form:
+        {
+          lat: float
+          lng: float
+          geo_resolution: str
+          country_new: str
+          admin_id: int
+          location: str
+          admin3: str
+          admin2: str
+          admin1: str
+        }
+    '''
+    normalized_tokens = [COMMON_LOCATION_ABBREVIATIONS[l.lower()]
+                         if l.lower() in COMMON_LOCATION_ABBREVIATIONS else l
+                         for l in location_tokens]
+
+    if normalized_tokens == []:
+        return None
+    if len(normalized_tokens) == 1:
+        # A location of a single token, which may be a country, city, county,
+        # etc. Ex. "Paris", "China", "FL"
+        return lookup_single_part_location(geocoder, normalized_tokens[0])
+    if len(normalized_tokens) == 2:
+        # A two-part location, which may be (county, country), (city, county),
+        # or (city, country) pairs. Ex. "Paris, France", "Hubei, China",
+        # "Boston, MA"
+        return lookup_two_part_location(
+            geocoder, normalized_tokens[0],
+            normalized_tokens[1])
+    if len(normalized_tokens) == 3:
+        # A three-part location, presumed to including city, county, and
+        # country.
+        return geocoder.geocode(
+            normalized_tokens[0],  # city
+            normalized_tokens[1],  # county
+            normalized_tokens[2])  # country
+
+    raise ValueError('Too many tokens in location')
+
+
+def lookup_two_part_location(
+        geocoder: Any, higher_res_location_token: str,
+        lower_res_location_token: str) -> Any:
+    '''
+    Attempts to match the two location tokens against known locations,
+    trying two-token pairs from broadest to most specific resolution. First we
+    check if it's a province and county pair; then city and country; then city
+    and province.
+
+    Parameters:
+        higher_res_location_token: The token representing the more specific part
+          of the location, e.g. city vs. country.
+        lower_res_location_token: The token representing the broader part of the
+          location, e.g. county vs. city.
+
+    Returns:
+      None: When no geocoding match is found.
+      [Dict[str, Any]]: Location data of the form:
+        {
+          lat: float
+          lng: float
+          geo_resolution: str
+          country_new: str
+          admin_id: int
+          location: str
+          admin3: str
+          admin2: str
+          admin1: str
+        }
+    '''
+    province_and_country = lookup(
+        geocoder, lambda location: location.admin1.lower() ==
+        higher_res_location_token and location.country_new.lower() ==
+        lower_res_location_token and location.geo_resolution == 'admin1')
+
+    if province_and_country:
+        return province_and_country
+
+    city_and_country = lookup(
+        geocoder, lambda location: location.admin2.lower() ==
+        higher_res_location_token and location.country_new.lower() ==
+        lower_res_location_token and location.geo_resolution == 'admin2')
+
+    if city_and_country:
+        return city_and_country
+
+    city_and_province = lookup(
+        geocoder, lambda location: location.admin2.lower() ==
+        higher_res_location_token and location.admin1.lower() ==
+        lower_res_location_token and location.geo_resolution == 'admin2')
+
+    if city_and_province:
+        return city_and_province
+
+    return None
+
+
+def lookup_single_part_location(geocoder: Any, value: str) -> Any:
+    '''
+    Attempts to match the location token against known locations, beginning from
+    lowest resolution and moving to higher resolutions if no match is found. No
+    Paris, TX matches for "Paris" over here.
+
+    Returns:
+      None: When no geocoding match is found.
+      [Dict[str, Any]]: Location data of the form:
+        {
+          lat: float
+          lng: float
+          geo_resolution: str
+          country_new: str
+          admin_id: int
+          location: str
+          admin3: str
+          admin2: str
+          admin1: str
+        }
+    '''
+    country = lookup(geocoder, lambda location: location.country_new.lower()
+                     == value and location.geo_resolution == 'admin0')
+    if country:
+        return country
+
+    province = lookup(geocoder, lambda location: location.admin1.lower()
+                      == value and location.geo_resolution == 'admin1')
+    if province:
+        return province
+
+    city = lookup(geocoder, lambda location: value ==
+                  location.admin2.lower() and location.geo_resolution == 'admin2')
+    if city:
+        return city
+
+    admin3 = lookup(geocoder, lambda location: value ==
+                    location.admin3.lower() and location.geo_resolution == 'admin3')
+    if admin3:
+        return admin3
+
+    location = lookup(geocoder, lambda location: value == location.location.lower(
+    ) and location.geo_resolution == 'point')
+    if location:
+        return location
+
+    return None
+
+
+def lookup(geocoder: Any, predicate: Callable[[str], bool]) -> Any:
+    '''
+    Finds a single geocode match given a predicate. The predicate could, for
+    example, require that the result match a given string and a given
+    resolution. If more than one match is found for the predicate, an error is
+    thrown.
+
+    Raises:
+      ValueError: When more than one match is found for the predicate, since we
+        are unable to determine which is correct.
+    Returns:
+      None: When no geocoding match is found.
+      [Dict[str, Any]]: Location data of the form:
+        {
+          lat: float
+          lng: float
+          geo_resolution: str
+          country_new: str
+          admin_id: int
+          location: str
+          admin3: str
+          admin2: str
+          admin1: str
+        }
+    '''
+    matches = [
+        geocode for id, geocode in geocoder.geocodes.items()
+        if predicate(geocode)]
+
+    if len(matches) > 1:
+        raise ValueError(f'Too many possible geocode matches: {matches}')
+
+    return matches[0] if len(matches) == 1 else None

--- a/data-serving/scripts/convert-data/geocode_util.py
+++ b/data-serving/scripts/convert-data/geocode_util.py
@@ -31,32 +31,31 @@ def lookup_location(geocoder: Any, location_tokens: [str]) -> Any:
           admin1: str
         }
     '''
-    normalized_tokens = [COMMON_LOCATION_ABBREVIATIONS[l.lower()]
-                         if l.lower() in COMMON_LOCATION_ABBREVIATIONS else l
+    normalized_tokens = [COMMON_LOCATION_ABBREVIATIONS.get(l.lower(), l)
                          for l in location_tokens]
 
-    if normalized_tokens == []:
-        return None
+    if not normalized_tokens:
+        raise ValueError('No location tokens')
+    if len(normalized_tokens) > 3:
+        raise ValueError('Too many tokens in location')
+
     if len(normalized_tokens) == 1:
         # A location of a single token, which may be a country, city, county,
         # etc. Ex. "Paris", "China", "FL"
         return lookup_single_part_location(geocoder, normalized_tokens[0])
-    if len(normalized_tokens) == 2:
+    elif len(normalized_tokens) == 2:
         # A two-part location, which may be (county, country), (city, county),
         # or (city, country) pairs. Ex. "Paris, France", "Hubei, China",
         # "Boston, MA"
         return lookup_two_part_location(
             geocoder, normalized_tokens[0],
             normalized_tokens[1])
-    if len(normalized_tokens) == 3:
-        # A three-part location, presumed to including city, county, and
-        # country.
+    else:
+        # A three-part location, presumed to include city, county, and country.
         return geocoder.geocode(
             normalized_tokens[0],  # city
             normalized_tokens[1],  # county
             normalized_tokens[2])  # country
-
-    raise ValueError('Too many tokens in location')
 
 
 def lookup_two_part_location(

--- a/data-serving/scripts/convert-data/geocode_util.py
+++ b/data-serving/scripts/convert-data/geocode_util.py
@@ -40,21 +40,22 @@ def lookup_location(geocoder: Any, location_tokens: [str]) -> Any:
         raise ValueError('Too many tokens in location')
 
     if len(normalized_tokens) == 1:
-        # A location of a single token, which may be a country, city, county,
+        # A location of a single token, which may be a country, city, province,
         # etc. Ex. "Paris", "China", "FL"
         return lookup_single_part_location(geocoder, normalized_tokens[0])
     elif len(normalized_tokens) == 2:
-        # A two-part location, which may be (county, country), (city, county),
-        # or (city, country) pairs. Ex. "Paris, France", "Hubei, China",
-        # "Boston, MA"
+        # A two-part location, which may be (province, country), (city,
+        # province), or (city, country) pairs. Ex. "Paris, France", "Hubei,
+        # China", "Boston, MA"
         return lookup_two_part_location(
             geocoder, normalized_tokens[0],
             normalized_tokens[1])
     else:
-        # A three-part location, presumed to include city, county, and country.
+        # A three-part location, presumed to include city, province, and
+        # country.
         return geocoder.geocode(
             normalized_tokens[0],  # city
-            normalized_tokens[1],  # county
+            normalized_tokens[1],  # province
             normalized_tokens[2])  # country
 
 
@@ -64,14 +65,14 @@ def lookup_two_part_location(
     '''
     Attempts to match the two location tokens against known locations,
     trying two-token pairs from broadest to most specific resolution. First we
-    check if it's a province and county pair; then city and country; then city
+    check if it's a province and province pair; then city and country; then city
     and province.
 
     Parameters:
         higher_res_location_token: The token representing the more specific part
           of the location, e.g. city vs. country.
         lower_res_location_token: The token representing the broader part of the
-          location, e.g. county vs. city.
+          location, e.g. province vs. city.
 
     Returns:
       None: When no geocoding match is found.
@@ -118,8 +119,7 @@ def lookup_two_part_location(
 def lookup_single_part_location(geocoder: Any, value: str) -> Any:
     '''
     Attempts to match the location token against known locations, beginning from
-    lowest resolution and moving to higher resolutions if no match is found. No
-    Paris, TX matches for "Paris" over here.
+    lowest resolution and moving to higher resolutions if no match is found.
 
     Returns:
       None: When no geocoding match is found.
@@ -196,4 +196,4 @@ def lookup(geocoder: Any, predicate: Callable[[str], bool]) -> Any:
     if len(matches) > 1:
         raise ValueError(f'Too many possible geocode matches: {matches}')
 
-    return matches[0] if len(matches) == 1 else None
+    return next(iter(matches), None)

--- a/data-serving/scripts/convert-data/geocode_util.py
+++ b/data-serving/scripts/convert-data/geocode_util.py
@@ -1,24 +1,8 @@
-from typing import Any, Callable
+from typing import Any, Callable, Dict, Optional, NewType, Union
 from constants import COMMON_LOCATION_ABBREVIATIONS
 
-
-def lookup_location(geocoder: Any, location_tokens: [str]) -> Any:
-    '''
-    Attempts to match the provided location tokens against known locations using
-    the provided geocoder.
-
-    Parameters:
-        location_tokens: One or more tokens representing a location, which 
-          may represent a part or whole of a location of any resolution.
-          Examples: ['NY'], ['Paris, France'], ['Wuhan City, Hubei, China'],
-          ['China']
-
-    Raises:
-        ValueError: When the location consists of more than 3 tokens.
-    Returns:
-      None: When no location tokens are passed in or no geocoding match is
-        found.
-      [Dict[str, Any]]: Location data of the form:
+'''
+Location data of the form:
         {
           lat: float
           lng: float
@@ -30,6 +14,26 @@ def lookup_location(geocoder: Any, location_tokens: [str]) -> Any:
           admin2: str
           admin1: str
         }
+'''
+Geocode = NewType('Geocode', Dict[str, Union[str, int, float]])
+
+
+def lookup_location(geocoder: Any, location_tokens: [str]) -> Geocode:
+    '''
+    Attempts to match the provided location tokens against known locations using
+    the provided geocoder.
+
+    Parameters:
+        location_tokens: One or more tokens representing a location, which 
+          may represent a part or whole of a location of any resolution.
+          Examples: ['NY'], ['Paris, France'], ['Wuhan City, Hubei, China'],
+          ['China']
+
+    Raises:
+        ValueError: When the provided location string could not be mapped to a
+          single, valid geocoding result.
+    Returns:
+      Geocode
     '''
     normalized_tokens = [COMMON_LOCATION_ABBREVIATIONS.get(l.lower(), l)
                          for l in location_tokens]
@@ -39,29 +43,38 @@ def lookup_location(geocoder: Any, location_tokens: [str]) -> Any:
     if len(normalized_tokens) > 3:
         raise ValueError('Too many tokens in location')
 
+    matches = []
     if len(normalized_tokens) == 1:
         # A location of a single token, which may be a country, city, province,
         # etc. Ex. "Paris", "China", "FL"
-        return lookup_single_part_location(geocoder, normalized_tokens[0])
+        matches = lookup_single_part_location(geocoder, normalized_tokens[0])
     elif len(normalized_tokens) == 2:
         # A two-part location, which may be (province, country), (city,
         # province), or (city, country) pairs. Ex. "Paris, France", "Hubei,
         # China", "Boston, MA"
-        return lookup_two_part_location(
+        matches = lookup_two_part_location(
             geocoder, normalized_tokens[0],
             normalized_tokens[1])
     else:
         # A three-part location, presumed to include city, province, and
         # country.
-        return geocoder.geocode(
+        matches = geocoder.geocode(
             normalized_tokens[0],  # city
             normalized_tokens[1],  # province
             normalized_tokens[2])  # country
 
+    if not matches:
+        raise ValueError('no geocode found for location string')
+    elif len(matches) > 1:
+        raise ValueError(
+            f'ambiguous location string; matches multiple geocodes: {matches}')
+    else:
+        return matches[0]
+
 
 def lookup_two_part_location(
         geocoder: Any, higher_res_location_token: str,
-        lower_res_location_token: str) -> Any:
+        lower_res_location_token: str) -> [Geocode]:
     '''
     Attempts to match the two location tokens against known locations,
     trying two-token pairs from broadest to most specific resolution. First we
@@ -75,125 +88,65 @@ def lookup_two_part_location(
           location, e.g. province vs. city.
 
     Returns:
-      None: When no geocoding match is found.
-      [Dict[str, Any]]: Location data of the form:
-        {
-          lat: float
-          lng: float
-          geo_resolution: str
-          country_new: str
-          admin_id: int
-          location: str
-          admin3: str
-          admin2: str
-          admin1: str
-        }
+      [Geocode] A list of possible geocode matches.
     '''
-    province_and_country = lookup(
-        geocoder, lambda location: location.admin1.lower() ==
-        higher_res_location_token and location.country_new.lower() ==
-        lower_res_location_token and location.geo_resolution == 'admin1')
-
-    if province_and_country:
-        return province_and_country
-
-    city_and_country = lookup(
-        geocoder, lambda location: location.admin2.lower() ==
-        higher_res_location_token and location.country_new.lower() ==
-        lower_res_location_token and location.geo_resolution == 'admin2')
-
-    if city_and_country:
-        return city_and_country
-
-    city_and_province = lookup(
-        geocoder, lambda location: location.admin2.lower() ==
-        higher_res_location_token and location.admin1.lower() ==
-        lower_res_location_token and location.geo_resolution == 'admin2')
-
-    if city_and_province:
-        return city_and_province
-
-    return None
+    matches = [
+        # (province, country)
+        lookup(
+            geocoder, lambda location: location.admin1.lower() ==
+            higher_res_location_token and location.country_new.lower() ==
+            lower_res_location_token and location.geo_resolution == 'admin1'),
+        # (city, country)
+        lookup(
+            geocoder, lambda location: location.admin2.lower() ==
+            higher_res_location_token and location.country_new.lower() ==
+            lower_res_location_token and location.geo_resolution == 'admin2'),
+        # (city, province)
+        lookup(
+            geocoder, lambda location: location.admin2.lower() ==
+            higher_res_location_token and location.admin1.lower() ==
+            lower_res_location_token and location.geo_resolution == 'admin2')]
+    return [item for sublist in matches for item in sublist]
 
 
-def lookup_single_part_location(geocoder: Any, value: str) -> Any:
+def lookup_single_part_location(geocoder: Any, value: str) -> [Geocode]:
     '''
     Attempts to match the location token against known locations, beginning from
     lowest resolution and moving to higher resolutions if no match is found.
 
     Returns:
-      None: When no geocoding match is found.
-      [Dict[str, Any]]: Location data of the form:
-        {
-          lat: float
-          lng: float
-          geo_resolution: str
-          country_new: str
-          admin_id: int
-          location: str
-          admin3: str
-          admin2: str
-          admin1: str
-        }
+      [Geocode] A list of possible geocode matches.
     '''
-    country = lookup(geocoder, lambda location: location.country_new.lower()
-                     == value and location.geo_resolution == 'admin0')
-    if country:
-        return country
-
-    province = lookup(geocoder, lambda location: location.admin1.lower()
-                      == value and location.geo_resolution == 'admin1')
-    if province:
-        return province
-
-    city = lookup(geocoder, lambda location: value ==
-                  location.admin2.lower() and location.geo_resolution == 'admin2')
-    if city:
-        return city
-
-    admin3 = lookup(geocoder, lambda location: value ==
-                    location.admin3.lower() and location.geo_resolution == 'admin3')
-    if admin3:
-        return admin3
-
-    location = lookup(geocoder, lambda location: value == location.location.lower(
-    ) and location.geo_resolution == 'point')
-    if location:
-        return location
-
-    return None
+    matches = [
+        # country
+        lookup(geocoder, lambda location: location.country_new.lower()
+               == value and location.geo_resolution == 'admin0'),
+        # province
+        lookup(geocoder, lambda location: location.admin1.lower()
+               == value and location.geo_resolution == 'admin1'),
+        # city
+        lookup(geocoder, lambda location: value ==
+               location.admin2.lower() and location.geo_resolution == 'admin2'),
+        # admin3
+        lookup(geocoder, lambda location: value ==
+               location.admin3.lower() and location.geo_resolution == 'admin3'),
+        # location
+        lookup(geocoder, lambda location: value ==
+               location.location.lower() and location.geo_resolution == 'point')
+    ]
+    return [item for sublist in matches for item in sublist]
 
 
-def lookup(geocoder: Any, predicate: Callable[[str], bool]) -> Any:
+def lookup(geocoder: Any, predicate: Callable[[str], bool]) -> [Geocode]:
     '''
     Finds a single geocode match given a predicate. The predicate could, for
     example, require that the result match a given string and a given
     resolution. If more than one match is found for the predicate, an error is
     thrown.
 
-    Raises:
-      ValueError: When more than one match is found for the predicate, since we
-        are unable to determine which is correct.
     Returns:
-      None: When no geocoding match is found.
-      [Dict[str, Any]]: Location data of the form:
-        {
-          lat: float
-          lng: float
-          geo_resolution: str
-          country_new: str
-          admin_id: int
-          location: str
-          admin3: str
-          admin2: str
-          admin1: str
-        }
+      [Geocode] A list of possible geocode matches.
     '''
-    matches = [
+    return [
         geocode for id, geocode in geocoder.geocodes.items()
         if predicate(geocode)]
-
-    if len(matches) > 1:
-        raise ValueError(f'Too many possible geocode matches: {matches}')
-
-    return next(iter(matches), None)

--- a/data-serving/scripts/convert-data/parsers.py
+++ b/data-serving/scripts/convert-data/parsers.py
@@ -203,9 +203,6 @@ def parse_location(geocoder: Any, value: Any) -> Dict[str, Any]:
     # try to find a match with the geocoder.
     geocode_result = lookup_location(geocoder, parse_list(value.lower(), ','))
 
-    if geocode_result is None:
-        raise ValueError('no geocode found for location')
-
     result = {
         'country': geocode_result.country_new,
         'geometry': {

--- a/data-serving/scripts/convert-data/parsers.py
+++ b/data-serving/scripts/convert-data/parsers.py
@@ -196,8 +196,6 @@ def parse_location(geocoder: Any, value: Any) -> Dict[str, Any]:
           }
         }
     '''
-    if pd.isna(value) or value.lower() in ['no', 'none', 'unknown']:
-        raise ValueError('boolean value is not a valid location')
     if type(value) is not str:
         raise ValueError('location is not a string')
 


### PR DESCRIPTION
Sorry for the big diff :\ This PR is doing a few things:

- Reusing the same geocoding data for the travelHistory.location as is used in the original CSV for geocoding the location field. This gets us (1) better coverage than pycountries (countries & counties only), (2) more consistency, and (3) full geospatial data (lat/longs).

- Changing the script to take in a path to the location of a locally-checked out nCoV19 repo, for (1) access to the CSV, and (2) for access to the geocoding script & data.

- Adding some very common abbreviations used in the travelHistory.location source, since fixing every one of these would be a lot of work.

- Remove hacks and workarounds, like removing 'Travelled to' prefixes. We're logging these as errors so we can fix them at the source.

Note that the existing geocoding script from the other doesn't do exactly what we need here, hence `geocode_util.py`.

This reduces errors quite a bit, down to 2,441 total errors, the vast majority of which seems like problems we need to solve in the CSV, rather than fixable geocoding misses.

Some example outputs:
```
    "travelHistory": [
      {
        "dateRange": {
          "start": {
            "$date": "2020-03-09T00:00:00Z"
          },
          "end": {
            "$date": "2020-03-09T00:00:00Z"
          }
        },
        "location": {
          "country": "Spain",
          "geometry": {
            "latitude": 40.3396,
            "longitude": -3.6226599999999998
          }
        }
      }
    ],
```

```
    "travelHistory": [
      {
        "location": {
          "country": "United Arab Emirates",
          "geometry": {
            "latitude": 25.204849,
            "longitude": 55.270782
          },
          "administrativeAreaLevel1": "Dubai",
          "administrativeAreaLevel2": "Dubai"
        }
      }
    ],
```