### PR TITLE
Improve performance of convert_data.py

### DIFF
--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install Python dependencies
-        run: python -m pip install --upgrade pandas
+        run: python -m pip install --upgrade progressbar
 
       - name: Run update script
         run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m ${{ secrets.DB_CONNECTION_URL }}

--- a/data-serving/scripts/convert-data/constants.py
+++ b/data-serving/scripts/convert-data/constants.py
@@ -20,10 +20,10 @@ GEOCODER_REPO_PATH = 'code/sheet_cleaner/geocoding'
 # new events-based outcome field.
 LOSSY_FIELDS = [
     'ID', 'province', 'geo_resolution', 'date_onset_symptoms',
-    'date_admission_hospital', 'date_confirmation', 'symptoms',
-    'travel_history_dates', 'travel_history_location',
-    'reported_market_exposure', 'chronic_disease_binary', 'outcome', 'location',
-    'admin3', 'country_new', 'admin_id', 'travel_history_binary'
+    'date_admission_hospital', 'date_confirmation', 'travel_history_dates',
+    'travel_history_location', 'reported_market_exposure',
+    'chronic_disease_binary', 'outcome', 'location', 'admin3', 'country_new',
+    'admin_id', 'travel_history_binary'
 ]
 
 '''

--- a/data-serving/scripts/convert-data/constants.py
+++ b/data-serving/scripts/convert-data/constants.py
@@ -18,11 +18,13 @@ GEOCODER_REPO_PATH = 'code/sheet_cleaner/geocoding'
 
 # TODO(khmoran): Include 'outcome' once the curator UI transitions to using the
 # new events-based outcome field.
-LOSSLESS_FIELDS = [
-    'additional_information', 'admin1', 'admin2', 'age', 'chronic_disease',
-    'city', 'country', 'data_moderator_initials', 'date_death_or_discharge',
-    'latitude', 'lives_in_Wuhan', 'longitude', 'notes_for_discussion',
-    'sequence_available', 'sex', 'source', 'symptoms']
+LOSSY_FIELDS = [
+    'ID', 'province', 'geo_resolution', 'date_onset_symptoms',
+    'date_admission_hospital', 'date_confirmation', 'symptoms',
+    'travel_history_dates', 'travel_history_location',
+    'reported_market_exposure', 'chronic_disease_binary', 'outcome', 'location',
+    'admin3', 'country_new', 'admin_id', 'travel_history_binary'
+]
 
 '''
 Mappings from location shorthands to tuples of their full location data, i.e.

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -7,19 +7,18 @@ import argparse
 import csv
 import logging
 import imp
+import itertools
 import json
-import pandas as pd
-import sys
+import progressbar
 from converters import (
     convert_demographics, convert_dictionary_field, convert_events,
     convert_imported_case, convert_location, convert_revision_metadata_field,
     convert_notes_field, convert_sources_field, convert_pathogens_field,
     convert_outbreak_specifics, convert_travel_history)
-from pandas import DataFrame
 from typing import Any
 from constants import (
     DATA_CSV_FILENAME, DATA_GZIP_FILENAME, DATA_REPO_PATH, GEOCODER_DB_FILENAME,
-    GEOCODER_MODULE, GEOCODER_REPO_PATH, LOSSLESS_FIELDS)
+    GEOCODER_MODULE, GEOCODER_REPO_PATH, LOSSY_FIELDS)
 import tarfile
 import os
 
@@ -33,32 +32,19 @@ def main():
         description='Convert CSV line-list data into json compliant with the '
         'MongoDB schema.')
     parser.add_argument('--ncov2019_path', type=str, required=True)
-    parser.add_argument('--outfile',
-                        nargs='?',
-                        type=argparse.FileType('w', encoding='UTF-8'),
-                        default=sys.stdout)
+    parser.add_argument('--outfile', type=str, required=True)
     parser.add_argument('--sample_rate', default=1.0, type=float)
 
     args = parser.parse_args()
 
     csv_path = extract_csv(args.ncov2019_path)
+    num_cases = len(open(csv_path).readlines())
+    num_to_convert = int(args.sample_rate*num_cases)
+    print(f'Converting {num_to_convert} / {num_cases} cases from {csv_path}')
 
-    print('Reading data from', csv_path)
-    original_cases = read_csv(csv_path)
-
-    if args.sample_rate < 1.0:
-        original_rows = original_cases.shape[0]
-        original_cases = original_cases.sample(frac=args.sample_rate)
-        print(
-            f'Downsampling to {args.sample_rate*100}% of cases from '
-            f'{original_rows} to {original_cases.shape[0]} rows')
-
-    print('Converting data to new schema')
-    geocoder = load_geocoder(args.ncov2019_path)
-    converted_cases = convert(original_cases, geocoder)
-
-    print('Writing results to', args.outfile.name)
-    write_json(converted_cases, args.outfile)
+    print('Converting data to new schema and writing to', args.outfile)
+    convert(csv_path, args.outfile, load_geocoder(
+        args.ncov2019_path), args.sample_rate, num_to_convert)
 
     # Clean up the CSV file we unzipped.
     os.remove(csv_path)
@@ -86,110 +72,105 @@ def extract_csv(repo_path: str) -> str:
     return DATA_CSV_FILENAME
 
 
-def read_csv(infile: str) -> DataFrame:
-    return pd.read_csv(infile, header=0, low_memory=False, encoding='utf-8')
+def convert(infile: str, outfile: str, geocoder: Any,
+            sample_rate: int, num_to_convert: int) -> None:
+    conversion_interval = int(1/sample_rate)
+    bar = progressbar.ProgressBar(
+        maxval=num_to_convert,
+        widgets=[progressbar.Bar('=', '[', ']'),
+                 ' ', progressbar.Percentage()])
+    bar.start()
 
+    with open(outfile, mode='w') as f:
+        f.write('[')
+        with open(infile, newline='') as csvfile:
+            csvreader = csv.DictReader(csvfile)
+            for i, csv_case in enumerate(itertools.islice(
+                    csvreader, None, None, conversion_interval)):
+                bar.update(i)
+                if i != 0:
+                    f.write(',')
 
-def convert(df_import: DataFrame, geocoder: Any) -> DataFrame:
-    # Operate on a separate output dataframe so we don't clobber or mutate the
-    # original data.
-    df_export = pd.DataFrame(columns={})
+                json_case = {}
 
-    # Generate new demographics column.
-    df_export['demographics'] = df_import.apply(lambda x: convert_demographics(
-        x['ID'], x['age'], x['sex']), axis=1)
+                json_case['demographics'] = convert_demographics(
+                    csv_case['ID'], csv_case['age'], csv_case['sex'])
 
-    # Generate new location column.
-    df_export['location'] = df_import.apply(
-        lambda
-        x:
-        convert_location(
-            x['ID'],
-            x['country'],
-            x['admin1'],
-            x['admin2'],
-            x['city'],
-            x['latitude'],
-            x['longitude']),
-        axis=1)
+                json_case['location'] = convert_location(
+                    csv_case['ID'],
+                    csv_case['country'],
+                    csv_case['admin1'],
+                    csv_case['admin2'],
+                    csv_case['city'],
+                    csv_case['latitude'],
+                    csv_case['longitude'])
 
-    # Generate new events column.
-    df_export['events'] = df_import.apply(
-        lambda x: convert_events(x['ID'], {
-            (
-                x['date_onset_symptoms'],
-                'date_onset_symptoms',
-                'onsetSymptoms'
-            ),
-            (
-                x['date_admission_hospital'],
-                'date_admission_hospital',
-                'admissionHospital'
-            ),
-            (
-                x['date_confirmation'],
-                'date_confirmation',
-                'confirmed'
-            ),
-            (
-                x['date_death_or_discharge'],
-                'date_death_or_discharge',
-                'deathOrDischarge'
-            )
-        }, x['outcome']), axis=1)
+                json_case['events'] = convert_events(csv_case['ID'], {
+                    (
+                        csv_case['date_onset_symptoms'],
+                        'date_onset_symptoms',
+                        'onsetSymptoms'
+                    ),
+                    (
+                        csv_case['date_admission_hospital'],
+                        'date_admission_hospital',
+                        'admissionHospital'
+                    ),
+                    (
+                        csv_case['date_confirmation'],
+                        'date_confirmation',
+                        'confirmed'
+                    ),
+                    (
+                        csv_case['date_death_or_discharge'],
+                        'date_death_or_discharge',
+                        'deathOrDischarge'
+                    )
+                }, csv_case['outcome'])
 
-    # Generate new symptoms column.
-    df_export['symptoms'] = df_import.apply(
-        lambda x: convert_dictionary_field(
-            x['ID'],
-            'symptoms',
-            x['symptoms']),
-        axis=1)
+                json_case['symptoms'] = convert_dictionary_field(
+                    csv_case['ID'],
+                    'symptoms',
+                    csv_case['symptoms'])
 
-    # Generate new chronic disease column.
-    df_export['chronicDisease'] = df_import.apply(
-        lambda x: convert_dictionary_field(
-            x['ID'],
-            'chronicDisease',
-            x['chronic_disease']),
-        axis=1)
+                json_case['chronicDisease'] = convert_dictionary_field(
+                    csv_case['ID'],
+                    'chronicDisease',
+                    csv_case['chronic_disease'])
 
-    # Generate new revision metadata column.
-    df_export['revisionMetadata'] = df_import.apply(
-        lambda x: convert_revision_metadata_field(
-            x['data_moderator_initials']
-        ), axis=1)
+                json_case['revisionMetadata'] = convert_revision_metadata_field(
+                    csv_case['data_moderator_initials'])
 
-    # Generate new notes column.
-    df_export['notes'] = df_import.apply(lambda x: convert_notes_field(
-        [x['notes_for_discussion'], x['additional_information']]), axis=1)
+                json_case['notes'] = convert_notes_field(
+                    [csv_case['notes_for_discussion'],
+                     csv_case['additional_information']])
 
-    # Generate new source column.
-    df_export['sources'] = df_import.apply(lambda x: convert_sources_field(
-        x['source']), axis=1)
+                json_case['sources'] = convert_sources_field(
+                    csv_case['source'])
 
-    # Generate new pathogens column.
-    df_export['pathogens'] = df_import.apply(lambda x: convert_pathogens_field(
-        x['sequence_available']), axis=1)
+                json_case['pathogens'] = convert_pathogens_field(
+                    csv_case['sequence_available'])
 
-    # Generate new outbreak specifics column.
-    df_export['outbreakSpecifics'] = df_import.apply(lambda x: convert_outbreak_specifics(
-        x['ID'], x['reported_market_exposure'], x['lives_in_Wuhan']), axis=1)
+                json_case['outbreakSpecifics'] = convert_outbreak_specifics(
+                    csv_case['ID'], csv_case['reported_market_exposure'], csv_case['lives_in_Wuhan'])
 
-    # Generate new travel history column.
-    df_export['travelHistory'] = df_import.apply(lambda x: convert_travel_history(
-        geocoder, x['ID'], x['travel_history_dates'], x['travel_history_location']), axis=1)
+                json_case['travelHistory'] = convert_travel_history(
+                    geocoder, csv_case['ID'],
+                    csv_case['travel_history_dates'],
+                    csv_case['travel_history_location'])
 
-    # Archive the original fields.
-    df_export['importedCase'] = df_import.apply(lambda x: convert_imported_case(
-        x.drop(LOSSLESS_FIELDS)), axis=1)
+                # Archive the original fields.
+                json_case['importedCase'] = convert_imported_case(
+                    {k: csv_case[k] for k in LOSSY_FIELDS})
 
-    return df_export
+                f.write(
+                    json.dumps(
+                        {k: v for k, v in json_case.items() if v},
+                        indent=2))
 
-
-def write_json(cases: DataFrame, outfile: str) -> None:
-    json.dump([row.dropna().to_dict()
-               for index, row in cases.iterrows()], outfile, indent=2)
+        # Close the json array.
+        bar.finish()
+        f.write(']')
 
 
 if __name__ == '__main__':

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -9,11 +9,9 @@ Converters log errors thrown by the parsers, since they have the context on
 which row failed to convert.
 '''
 
-import pandas as pd
 from parsers import (parse_age, parse_bool, parse_date,
                      parse_latitude, parse_list, parse_location_list,
                      parse_longitude, parse_range, parse_sex, parse_string_list)
-from pandas import Series
 from typing import Any, Callable, Dict, List
 from utils import format_iso_8601_date, is_url, log_error
 
@@ -145,7 +143,7 @@ def convert_event(id: str, dates: Any, field_name: str, event_name: str) -> Dict
         where the date strings are ISO 8601 date representations.
 
     '''
-    if pd.isna(dates):
+    if not dates:
         return None
 
     try:
@@ -188,7 +186,7 @@ def convert_events(id: str, event_dates: Dict[str, Any],
 
     # The old data model had an outcome string, which will become an event in
     # the new data model, but it won't have a date associated with it.
-    if pd.notna(outcome):
+    if outcome:
         events.append({'name': str(outcome)})
 
     # Filter out None values.
@@ -262,16 +260,16 @@ def convert_location(id: str, country: str, adminL1: str,
     '''
     location = {}
 
-    if pd.notna(country):
+    if country:
         location['country'] = str(country)
 
-    if pd.notna(adminL1):
+    if adminL1:
         location['administrativeAreaLevel1'] = str(adminL1)
 
-    if pd.notna(adminL2):
+    if adminL2:
         location['administrativeAreaLevel2'] = str(adminL2)
 
-    if pd.notna(locality):
+    if locality:
         location['locality'] = str(locality)
 
     geometry = {}
@@ -339,7 +337,7 @@ def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
         'id': 0
     }
 
-    if pd.notna(data_moderator_initials):
+    if data_moderator_initials:
         revision_metadata['moderator'] = str(data_moderator_initials)
 
     return revision_metadata
@@ -352,7 +350,7 @@ def convert_notes_field(notes_fields: [str]) -> str:
     Returns:
       str: Always.
     '''
-    notes = '; '.join([x for x in notes_fields if pd.notna(x)])
+    notes = '; '.join([x for x in notes_fields if x])
     return notes or None
 
 
@@ -370,7 +368,7 @@ def convert_sources_field(source: str) -> Dict[str, str]:
           'other': str
         }
     '''
-    if pd.isna(source):
+    if not source:
         return None
 
     sources = parse_list(source, ',')
@@ -492,7 +490,7 @@ def convert_travel_history(geocoder: Any, id: str, dates: str,
     return [{'dateRange': date_range, 'location': l} for l in location_list if l]
 
 
-def convert_imported_case(values_to_archive: Series) -> Dict[str, Any]:
+def convert_imported_case(values_to_archive: Dict[str, Any]) -> Dict[str, Any]:
     '''
     Converts original field names and values to the importedCase archival
     object.
@@ -501,5 +499,4 @@ def convert_imported_case(values_to_archive: Series) -> Dict[str, Any]:
       Dict[str, Any]: Always. Dictionary keys are the names of the original
         fields, and the values are the values of the original fields.
     '''
-    return {k: str(v) for k, v in values_to_archive.iteritems()
-            if pd.notna(v)}
+    return {k: str(v) for k, v in values_to_archive.items() if v}

--- a/data-serving/scripts/convert-data/geocode_util.py
+++ b/data-serving/scripts/convert-data/geocode_util.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, NamedTuple, NewType, Tuple, Union
+from typing import Any, Callable, Dict, NamedTuple, Tuple
 
 
 class Geocode(NamedTuple):

--- a/data-serving/scripts/convert-data/parsers.py
+++ b/data-serving/scripts/convert-data/parsers.py
@@ -13,7 +13,6 @@
   '''
 
 import re
-import pandas as pd
 import numbers
 import math
 import datetime
@@ -53,7 +52,7 @@ def parse_bool(value: Any) -> bool:
       None: When the input value is empty or a string indicating n/a.
       bool: When the value is present and successfully parsed.
     '''
-    if pd.isna(value) or value == 'na':
+    if value is None or value == 'na':
         return None
 
     # Throw an error if the value can't be converted to a boolean.
@@ -79,7 +78,7 @@ def parse_range(
     Returns:
       Tuple[Any, Any]: Always. The tuple is in the format (start, end).
     '''
-    if pd.isna(value):
+    if not value:
         return (None, None)
 
     # First check if the value is represented as a range.
@@ -120,7 +119,7 @@ def parse_age(value: Any) -> float:
       None: When the value is empty.
       float: When the value is present and successfully parsed.
     '''
-    if pd.isna(value):
+    if not value:
         return None
 
     if type(value) is str:
@@ -156,7 +155,7 @@ def parse_date(value: str) -> datetime:
       None: When the value is empty.
       datetime: When the value is present and successfully parsed.
     '''
-    if pd.isna(value):
+    if not value:
         return None
 
     try:
@@ -238,7 +237,7 @@ def parse_location_list(geocoder: Any, value: Any) -> [Dict[str, Any]]:
         A list of dictionaries containing the location data.
     '''
     separator = None
-    if pd.isna(value):
+    if not value:
         return None
     if ';' in value:
         separator = ';'
@@ -262,7 +261,7 @@ def parse_sex(value: Any) -> str:
       None: When the input value is empty or a string indicating n/a.
       str: When the value is present and successfully parsed.
     '''
-    if pd.isna(value):
+    if not value:
         return None
 
     if str(value).lower() not in VALID_SEXES:
@@ -284,7 +283,7 @@ def parse_latitude(value: Any) -> float:
       None: When the input value is empty.
       float: When the value is present and successfully parsed.
     '''
-    if pd.isna(value):
+    if not value:
         return None
 
     latitude = float(value)
@@ -308,7 +307,7 @@ def parse_longitude(value: Any) -> float:
       None: When the input value is empty.
       float: When the value is present and successfully parsed.
     '''
-    if pd.isna(value):
+    if not value:
         return None
 
     longitude = float(value)
@@ -333,7 +332,7 @@ def parse_string_list(value: Any) -> List[str]:
       None: When the input value is empty.
       List[str]: When the value is present and successfully parsed.
     '''
-    if pd.isna(value):
+    if not value:
         return None
     if type(value) is not str:
         raise ValueError('not a string')


### PR DESCRIPTION
Now that the CSV has over 2M rows, the script is taking a long time to run. Especially since it will be run from a GitHub action, I wanted to optimize it a bit. I figured that reducing the amount of json in memory would help, so I'm now reading in 1 row at a time and writing out 1 case at a time. It unfortunately requires a little JSON hackery but it's not too bad.

Since we're doing manipulations only on a single row, and not across columns, I think pandas isn't really speeding things up, so I switched to a pure CSV reader (it's a bit simpler).

The current dataset (2M+ rows) converts on my machine in:
- 9min16s with this version
- 39m44s with the prior version is still running 

Note that the sampling is no longer random; it's systematic. (Which maybe is preferable for diffing changes across runs tbh.)

LMK what you think!