### PR TITLE
Update the setup-db script to take in an optional connection string

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -179,9 +179,6 @@
         "items": {
           "bsonType": "object",
           "additionalProperties": false,
-          "required": [
-            "location"
-          ],
           "properties": {
             "_id": {
               "bsonType": "objectId"

--- a/data-serving/scripts/setup-db/README.md
+++ b/data-serving/scripts/setup-db/README.md
@@ -1,0 +1,26 @@
+# Database setup
+
+This directory contains a script to set up a fresh MongoDB collection.
+
+## What does it do?
+
+1. Gets or creates the database;
+2. Drops the collection, if it already exists;
+3. (Re-)creates the collection with the schema applied;
+4. TODO: Creates indexes.
+
+## Run it!
+
+To run it with the defaults -- i.e. against localhost, no authentication, using
+the default database (`covid19`) and collection (`cases`), run:
+
+`npm run setup_cases`
+
+To run it with configurable options, e.g. a different connection string, run:
+
+`CONN="some_conn_string" DB="some_db" COLL="some_collection" SCHEMA="../some/schema/path.json" npm run setup`
+
+For example, the below invocation of `setup` would give you the same result as
+`setup_cases`:
+
+`CONN="mongodb://127.0.0.1:27017" DB="covid19" COLL="cases" SCHEMA="./../../data-service/schemas/cases.schema.json" npm run setup`

--- a/data-serving/scripts/setup-db/package.json
+++ b/data-serving/scripts/setup-db/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit && eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
-    "setup": "npm install && tsc && mongo --eval \"let args={databaseName: '$DB', collectionName: '$COLL', schemaPath: '$SCHEMA'}\" dist/index.js",
+    "setup": "npm install && tsc && mongo --eval \"let args={connectionString: '$CONN', databaseName: '$DB', collectionName: '$COLL', schemaPath: '$SCHEMA'}\" dist/index.js",
     "setup-cases": "npm install && tsc && mongo --eval \"let args={databaseName: 'covid19', collectionName: 'cases', schemaPath: './../../data-service/schemas/cases.schema.json'}\" dist/index.js"
   },
   "repository": {

--- a/data-serving/scripts/setup-db/src/index.ts
+++ b/data-serving/scripts/setup-db/src/index.ts
@@ -1,12 +1,14 @@
 declare let args: SetupDatabaseParameters;
 
 interface SetupDatabaseParameters {
+    connectionString: string;
     databaseName: string;
     collectionName: string;
     schemaPath: string;
 }
 
 const setupDatabase = async ({
+    connectionString,
     databaseName,
     collectionName,
     schemaPath,
@@ -16,7 +18,7 @@ const setupDatabase = async ({
         print(`Read schema from ${schemaPath}`);
 
         // Connect to the default MongoDb instance.
-        const connection: Connection = new Mongo();
+        const connection: Connection = new Mongo(connectionString);
         print(`Connected to instance at ${connection['host']}`);
 
         // Get or create the database. (If it doesn't exist, it will be created.)


### PR DESCRIPTION
This is the first step in letting us trigger updates to the prod db; this will be one of the scripts called by the workflow when the CSV data is updated.

Specifically, after this change, I can update prod MongoDB with the latest CSV by:

1. Git pull on the ` nCoV2019` repo
2. Running `healthmap-gdo-temp/data-serving/scripts/convert-data.py`
3. Running this script (in `healthmap-gdo-temp/data-serving/scripts/setup-db`)
4. Running `mongoimport` on the results of (2)

I'll chain these things together in a master script that will get triggered by the webhook.

And you get a bonus small schema change! Issue discovered after setting up the prod db and importing the newest data. You're welcome!

TESTED=Successfully updated the prod db using this script