### PR TITLE
Creates github workflow to execute the data update pipeline against prod mongodb

### DIFF
--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -1,0 +1,37 @@
+name: Update case data
+
+on:
+  push:
+    branches: [master]
+    paths: ["/data-serving/scripts/convert-data/**"]
+
+jobs:
+  update-case-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install MongoDB CLIs
+        run: |
+          wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
+          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+          sudo apt-get update
+          sudo apt-get install -y mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pandas
+
+      - name: Run update script
+        run: ./data-serving/scripts/data-pipeline/run_pipeline.sh -r .1 -m mongodb+srv://khmoran:P07EMKHI6Hk5kbhi@covid19-map-cluster01-sc7u9.mongodb.net

--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -38,4 +38,4 @@ jobs:
         run: python -m pip install --upgrade pandas
 
       - name: Run update script
-        run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m mongodb+srv://${{ secrets.MONGODB_USER }}:${{ secrets.MONGODB_PASS }}@covid19-map-cluster01-sc7u9.mongodb.net
+        run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m ${{ secrets.DB_CONNECTION_URL }}

--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -38,4 +38,4 @@ jobs:
         run: python -m pip install --upgrade pandas
 
       - name: Run update script
-        run: ./data-serving/scripts/data-pipeline/run_pipeline.sh -m mongodb+srv://${{ secrets.MONGODB_USER }}:${{ secrets.MONGODB_PASS }}@covid19-map-cluster01-sc7u9.mongodb.net
+        run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m mongodb+srv://${{ secrets.MONGODB_USER }}:${{ secrets.MONGODB_PASS }}@covid19-map-cluster01-sc7u9.mongodb.net

--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches: [master]
     paths: ["/data-serving/scripts/convert-data/**"]
+  # TODO: Remove this once we have a webhook that triggers the update.
+  schedule:
+    # Every day at 5AM (data is typically pushed a little after 4AM UTC).
+    - cron: "* 5 * * *"
 
 jobs:
-  update-case-data:
+  update-case-data-prod:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,4 +38,4 @@ jobs:
         run: python -m pip install --upgrade pandas
 
       - name: Run update script
-        run: ./data-serving/scripts/data-pipeline/run_pipeline.sh -r .1 -m mongodb+srv://khmoran:P07EMKHI6Hk5kbhi@covid19-map-cluster01-sc7u9.mongodb.net
+        run: ./data-serving/scripts/data-pipeline/run_pipeline.sh -m mongodb+srv://${{ secrets.MONGODB_USER }}:${{ secrets.MONGODB_PASS }}@covid19-map-cluster01-sc7u9.mongodb.net


### PR DESCRIPTION
Note that is only run on updates to the data conversion script & on a once-a-day schedule -- the next step is to figure out the webhook piece

TESTED=Using https://github.com/nektos/act, ran:
`act -j update-case-data-prod -P ubuntu-latest=nektos/act-environments-ubuntu:18.04-full -s DB_CONNECTION_URL=<db_conn_url>`