### PR TITLE
Populate source rule targets to trigger the global retrieval function

### DIFF
--- a/verification/curator-service/api/package.json
+++ b/verification/curator-service/api/package.json
@@ -14,7 +14,8 @@
     "lint": "tsc --noEmit && eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
     "start": "node dist/server.js",
     "test": "jest --forceExit --coverage --verbose --detectOpenHandles",
-    "test-silent": "jest --forceExit --silent --detectOpenHandles"
+    "test-silent": "jest --forceExit --silent --detectOpenHandles",
+    "test-watch": "jest --watch"
   },
   "keywords": [],
   "author": "",

--- a/verification/curator-service/api/package.json
+++ b/verification/curator-service/api/package.json
@@ -15,7 +15,7 @@
     "start": "node dist/server.js",
     "test": "jest --forceExit --coverage --verbose --detectOpenHandles",
     "test-silent": "jest --forceExit --silent --detectOpenHandles",
-    "test-watch": "jest --watch"
+    "test-watch": "jest --watch --silent"
   },
   "keywords": [],
   "author": "",

--- a/verification/curator-service/api/src/clients/aws-events-client.ts
+++ b/verification/curator-service/api/src/clients/aws-events-client.ts
@@ -52,7 +52,7 @@ export default class AwsEventsClient {
                         {
                             Arn: this.retrievalFunctionArn,
                             Id: `${targetId}_Target`,
-                            Input: `{ targetId: "${targetId}"}`,
+                            Input: `{ sourceId: "${targetId}"}`,
                         },
                     ],
                 };

--- a/verification/curator-service/api/src/clients/aws-events-client.ts
+++ b/verification/curator-service/api/src/clients/aws-events-client.ts
@@ -13,7 +13,10 @@ import { AssertionError } from 'assert';
  */
 export default class AwsEventsClient {
     private readonly cloudWatchEventsClient: AWS.CloudWatchEvents;
-    constructor(awsRegion: string) {
+    constructor(
+        private readonly retrievalFunctionArn: string,
+        awsRegion: string,
+    ) {
         AWS.config.update({ region: awsRegion });
         this.cloudWatchEventsClient = new AWS.CloudWatchEvents({
             apiVersion: '2015-10-07',
@@ -30,17 +33,33 @@ export default class AwsEventsClient {
         ruleName: string,
         description: string,
         scheduleExpression?: string,
+        targetId?: string,
     ): Promise<string> => {
-        const params = {
-            Name: ruleName,
-            ScheduleExpression: scheduleExpression,
-            Description: description,
-        };
         try {
+            const putRuleParams = {
+                Name: ruleName,
+                ScheduleExpression: scheduleExpression,
+                Description: description,
+            };
             const response = await this.cloudWatchEventsClient
-                .putRule(params)
+                .putRule(putRuleParams)
                 .promise();
             this.assertString(response.RuleArn);
+            if (targetId) {
+                const putTargetsParams = {
+                    Rule: ruleName,
+                    Targets: [
+                        {
+                            Arn: this.retrievalFunctionArn,
+                            Id: `${targetId}_Target`,
+                            Input: `{ targetId: "${targetId}"}`,
+                        },
+                    ],
+                };
+                await this.cloudWatchEventsClient
+                    .putTargets(putTargetsParams)
+                    .promise();
+            }
             return response.RuleArn;
         } catch (err) {
             console.warn(
@@ -66,10 +85,20 @@ export default class AwsEventsClient {
      * For the full API definition, see:
      *   https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteRule.html
      */
-    deleteRule = async (ruleName: string): Promise<void> => {
+    deleteRule = async (ruleName: string, targetId?: string): Promise<void> => {
         try {
+            if (targetId) {
+                const removeTargetsParams = {
+                    Rule: ruleName,
+                    Ids: [targetId],
+                };
+                await this.cloudWatchEventsClient
+                    .removeTargets(removeTargetsParams)
+                    .promise();
+            }
+            const deleteRuleParams = { Name: ruleName };
             await this.cloudWatchEventsClient
-                .deleteRule({ Name: ruleName })
+                .deleteRule(deleteRuleParams)
                 .promise();
         } catch (err) {
             console.warn(

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -76,7 +76,10 @@ app.use(passport.session());
 app.use('/auth', authController.router);
 
 // Configure connection to AWS services.
-const awsEventsClient = new AwsEventsClient(env.AWS_SERVICE_REGION);
+const awsEventsClient = new AwsEventsClient(
+    env.AWS_SERVICE_REGION,
+    env.GLOBAL_RETRIEVAL_FUNCTION_ARN,
+);
 
 // Configure curator API routes.
 const apiRouter = express.Router();

--- a/verification/curator-service/api/src/util/validate-env.ts
+++ b/verification/curator-service/api/src/util/validate-env.ts
@@ -7,6 +7,7 @@ export default function validateEnv(): Readonly<{
     DATASERVER_URL: string;
     DB_CONNECTION_STRING: string;
     PORT: number;
+    GLOBAL_RETRIEVAL_FUNCTION_ARN: string;
     GOOGLE_OAUTH_CLIENT_ID: string;
     GOOGLE_OAUTH_CLIENT_SECRET: string;
     SESSION_COOKIE_KEY: string;
@@ -44,6 +45,11 @@ export default function validateEnv(): Readonly<{
             devDefault: 'mongodb://localhost:27017/covid19',
         }),
         PORT: port({ default: 3001 }),
+        GLOBAL_RETRIEVAL_FUNCTION_ARN: str({
+            desc: 'AWS ARN for the global source retrieval Lambda function',
+            default:
+                'arn:aws:lambda:us-east-1:612888738066:function:epid-ingestion-RetrievalFunction-1CEVOE6F2OOIV',
+        }),
         GOOGLE_OAUTH_CLIENT_ID: str({
             desc: 'OAuth client ID from the Google developer console',
             devDefault: 'replace to enable auth',

--- a/verification/curator-service/api/test/clients/aws-events-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-client.test.ts
@@ -2,7 +2,7 @@ import AWS from 'aws-sdk';
 import AWSMock from 'aws-sdk-mock';
 import AwsEventsClient from '../../src/clients/aws-events-client';
 
-const fakeRetrievalFunctionArn = 'fakeArn';
+let client: AwsEventsClient;
 const deleteRuleSpy = jest.fn().mockResolvedValueOnce({});
 const putRuleSpy = jest.fn().mockResolvedValue({ RuleArn: 'ruleArn' });
 const putTargetsSpy = jest.fn().mockResolvedValue({
@@ -27,6 +27,7 @@ beforeEach(() => {
     AWSMock.mock('CloudWatchEvents', 'putRule', putRuleSpy);
     AWSMock.mock('CloudWatchEvents', 'putTargets', putTargetsSpy);
     AWSMock.mock('CloudWatchEvents', 'removeTargets', removeTargetsSpy);
+    client = new AwsEventsClient('us-east-1', 'fakeArn');
 });
 
 afterEach(() => {
@@ -37,10 +38,6 @@ describe('putRule', () => {
     it('returns subject AWS CloudWatch Events rule ARN', async () => {
         const expectedArn = 'expectedArn';
         putRuleSpy.mockResolvedValueOnce({ RuleArn: expectedArn });
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
 
         const ruleArn = await client.putRule(
             'passingRule',
@@ -51,11 +48,6 @@ describe('putRule', () => {
         expect(putRuleSpy).toHaveBeenCalledTimes(1);
     });
     it('creates a target for the rule if targetId is provided', async () => {
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
-
         await client.putRule(
             'passingRule',
             'description',
@@ -65,21 +57,12 @@ describe('putRule', () => {
         expect(putTargetsSpy).toHaveBeenCalledTimes(1);
     });
     it('does not mutate rule targets if targetId not provided', async () => {
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
-
         await client.putRule('passingRule', 'description', 'rate(1 hour)');
         expect(putTargetsSpy).not.toHaveBeenCalled();
     });
     it('throws errors from AWS putRule call', async () => {
         const expectedError = new Error('AWS error');
         putRuleSpy.mockRejectedValueOnce(expectedError);
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
 
         expect.assertions(1);
         return expect(
@@ -89,10 +72,6 @@ describe('putRule', () => {
     it('throws errors from AWS putTargets call', async () => {
         const expectedError = new Error('AWS error');
         putTargetsSpy.mockRejectedValueOnce(expectedError);
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
 
         expect.assertions(1);
         return expect(
@@ -106,10 +85,6 @@ describe('putRule', () => {
     });
     it('throws error if PutRuleResponse somehow lacks RuleArn', async () => {
         putRuleSpy.mockResolvedValueOnce({});
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
 
         expect.assertions(1);
         return expect(
@@ -120,11 +95,6 @@ describe('putRule', () => {
 
 describe('deleteRule', () => {
     it('deletes the AWS CloudWatch Event rule and target via the SDK', async () => {
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
-
         await expect(
             client.deleteRule('passingRuleName', 'targetId'),
         ).resolves.not.toThrow();
@@ -134,10 +104,6 @@ describe('deleteRule', () => {
     it('throws errors from AWS removeTargets call', async () => {
         const expectedError = new Error('AWS error');
         removeTargetsSpy.mockRejectedValueOnce(expectedError);
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
 
         expect.assertions(1);
         return expect(
@@ -147,10 +113,6 @@ describe('deleteRule', () => {
     it('throws errors from AWS deleteRule call', async () => {
         const expectedError = new Error('AWS error');
         deleteRuleSpy.mockRejectedValueOnce(expectedError);
-        const client = new AwsEventsClient(
-            'us-east-1',
-            fakeRetrievalFunctionArn,
-        );
 
         expect.assertions(1);
         return expect(

--- a/verification/curator-service/api/test/clients/aws-events-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-client.test.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
     AWSMock.mock('CloudWatchEvents', 'putRule', putRuleSpy);
     AWSMock.mock('CloudWatchEvents', 'putTargets', putTargetsSpy);
     AWSMock.mock('CloudWatchEvents', 'removeTargets', removeTargetsSpy);
-    client = new AwsEventsClient('us-east-1', 'fakeArn');
+    client = new AwsEventsClient('fakeArn', 'us-east-1');
 });
 
 afterEach(() => {

--- a/verification/curator-service/api/test/clients/aws-events-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-client.test.ts
@@ -64,7 +64,6 @@ describe('putRule', () => {
         const expectedError = new Error('AWS error');
         putRuleSpy.mockRejectedValueOnce(expectedError);
 
-        expect.assertions(1);
         return expect(
             client.putRule('awsErrorRule', 'description', 'rate(1 hour)'),
         ).rejects.toThrow(expectedError);
@@ -73,7 +72,6 @@ describe('putRule', () => {
         const expectedError = new Error('AWS error');
         putTargetsSpy.mockRejectedValueOnce(expectedError);
 
-        expect.assertions(1);
         return expect(
             client.putRule(
                 'ruleName',
@@ -86,7 +84,6 @@ describe('putRule', () => {
     it('throws error if PutRuleResponse somehow lacks RuleArn', async () => {
         putRuleSpy.mockResolvedValueOnce({});
 
-        expect.assertions(1);
         return expect(
             client.putRule('noResponseArnRule', 'description', 'rate(1 hour'),
         ).rejects.toThrow('missing RuleArn');
@@ -105,7 +102,6 @@ describe('deleteRule', () => {
         const expectedError = new Error('AWS error');
         removeTargetsSpy.mockRejectedValueOnce(expectedError);
 
-        expect.assertions(1);
         return expect(
             client.deleteRule('awsErrorRuleName', 'targetId'),
         ).rejects.toThrow(expectedError);
@@ -114,7 +110,6 @@ describe('deleteRule', () => {
         const expectedError = new Error('AWS error');
         deleteRuleSpy.mockRejectedValueOnce(expectedError);
 
-        expect.assertions(1);
         return expect(
             client.deleteRule('awsErrorRuleName', 'targetId'),
         ).rejects.toThrow(expectedError);


### PR DESCRIPTION
Couple notes:

- I wouldn't consider the way this synchronizes our state with AWS resources to be particularly "hardened." For instance, if our `putTargets` call fails following a `putRule` call, we'd probably want to rollback the rule creation. This isn't a now problem -- can do this hardening later.
- Now that the test AWS integration is a bit more in depth, I streamlined the way we configure the mock package. Sorry to include this in one change, but thought it was the lesser of two evils as compared to sending a dedicated PR for this.