### PR TITLE
Add logic that dictates whether AWS CW rules are put or deleted during source updates

### DIFF
--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -94,8 +94,9 @@ export default class SourcesController {
      * based on the content of the update operation.
      *
      * Note that, because Mongoose document validation is currently used for all
-     * of our APIs, the condition in which a field is updated to be empty is
-     * unreachable.
+     * of our APIs, and we're performing partial updates (as opposed to
+     * overwrites) by default, the condition in which a validated field is
+     * updated to be empty is unreachable.
      *
      * TODO: Allow deleting schema-validated fields in update operations.
      */


### PR DESCRIPTION
I'd intended this to be a more interesting change, but ran into a bug with our various APIs' update operations (re: Slack). We cannot yet remove a field on an update, and so the `else` branch I'm adding here is effectively unreachable.

For now, add some simple logic that -- in the event of nefarious alpha particle induced bit flips, or the event that we inadvertently goof up Mongoose validation -- correctly performs either a `put`- or `deleteRule` request to the AWS CW Events API based on a given Source API update.