### PR TITLE
Add an HTTP bearer token auth strategy for the curator server

### DIFF
--- a/verification/curator-service/api/package-lock.json
+++ b/verification/curator-service/api/package-lock.json
@@ -1329,6 +1329,16 @@
         "@types/passport-oauth2": "*"
       }
     },
+    "@types/passport-http-bearer": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/@types/passport-http-bearer/-/passport-http-bearer-1.0.35.tgz",
+      "integrity": "sha512-zAwDt99tmFquIQi0VNnKSim4+zW2D5nXCyuoefchy9q9puWT2GGNRbWII1rgKrbchGqaktI4Fw7o4fQmllL01A==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
+    },
     "@types/passport-oauth2": {
       "version": "1.4.9",
       "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.9.tgz",
@@ -7086,6 +7096,14 @@
       "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
       "requires": {
         "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-http-bearer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-http-bearer/-/passport-http-bearer-1.0.1.tgz",
+      "integrity": "sha1-FHRp6jZp4qhMYWfvmdu3fh8AmKg=",
+      "requires": {
+        "passport-strategy": "1.x.x"
       }
     },
     "passport-oauth2": {

--- a/verification/curator-service/api/package.json
+++ b/verification/curator-service/api/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^13.13.8",
     "@types/passport": "^1.0.3",
     "@types/passport-google-oauth20": "^2.0.3",
+    "@types/passport-http-bearer": "^1.0.35",
     "@types/supertest": "^2.0.9",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
@@ -67,6 +68,7 @@
     "mongoose": "^5.9.15",
     "passport": "^0.4.1",
     "passport-google-oauth20": "^2.0.0",
+    "passport-http-bearer": "^1.0.1",
     "swagger-ui-express": "^4.1.4",
     "yamljs": "^0.3.0"
   }

--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -25,6 +25,13 @@ export const mustBeAuthenticated = (
     res.sendStatus(403);
 };
 
+const userHasRequiredRole = (
+    user: UserDocument,
+    requiredRoles: Set<string>,
+): boolean => {
+    return user.roles?.filter((r: string) => requiredRoles.has(r)).length > 0;
+};
+
 /**
  * Express middleware that checks to see if there's an authenticated principal
  * that has any of the specified roles.
@@ -38,9 +45,7 @@ export const mustHaveAnyRole = (requiredRoles: string[]) => {
         const requiredSet = new Set(requiredRoles);
         if (
             req.isAuthenticated() &&
-            (req.user as UserDocument).roles?.filter((r: string) =>
-                requiredSet.has(r),
-            ).length > 0
+            userHasRequiredRole(req.user as UserDocument, requiredSet)
         ) {
             return next();
         } else {
@@ -49,9 +54,7 @@ export const mustHaveAnyRole = (requiredRoles: string[]) => {
                     return next(err);
                 } else if (
                     user &&
-                    (user as UserDocument).roles?.filter((r: string) =>
-                        requiredSet.has(r),
-                    ).length > 0
+                    userHasRequiredRole(user as UserDocument, requiredSet)
                 ) {
                     return next();
                 } else {

--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -29,7 +29,7 @@ const userHasRequiredRole = (
     user: UserDocument,
     requiredRoles: Set<string>,
 ): boolean => {
-    return user.roles?.filter((r: string) => requiredRoles.has(r)).length > 0;
+    return user.roles?.some((r: string) => requiredRoles.has(r));
 };
 
 /**
@@ -211,7 +211,6 @@ export class AuthController {
                         if (!user) {
                             user = await User.create({
                                 email: email,
-                                token: token,
                             });
                         }
                         return done(null, user);

--- a/verification/curator-service/api/src/model/user.ts
+++ b/verification/curator-service/api/src/model/user.ts
@@ -1,19 +1,12 @@
 import mongoose from 'mongoose';
 
 const userSchema = new mongoose.Schema({
-    name: {
-        type: String,
-    },
+    name: String,
     email: {
         type: String,
         required: 'User must have an email',
     },
-    googleID: {
-        type: String,
-        // Note: we can relax that requirement if we start
-        // supporting more identity platforms.
-        required: 'User must be logged-in with Google',
-    },
+    googleID: String,
     roles: {
         type: [String],
         enum: ['reader', 'curator', 'admin'],

--- a/verification/curator-service/api/test/model/user.test.ts
+++ b/verification/curator-service/api/test/model/user.test.ts
@@ -15,9 +15,6 @@ describe('User schema', () => {
         const errors = new User({}).validateSync();
         expect(errors).toBeDefined();
         expect(errors?.toString()).toMatch('User must have an email');
-        expect(errors?.toString()).toMatch(
-            'User must be logged-in with Google',
-        );
     });
 
     it('should restrict roles to values in the enum', () => {


### PR DESCRIPTION
Since I'm adding a programmatic API consumer elsewhere (ingestion), I've found that the passport Google auth strategy is largely built around the browser flow. While it's conceivable we could _somehow_ manually spoof that flow, the canonical solution for API support is typically to accept bearer token auth.

I'm adding it as a fallback for RBAC'd requests in which there isn't an active user session. Passport's bearer strategy inspects the request for a token (in various RFC 6750 formats), and if present, will execute the strategy I defined.

While I was adding tests, I noticed that a handful of the existing auth tests have a classic async Jest bug -- not returning or awaiting the promise. I can clean this up in a separate PR; some of the cases didn't pass.