### PR TITLE
Expose curator services externally

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -161,6 +161,15 @@ To push a new release of the data service, follow the same procedure but change 
 
 You can list the existing tags/versions with `git tag` or on the [github repo](https://github.com/open-covid-data/healthmap-gdo-temp/releases).
 
+### `Latest` image tag for dev
+
+Dev instances of curator and data services are using the `latest` image tag, that's not best practice but is okay while we work on other features. The latest image is fetched when a deployment is updated, to update dev to the `latest` image built by docker-hub, do:
+
+```shell
+kubectl rollout restart deployment/curator-dev
+kubectl rollout restart deployment/curator-prod
+```
+
 ### Rollback
 
 Just change the image tag referenced in the deployment file to an earlier version and apply the change.

--- a/aws/README.md
+++ b/aws/README.md
@@ -168,3 +168,83 @@ Just change the image tag referenced in the deployment file to an earlier versio
 ### Deleting a release
 
 If for some reason you need to delete a tag, you can do it with `git tag -d curator-1.2.3` then `git push origin :refs/tags/curator-0.1.2` to delete it remotely.
+
+## Ingress / Application load balancer
+
+Curator services are exposed here:
+
+- [dev](http://51cfaa79-default-curatorde-771d-764651811.us-east-1.elb.amazonaws.com/)
+- [prod](http://51cfaa79-default-curatorpr-5c7d-1665373250.us-east-1.elb.amazonaws.com)
+
+TODO: Apply `external-dns` to configs once we know where we'll run those.
+
+TODO: Map port 443 in ingress configs for HTTPS support.
+
+This section unfortunately involves quite a few sequential command-line executions for properly setting-up IAM.
+
+The setup was done following a mix of articles:
+
+- https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+- https://aws.amazon.com/premiumsupport/knowledge-center/eks-alb-ingress-controller-fargate/
+- https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/
+- https://aws.amazon.com/blogs/containers/using-alb-ingress-controller-with-amazon-eks-on-fargate/
+
+
+```shell
+$ eksctl utils associate-iam-oidc-provider \
+    --region us-east-1 \
+    --cluster healthmapidha \
+    --approve
+[ℹ]  eksctl version 0.19.0
+[ℹ]  using region us-east-1
+[ℹ]  will create IAM Open ID Connect provider for cluster "healthmapidha" in "us-east-1"
+[✔]  created IAM Open ID Connect provider for cluster "healthmapidha" in "us-east-1"
+```
+
+```shell
+$ kubectl apply -f rbac-role.yaml
+clusterrole.rbac.authorization.k8s.io/alb-ingress-controller created
+clusterrolebinding.rbac.authorization.k8s.io/alb-ingress-controller created
+serviceaccount/alb-ingress-controller created
+```
+
+```shell
+curl -o alb-ingress-iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/docs/examples/iam-policy.json
+aws iam create-policy --policy-name ALBIngressControllerIAMPolicy --policy-document file://alb-ingress-iam-policy.json
+```
+
+Output looks like:
+```json
+{
+    "Policy": {
+        "PolicyName": "ALBIngressControllerIAMPolicy",
+        "PolicyId": "ANPAY5MYD7EJNLANRK5BI",
+        "Arn": "arn:aws:iam::612888738066:policy/ALBIngressControllerIAMPolicy",
+        "Path": "/",
+        "DefaultVersionId": "v1",
+        "AttachmentCount": 0,
+        "PermissionsBoundaryUsageCount": 0,
+        "IsAttachable": true,
+        "CreateDate": "2020-06-02T08:36:54+00:00",
+        "UpdateDate": "2020-06-02T08:36:54+00:00"
+    }
+}
+```
+
+The ALB needs to run with its own service account, to create one do:
+
+```shell
+CLUSTER_NAME=healthmapidha
+STACK_NAME=eksctl-$CLUSTER_NAME-cluster
+VPC_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" | jq -r '[.Stacks[0].Outputs[] | {key: .OutputKey, value: .OutputValue}] | from_entries' | jq -r '.VPC')
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
+eksctl create iamserviceaccount \
+--name alb-ingress-controller \
+--namespace kube-system \
+--cluster $CLUSTER_NAME \
+--attach-policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/ALBIngressControllerIAMPolicy \
+--approve \
+--override-existing-serviceaccounts
+```
+
+We created our cluster with eksctl so the subnets are automatically tagged correctly for auto-discovery by the ALB controller.

--- a/aws/README.md
+++ b/aws/README.md
@@ -45,11 +45,16 @@ data-prod-bd57576d8-p8wp4      1/1     Running   0          14m
 
 kubectl get services
 NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
-curator-dev    ClusterIP   10.100.116.43    <none>        80/TCP    19h
-curator-prod   ClusterIP   10.100.66.95     <none>        80/TCP    19h
-data-dev       ClusterIP   10.100.108.137   <none>        80/TCP    19h
-data-prod      ClusterIP   10.100.71.150    <none>        80/TCP    19h
-kubernetes     ClusterIP   10.100.0.1       <none>        443/TCP   20h
+curator-dev    NodePort    10.100.116.43    <none>        80:32119/TCP   4d21h
+curator-prod   NodePort    10.100.66.95     <none>        80:32085/TCP   4d21h
+data-dev       ClusterIP   10.100.108.137   <none>        80/TCP         4d22h
+data-prod      ClusterIP   10.100.71.150    <none>        80/TCP         4d22h
+kubernetes     ClusterIP   10.100.0.1       <none>        443/TCP        4d22h
+
+kubectl get ingress
+NAME           HOSTS   ADDRESS                                                                  PORTS   AGE
+curator-dev    *       51cfaa79-default-curatorde-771d-764651811.us-east-1.elb.amazonaws.com    80      3h18m
+curator-prod   *       51cfaa79-default-curatorpr-5c7d-1665373250.us-east-1.elb.amazonaws.com   80      121m
 ```
 
 
@@ -167,7 +172,7 @@ Dev instances of curator and data services are using the `latest` image tag, tha
 
 ```shell
 kubectl rollout restart deployment/curator-dev
-kubectl rollout restart deployment/curator-prod
+kubectl rollout restart deployment/data-dev
 ```
 
 ### Rollback
@@ -198,6 +203,8 @@ The setup was done following a mix of articles:
 - https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/
 - https://aws.amazon.com/blogs/containers/using-alb-ingress-controller-with-amazon-eks-on-fargate/
 
+
+A one-time set-up is required the first time you create an ALB on the cluster:
 
 ```shell
 $ eksctl utils associate-iam-oidc-provider \
@@ -257,3 +264,9 @@ eksctl create iamserviceaccount \
 ```
 
 We created our cluster with eksctl so the subnets are automatically tagged correctly for auto-discovery by the ALB controller.
+
+You can now run the controller and setup the ingresses:
+
+```
+kubectl apply -f alb-ingress.controller.yaml -f curator-ingress.yaml
+```

--- a/aws/alb-ingress-controller.yaml
+++ b/aws/alb-ingress-controller.yaml
@@ -1,0 +1,28 @@
+# Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
+# This manifest details sensible defaults for deploying an ALB Ingress Controller.
+# GitHub: https://github.com/kubernetes-sigs/aws-alb-ingress-controller
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alb-ingress-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alb-ingress-controller
+    spec:
+      containers:
+        - name: alb-ingress-controller
+          args:
+            - --ingress-class=alb
+            - --cluster-name=healthmapidha
+            - --aws-vpc-id=vpc-033fc05f98d0e7b1e
+            - --aws-region=us-east-1
+          image: docker.io/amazon/aws-alb-ingress-controller:v1.1.6
+      serviceAccountName: alb-ingress-controller

--- a/aws/alb-ingress-controller.yaml
+++ b/aws/alb-ingress-controller.yaml
@@ -22,6 +22,7 @@ spec:
           args:
             - --ingress-class=alb
             - --cluster-name=healthmapidha
+            # Value from: eksctl get cluster healthmapidha
             - --aws-vpc-id=vpc-033fc05f98d0e7b1e
             - --aws-region=us-east-1
           image: docker.io/amazon/aws-alb-ingress-controller:v1.1.6

--- a/aws/alb-ingress-iam-policy.json
+++ b/aws/alb-ingress-iam-policy.json
@@ -1,0 +1,140 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "acm:DescribeCertificate",
+        "acm:ListCertificates",
+        "acm:GetCertificate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:SetWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole",
+        "iam:GetServerCertificate",
+        "iam:ListServerCertificates"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:GetWebACL",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetResources",
+        "tag:TagResources"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "waf:GetWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "wafv2:GetWebACL",
+        "wafv2:GetWebACLForResource",
+        "wafv2:AssociateWebACL",
+        "wafv2:DisassociateWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "shield:DescribeProtection",
+        "shield:GetSubscriptionState",
+        "shield:DeleteProtection",
+        "shield:CreateProtection",
+        "shield:DescribeSubscription",
+        "shield:ListProtections"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/aws/curator-ingress.yaml
+++ b/aws/curator-ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: curator-dev
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+  labels:
+    app: curator
+    environment: dev
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: curator-dev
+              servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: curator-prod
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+  labels:
+    app: curator
+    environment: prod
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: curator-prod
+              servicePort: 80

--- a/aws/curator-ingress.yaml
+++ b/aws/curator-ingress.yaml
@@ -1,3 +1,6 @@
+# Ingress defines how load balancers should forward traffic
+# from the internet traffic to the cluster.
+# https://kubernetes.io/docs/concepts/services-networking/ingress/
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: curator
-          image: docker.io/healthmapidha/curatorservice:0.0.3
+          image: docker.io/healthmapidha/curatorservice:latest
           ports:
             - containerPort: 3001
           env:

--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -133,6 +133,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: curator-dev
+  annotations:
+    alb.ingress.kubernetes.io/target-type: ip
 spec:
   selector:
     app: curator
@@ -141,16 +143,20 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 3001
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: curator-prod
+  annotations:
+    alb.ingress.kubernetes.io/target-type: ip
 spec:
   selector:
     app: curator
-    environment: dev
+    environment: prod
   ports:
     - protocol: TCP
       port: 80
       targetPort: 3001
+  type: NodePort

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: data
-          image: docker.io/healthmapidha/dataservice:0.0.3
+          image: docker.io/healthmapidha/dataservice:latest
           ports:
             - containerPort: 3000
           env:

--- a/aws/rbac-role.yaml
+++ b/aws/rbac-role.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - ingresses
+      - ingresses/status
+      - services
+      - pods/status
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - nodes
+      - pods
+      - secrets
+      - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: alb-ingress-controller
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+  namespace: kube-system


### PR DESCRIPTION
Currently login doesn't work as we have to change the oauth callback URLs and I don't have the perms to do that, I asked Spencer for perms and or changes to be made.

Also switches back to `latest` tag for dev images.

dev: http://51cfaa79-default-curatorde-771d-764651811.us-east-1.elb.amazonaws.com/

prod: http://51cfaa79-default-curatorpr-5c7d-1665373250.us-east-1.elb.amazonaws.com/ (old version from last week)