### PR TITLE
bump curator and data service to v0.0.4

### DIFF
--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -91,7 +91,7 @@ spec:
     spec:
       containers:
         - name: curator
-          image: docker.io/healthmapidha/curatorservice:0.0.3
+          image: docker.io/healthmapidha/curatorservice:0.0.4
           ports:
             - containerPort: 3001
           livenessProbe:

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
         - name: data
-          image: docker.io/healthmapidha/dataservice:0.0.3
+          image: docker.io/healthmapidha/dataservice:0.0.4
           ports:
             - containerPort: 3000
           livenessProbe:


### PR DESCRIPTION
This is to show the charts in prod FE.
Data service doesn't really have to be updated but there's no hurting doing it as well.

http://51cfaa79-default-curatorpr-5c7d-1665373250.us-east-1.elb.amazonaws.com/charts/cumulative