### PR TITLE
Fix flaky test

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -53,11 +53,11 @@ describe('Manage users page', function () {
         cy.get('ul').type('{esc}').then(() =>
             console.log('in here 2'));
 
-        cy.get('th[data-testid="Bob-roles"]').contains('curator');
-        cy.get('th[data-testid="Bob-roles"]').contains('admin');
-        cy.get('th[data-testid="Bob-roles"]')
-            .contains('reader')
-            .should('not.exist');
+        // cy.get('th[data-testid="Bob-roles"]').contains('curator');
+        // cy.get('th[data-testid="Bob-roles"]').contains('admin');
+        // cy.get('th[data-testid="Bob-roles"]')
+        //     .contains('reader')
+        //     .should('not.exist');
 
         // Roles are maintained on refresh
         // cy.visit('/users').then(() =>

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -66,7 +66,7 @@ describe('Manage users page', function () {
         cy.get('th[data-testid="Bob-roles"]')
             .contains('reader')
             .should('not.exist');
-    });//hiya
+    });
 
     it('Updated roles propagate to other pages', function () {
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -38,6 +38,7 @@ describe('Manage users page', function () {
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });
         cy.visit('/users');
         cy.contains('Bob');
+        console.log('in here');
         cy.get('th[data-testid="Bob-roles"]').contains('curator');
         cy.get('th[data-testid="Bob-roles"]').contains('reader');
         cy.get('th[data-testid="Bob-roles"]')
@@ -51,6 +52,7 @@ describe('Manage users page', function () {
         // Close popup
         cy.get('ul').type('{esc}');
 
+        console.log('in here 2');
         cy.get('th[data-testid="Bob-roles"]').contains('curator');
         cy.get('th[data-testid="Bob-roles"]').contains('admin');
         cy.get('th[data-testid="Bob-roles"]')
@@ -59,6 +61,7 @@ describe('Manage users page', function () {
 
         // Roles are maintained on refresh
         cy.visit('/users');
+        console.log('in here 3');
         cy.get('th[data-testid="Bob-roles"]').contains('curator');
         cy.get('th[data-testid="Bob-roles"]').contains('admin');
         cy.get('th[data-testid="Bob-roles"]')

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -60,13 +60,13 @@ describe('Manage users page', function () {
             .should('not.exist');
 
         // Roles are maintained on refresh
-        cy.visit('/users').then(() =>
-            console.log('in here 3'));
-        cy.get('th[data-testid="Bob-roles"]').contains('curator');
-        cy.get('th[data-testid="Bob-roles"]').contains('admin');
-        cy.get('th[data-testid="Bob-roles"]')
-            .contains('reader')
-            .should('not.exist');
+        // cy.visit('/users').then(() =>
+        //     console.log('in here 3'));
+        // cy.get('th[data-testid="Bob-roles"]').contains('curator');
+        // cy.get('th[data-testid="Bob-roles"]').contains('admin');
+        // cy.get('th[data-testid="Bob-roles"]')
+        //     .contains('reader')
+        //     .should('not.exist');
     });
 
     it('Updated roles propagate to other pages', function () {

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -37,8 +37,8 @@ describe('Manage users page', function () {
         });
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });
         cy.visit('/users');
-        cy.contains('Bob');
-        console.log('in here');
+        cy.contains('Bob').then(() =>
+            console.log('in here'));
         cy.get('th[data-testid="Bob-roles"]').contains('curator');
         cy.get('th[data-testid="Bob-roles"]').contains('reader');
         cy.get('th[data-testid="Bob-roles"]')
@@ -50,9 +50,9 @@ describe('Manage users page', function () {
         cy.get('li[data-value="admin"]').click();
         cy.get('li[data-value="reader"]').click();
         // Close popup
-        cy.get('ul').type('{esc}');
+        cy.get('ul').type('{esc}').then(() =>
+            console.log('in here 2'));
 
-        console.log('in here 2');
         cy.get('th[data-testid="Bob-roles"]').contains('curator');
         cy.get('th[data-testid="Bob-roles"]').contains('admin');
         cy.get('th[data-testid="Bob-roles"]')
@@ -60,8 +60,8 @@ describe('Manage users page', function () {
             .should('not.exist');
 
         // Roles are maintained on refresh
-        cy.visit('/users');
-        console.log('in here 3');
+        cy.visit('/users').then(() =>
+            console.log('in here 3'));
         cy.get('th[data-testid="Bob-roles"]').contains('curator');
         cy.get('th[data-testid="Bob-roles"]').contains('admin');
         cy.get('th[data-testid="Bob-roles"]')

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -54,6 +54,7 @@ describe('Manage users page', function () {
         cy.get('th[data-testid="Bob-roles"]')
             .contains('reader')
             .should('not.exist');
+        //TODO: remove this comment
 
         // Roles are maintained on refresh
         cy.visit('/users');

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -45,9 +45,13 @@ describe('Manage users page', function () {
             .should('not.exist');
 
         // Select new roles
+        cy.server();
+        cy.route('PUT', '/api/users/*').as('updateUser');
         cy.get('div[data-testid="Bob-select-roles"]').click();
         cy.get('li[data-value="admin"]').click();
+        cy.wait('@updateUser');
         cy.get('li[data-value="reader"]').click();
+        cy.wait('@updateUser');
 
         cy.get('th[data-testid="Bob-roles"]').contains('curator');
         cy.get('th[data-testid="Bob-roles"]').contains('admin');
@@ -69,8 +73,11 @@ describe('Manage users page', function () {
         cy.visit('/users');
 
         // Select new role
+        cy.server();
+        cy.route('PUT', '/api/users/*').as('updateUser');
         cy.get('div[data-testid="Alice-select-roles"]').click();
         cy.get('li[data-value="reader"]').click();
+        cy.wait('@updateUser');
 
         // Home page has reader links
         cy.visit('/');

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -54,7 +54,6 @@ describe('Manage users page', function () {
         cy.get('th[data-testid="Bob-roles"]')
             .contains('reader')
             .should('not.exist');
-        //TODO: remove this comment
 
         // Roles are maintained on refresh
         cy.visit('/users');

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -66,7 +66,6 @@ describe('Manage users page', function () {
         cy.get('th[data-testid="Bob-roles"]')
             .contains('reader')
             .should('not.exist');
-        //testing
     });
 
     it('Updated roles propagate to other pages', function () {

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -66,7 +66,7 @@ describe('Manage users page', function () {
         cy.get('th[data-testid="Bob-roles"]')
             .contains('reader')
             .should('not.exist');
-    });
+    });//hiya
 
     it('Updated roles propagate to other pages', function () {
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -37,8 +37,7 @@ describe('Manage users page', function () {
         });
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });
         cy.visit('/users');
-        cy.contains('Bob').then(() =>
-            console.log('in here'));
+        cy.contains('Bob');
         cy.get('th[data-testid="Bob-roles"]').contains('curator');
         cy.get('th[data-testid="Bob-roles"]').contains('reader');
         cy.get('th[data-testid="Bob-roles"]')
@@ -49,24 +48,20 @@ describe('Manage users page', function () {
         cy.get('div[data-testid="Bob-select-roles"]').click();
         cy.get('li[data-value="admin"]').click();
         cy.get('li[data-value="reader"]').click();
-        // Close popup
-        cy.get('ul').type('{esc}').then(() =>
-            console.log('in here 2'));
 
-        // cy.get('th[data-testid="Bob-roles"]').contains('curator');
-        // cy.get('th[data-testid="Bob-roles"]').contains('admin');
-        // cy.get('th[data-testid="Bob-roles"]')
-        //     .contains('reader')
-        //     .should('not.exist');
+        cy.get('th[data-testid="Bob-roles"]').contains('curator');
+        cy.get('th[data-testid="Bob-roles"]').contains('admin');
+        cy.get('th[data-testid="Bob-roles"]')
+            .contains('reader')
+            .should('not.exist');
 
         // Roles are maintained on refresh
-        // cy.visit('/users').then(() =>
-        //     console.log('in here 3'));
-        // cy.get('th[data-testid="Bob-roles"]').contains('curator');
-        // cy.get('th[data-testid="Bob-roles"]').contains('admin');
-        // cy.get('th[data-testid="Bob-roles"]')
-        //     .contains('reader')
-        //     .should('not.exist');
+        cy.visit('/users');
+        cy.get('th[data-testid="Bob-roles"]').contains('curator');
+        cy.get('th[data-testid="Bob-roles"]').contains('admin');
+        cy.get('th[data-testid="Bob-roles"]')
+            .contains('reader')
+            .should('not.exist');
     });
 
     it('Updated roles propagate to other pages', function () {
@@ -76,8 +71,6 @@ describe('Manage users page', function () {
         // Select new role
         cy.get('div[data-testid="Alice-select-roles"]').click();
         cy.get('li[data-value="reader"]').click();
-        // Close popup
-        cy.get('ul').type('{esc}');
 
         // Home page has reader links
         cy.visit('/');

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -66,6 +66,7 @@ describe('Manage users page', function () {
         cy.get('th[data-testid="Bob-roles"]')
             .contains('reader')
             .should('not.exist');
+        //testing
     });
 
     it('Updated roles propagate to other pages', function () {


### PR DESCRIPTION
Key fix is waiting for the http request to finish before checking the updates. The check for updates waits 4 seconds, but that is not enough when running on CI. 

Also removes closing the popup, since it is unnecessary and adds complications.