### PR TITLE
Wire up the source API to set rule targets to the global retrieval Lambda ARN

### DIFF
--- a/verification/curator-service/api/src/clients/aws-events-client.ts
+++ b/verification/curator-service/api/src/clients/aws-events-client.ts
@@ -34,6 +34,7 @@ export default class AwsEventsClient {
         description: string,
         scheduleExpression?: string,
         targetId?: string,
+        sourceId?: string,
     ): Promise<string> => {
         try {
             const putRuleParams = {
@@ -45,14 +46,14 @@ export default class AwsEventsClient {
                 .putRule(putRuleParams)
                 .promise();
             this.assertString(response.RuleArn);
-            if (targetId) {
+            if (targetId && sourceId) {
                 const putTargetsParams = {
                     Rule: ruleName,
                     Targets: [
                         {
                             Arn: this.retrievalFunctionArn,
-                            Id: `${targetId}_Target`,
-                            Input: `{ sourceId: "${targetId}"}`,
+                            Id: targetId,
+                            Input: JSON.stringify({ sourceId: sourceId }),
                         },
                     ],
                 };

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -106,13 +106,18 @@ export default class SourcesController {
         if (source.isModified('automation.schedule.awsScheduleExpression')) {
             if (source.automation?.schedule?.awsScheduleExpression) {
                 const awsRuleArn = await this.awsEventsClient.putRule(
-                    source._id.toString(),
+                    source.toAwsRuleName(),
                     source.toAwsRuleDescription(),
                     source.automation.schedule.awsScheduleExpression,
+                    source.toAwsRuleTargetId(),
+                    source._id.toString(),
                 );
                 source.set('automation.schedule.awsRuleArn', awsRuleArn);
             } else {
-                await this.awsEventsClient.deleteRule(source._id.toString());
+                await this.awsEventsClient.deleteRule(
+                    source.toAwsRuleName(),
+                    source.toAwsRuleTargetId(),
+                );
                 source.set('automation.schedule', undefined);
             }
         } else if (
@@ -120,7 +125,7 @@ export default class SourcesController {
             source.automation?.schedule?.awsRuleArn
         ) {
             await this.awsEventsClient.putRule(
-                source._id.toString(),
+                source.toAwsRuleName(),
                 source.toAwsRuleDescription(),
             );
         }
@@ -135,9 +140,11 @@ export default class SourcesController {
             await source.validate();
             if (source.automation?.schedule) {
                 const createdRuleArn = await this.awsEventsClient.putRule(
-                    source._id.toString(),
+                    source.toAwsRuleName(),
                     source.toAwsRuleDescription(),
                     source.automation.schedule.awsScheduleExpression,
+                    source.toAwsRuleTargetId(),
+                    source._id.toString(),
                 );
                 source.set('automation.schedule.awsRuleArn', createdRuleArn);
             }
@@ -162,7 +169,10 @@ export default class SourcesController {
             return;
         }
         if (source.automation?.schedule?.awsRuleArn) {
-            await this.awsEventsClient.deleteRule(source._id.toString());
+            await this.awsEventsClient.deleteRule(
+                source.toAwsRuleName(),
+                source.toAwsRuleTargetId(),
+            );
         }
         source.remove();
         res.json(source);

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -77,8 +77,8 @@ app.use('/auth', authController.router);
 
 // Configure connection to AWS services.
 const awsEventsClient = new AwsEventsClient(
-    env.AWS_SERVICE_REGION,
     env.GLOBAL_RETRIEVAL_FUNCTION_ARN,
+    env.AWS_SERVICE_REGION,
 );
 
 // Configure curator API routes.

--- a/verification/curator-service/api/src/model/source.ts
+++ b/verification/curator-service/api/src/model/source.ts
@@ -27,13 +27,24 @@ sourceSchema.methods.toAwsRuleDescription = function (): string {
     return `Scheduled ingestion rule for source: ${this.name}`;
 };
 
+sourceSchema.methods.toAwsRuleName = function (): string {
+    return this._id.toString();
+};
+
+sourceSchema.methods.toAwsRuleTargetId = function (): string {
+    return `${this._id}_Target`;
+};
+
 export type SourceDocument = mongoose.Document & {
+    _id: mongoose.Types.ObjectId;
     name: string;
     origin: OriginDocument;
     format: string;
     automation: AutomationDocument;
 
     toAwsRuleDescription(): string;
+    toAwsRuleName(): string;
+    toAwsRuleTargetId(): string;
 };
 
 export const Source = mongoose.model<SourceDocument>('Source', sourceSchema);

--- a/verification/curator-service/api/test/clients/aws-events-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-client.test.ts
@@ -47,12 +47,13 @@ describe('putRule', () => {
         expect(ruleArn).toEqual(expectedArn);
         expect(putRuleSpy).toHaveBeenCalledTimes(1);
     });
-    it('creates a target for the rule if targetId is provided', async () => {
+    it('creates a target for the rule if targetId and sourceId provided', async () => {
         await client.putRule(
             'passingRule',
             'description',
             'rate(1 hour)',
             'targetId',
+            'sourceId',
         );
         expect(putTargetsSpy).toHaveBeenCalledTimes(1);
     });
@@ -78,6 +79,7 @@ describe('putRule', () => {
                 'description',
                 'rate(1 hour)',
                 'awsErrorTargetId',
+                'sourceId',
             ),
         ).rejects.toThrow(expectedError);
     });

--- a/verification/curator-service/api/test/model/source.test.ts
+++ b/verification/curator-service/api/test/model/source.test.ts
@@ -23,8 +23,16 @@ describe('validate', () => {
 });
 
 describe('custom instance methods', () => {
-    it('toAwsRuleDescription returns formatted rule name', () => {
+    it('toAwsRuleDescription returns formatted source name', () => {
         const s = new Source(minimalSource);
         expect(s.toAwsRuleDescription()).toContain(s.name);
+    });
+    it('toAwsRuleName returns formatted source ID', () => {
+        const s = new Source(minimalSource);
+        expect(s.toAwsRuleName()).toContain(s._id);
+    });
+    it('toAwsRuleTargetId returns formatted source ID', () => {
+        const s = new Source(minimalSource);
+        expect(s.toAwsRuleTargetId()).toContain(s._id);
     });
 });

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -153,7 +153,7 @@ describe('PUT', () => {
         expect(res.body.origin.url).toEqual('http://foo.bar');
         expect(mockPutRule).not.toHaveBeenCalled();
     });
-    it('should create an AWS rule if provided schedule expression', async () => {
+    it('should create an AWS rule with target if provided schedule expression', async () => {
         const source = await new Source({
             name: 'test-source',
             origin: { url: 'http://foo.bar' },
@@ -170,9 +170,11 @@ describe('PUT', () => {
             .expect('Content-Type', /json/);
         expect(res.body.automation.schedule.awsRuleArn).toBeDefined();
         expect(mockPutRule).toHaveBeenCalledWith(
-            source._id.toString(),
+            source.toAwsRuleName(),
             source.toAwsRuleDescription(),
             scheduleExpression,
+            source.toAwsRuleTargetId(),
+            source._id.toString(),
         );
     });
     it('should update AWS rule description on source rename', async () => {
@@ -231,7 +233,7 @@ describe('POST', () => {
         expect(res.body.name).toEqual(source.name);
         expect(mockPutRule).not.toHaveBeenCalled();
     });
-    it('should create an AWS rule if provided schedule expression', async () => {
+    it('should create an AWS rule with target if provided schedule expression', async () => {
         const scheduleExpression = 'rate(1 hour)';
         const source = {
             name: 'some_name',
@@ -245,11 +247,14 @@ describe('POST', () => {
             .send(source)
             .expect('Content-Type', /json/)
             .expect(201);
-        expect(res.body.automation.schedule.awsRuleArn).toBeDefined();
+        const createdSource = new Source(res.body);
+        expect(createdSource.automation.schedule.awsRuleArn).toBeDefined();
         expect(mockPutRule).toHaveBeenCalledWith(
-            res.body._id,
-            new Source(source).toAwsRuleDescription(),
+            createdSource.toAwsRuleName(),
+            createdSource.toAwsRuleDescription(),
             scheduleExpression,
+            createdSource.toAwsRuleTargetId(),
+            createdSource._id.toString(),
         );
     });
     it('should not create invalid source', async () => {
@@ -271,7 +276,7 @@ describe('DELETE', () => {
         expect(res.body._id).toEqual(source.id);
         expect(mockDeleteRule).not.toHaveBeenCalled();
     });
-    it('should delete corresponding AWS rule if source contains ruleArn', async () => {
+    it('should delete corresponding AWS rule and target if source contains ruleArn', async () => {
         const source = await new Source({
             name: 'test-source',
             origin: { url: 'http://foo.bar' },
@@ -283,7 +288,10 @@ describe('DELETE', () => {
             },
         }).save();
         await curatorRequest.delete(`/api/sources/${source.id}`).expect(200);
-        expect(mockDeleteRule).toHaveBeenCalledWith(source._id.toString());
+        expect(mockDeleteRule).toHaveBeenCalledWith(
+            source.toAwsRuleName(),
+            source.toAwsRuleTargetId(),
+        );
     });
     it('should not be able to delete a non existent source', (done) => {
         curatorRequest


### PR DESCRIPTION
Includes a couple changes to the AWS CWE client itself. Mostly to keep logic as AWS-oriented as possible, and leaving the intepretation from source data model-to-AWS params in the source controller (and source data model custom instance methods).