### PR TITLE
Improve reporting of conversion errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Local AWS testing and deployment artifacts.
 .aws
 # Log file for conversion warnings
-convert_data.log
+conversion_errors.tsv
 
 # Cypress generates videos, do not store them in revision history.
 **/cypress/**/*.mp4

--- a/data-serving/scripts/convert-data/README.md
+++ b/data-serving/scripts/convert-data/README.md
@@ -11,7 +11,7 @@ schema-compliant json format.
 python3 convert_data.py --ncov2019_path=/path/to/nCoV2019 [--sample_rate=.1] [--outfile=cases.json]
 ```
 
-Logs will be written to `convert_data.log`.
+Errors will be written to `conversion_errors.tsv`.
 
 ### Current stats
 

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -25,8 +25,9 @@ import os
 
 
 def main():
-    logging.basicConfig(filename='convert_data.log',
-                        filemode='w', level=logging.ERROR)
+    logging.basicConfig(filename='conversion_errors.tsv',
+                        filemode='w', level=logging.ERROR,
+                        format='%(message)s')
 
     parser = argparse.ArgumentParser(
         description='Convert CSV line-list data into json compliant with the '

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -113,10 +113,26 @@ def convert(df_import: DataFrame, geocoder: Any) -> DataFrame:
     # Generate new events column.
     df_export['events'] = df_import.apply(
         lambda x: convert_events(x['ID'], {
-            'onsetSymptoms': x['date_onset_symptoms'],
-            'admissionHospital': x['date_admission_hospital'],
-            'confirmed': x['date_confirmation'],
-            'deathOrDischarge': x['date_death_or_discharge']
+            (
+                x['date_onset_symptoms'],
+                'date_onset_symptoms',
+                'onsetSymptoms'
+            ),
+            (
+                x['date_admission_hospital'],
+                'date_admission_hospital',
+                'admissionHospital'
+            ),
+            (
+                x['date_confirmation'],
+                'date_confirmation',
+                'confirmed'
+            ),
+            (
+                x['date_death_or_discharge'],
+                'date_death_or_discharge',
+                'deathOrDischarge'
+            )
         }, x['outcome']), axis=1)
 
     # Generate new symptoms column.

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -26,7 +26,7 @@ import os
 
 def main():
     logging.basicConfig(filename='convert_data.log',
-                        filemode='w', level=logging.DEBUG)
+                        filemode='w', level=logging.ERROR)
 
     parser = argparse.ArgumentParser(
         description='Convert CSV line-list data into json compliant with the '

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -116,7 +116,7 @@ def convert_date_range(dates: str) -> Dict[str, Dict[str, str]]:
     })
 
 
-def convert_event(id: str, name: str, dates: Any) -> Dict[str, Any]:
+def convert_event(id: str, dates: Any, field_name: str, event_name: str) -> Dict[str, Any]:
     '''
     Converts a single event date column to the new event object with a name and
     range of dates.
@@ -150,11 +150,11 @@ def convert_event(id: str, name: str, dates: Any) -> Dict[str, Any]:
 
     try:
         return {
-            'name': str(name),
+            'name': str(event_name),
             'dateRange': convert_date_range(dates)
         }
     except ValueError as e:
-        log_error(id, name, f'event[name="{name}"]', dates, e)
+        log_error(id, field_name, f'event[name="{event_name}"]', dates, e)
 
 
 def convert_events(id: str, event_dates: Dict[str, Any],
@@ -184,7 +184,7 @@ def convert_events(id: str, event_dates: Dict[str, Any],
         where the date strings are ISO 8601 date representations.
     '''
     events = list(map(lambda i: convert_event(
-        id, i[0], i[1]), event_dates.items()))
+        id, i[0], i[1], i[2]), event_dates))
 
     # The old data model had an outcome string, which will become an event in
     # the new data model, but it won't have a date associated with it.

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -154,7 +154,7 @@ def convert_event(id: str, name: str, dates: Any) -> Dict[str, Any]:
             'dateRange': convert_date_range(dates)
         }
     except ValueError as e:
-        warn(id, f'event[name="{name}"]', dates, e)
+        warn(id, name, f'event[name="{name}"]', dates, e)
 
 
 def convert_events(id: str, event_dates: Dict[str, Any],
@@ -226,14 +226,14 @@ def convert_demographics(id: str, age: Any, sex: str) -> Dict[str, Any]:
         if converted_age is not None:
             demographics['ageRange'] = converted_age
     except ValueError as e:
-        warn(id, 'demographics.ageRange', age, e)
+        warn(id, 'age', 'demographics.ageRange', age, e)
 
     try:
         parsed_sex = parse_sex(sex)
         if parsed_sex:
             demographics['sex'] = parsed_sex
     except ValueError as e:
-        warn(id, 'demographics.sex', age, e)
+        warn(id, 'sex', 'demographics.sex', age, e)
 
     return demographics or None
 
@@ -281,14 +281,14 @@ def convert_location(id: str, country: str, adminL1: str,
         if parsed_latitude is not None:
             geometry['latitude'] = parsed_latitude
     except ValueError as e:
-        warn(id, 'location.latitude', latitude, e)
+        warn(id, 'latitude', 'location.latitude', latitude, e)
 
     try:
         parsed_longitude = parse_longitude(longitude)
         if parsed_longitude is not None:
             geometry['longitude'] = parsed_longitude
     except ValueError as e:
-        warn(id, 'location.longitude', longitude, e)
+        warn(id, 'longitude', 'location.longitude', longitude, e)
 
     if geometry:
         location['geometry'] = geometry
@@ -319,7 +319,7 @@ def convert_dictionary_field(id: str, field_name: str, value: str) -> Dict[
         string_list = parse_string_list(value)
         return {'provided': string_list} if string_list else None
     except ValueError as e:
-        warn(id, 'field_name.provided', value, e)
+        warn(id, field_name, f'{field_name}.provided', value, e)
 
 
 def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
@@ -431,7 +431,8 @@ def convert_outbreak_specifics(id: str, reported_market_exposure: str,
             outbreak_specifics['reportedMarketExposure'] = normalized
     except ValueError as e:
         warn(
-            id, 'outbreakSpecifics.reportedMarketExposure',
+            id, 'reported_market_exposure',
+            'outbreakSpecifics.reportedMarketExposure',
             reported_market_exposure, e)
 
     try:
@@ -439,7 +440,9 @@ def convert_outbreak_specifics(id: str, reported_market_exposure: str,
         if normalized is not None:
             outbreak_specifics['livesInWuhan'] = normalized
     except ValueError as e:
-        warn(id, 'outbreakSpecifics.livesInWuhan', lives_in_wuhan, e)
+        warn(
+            id, 'lives_in_wuhan', 'outbreakSpecifics.livesInWuhan',
+            lives_in_wuhan, e)
 
     return outbreak_specifics or None
 
@@ -466,13 +469,13 @@ def convert_travel_history(geocoder: Any, id: str, dates: str,
     try:
         location_list = parse_location_list(geocoder, location)
     except (LookupError, ValueError) as e:
-        warn(id, 'travelHistory.location', location, e)
+        warn(id, 'travel_history_location', 'travelHistory.location', location, e)
 
     date_range = None
     try:
         date_range = convert_date_range(dates)
     except (ValueError) as e:
-        warn(id, 'travelHistory.dateRange', location, e)
+        warn(id, 'travel_history_dates', 'travelHistory.dateRange', location, e)
 
     if not location_list and not date_range:
         return None

--- a/data-serving/scripts/convert-data/utils.py
+++ b/data-serving/scripts/convert-data/utils.py
@@ -39,5 +39,5 @@ def format_iso_8601_date(value: datetime) -> str:
 def log_error(
         id: str, old_field_name: str, new_field_name: str, value: str,
         error: Exception) -> None:
-    logging.error('\t%s\t%s\t%s\t%s\t%s', id, old_field_name,
+    logging.error('%s\t%s\t%s\t%s\t%s', id, old_field_name,
                   new_field_name, value, error)

--- a/data-serving/scripts/convert-data/utils.py
+++ b/data-serving/scripts/convert-data/utils.py
@@ -36,5 +36,8 @@ def format_iso_8601_date(value: datetime) -> str:
     return value.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
-def warn(id: str, field_name: str, value: str, error: Exception) -> None:
-    logging.warning('[%s] [%s] "%s": %s', id, field_name, value, error)
+def warn(
+        id: str, old_field_name: str, new_field_name: str, value: str,
+        error: Exception) -> None:
+    logging.warning('\t%s\t%s\t%s\t%s\t%s', id, old_field_name,
+                    new_field_name, value, error)

--- a/data-serving/scripts/convert-data/utils.py
+++ b/data-serving/scripts/convert-data/utils.py
@@ -36,8 +36,8 @@ def format_iso_8601_date(value: datetime) -> str:
     return value.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
-def warn(
+def log_error(
         id: str, old_field_name: str, new_field_name: str, value: str,
         error: Exception) -> None:
-    logging.warning('\t%s\t%s\t%s\t%s\t%s', id, old_field_name,
-                    new_field_name, value, error)
+    logging.error('\t%s\t%s\t%s\t%s\t%s', id, old_field_name,
+                  new_field_name, value, error)


### PR DESCRIPTION
This lets us easily import the results into a spreadsheet to share with the folks who will be fixing them

- Format as TSV for easy import into sheet
- Filter out logs from geocoding script by setting log level to error
- Include original field names so that folks correcting original data know where to look