### PR TITLE
Update the case data update workflow to fix mongodb cli install

### DIFF
--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -21,8 +21,9 @@ jobs:
         run: |
           wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5DC22404A6F9F1CA 656408E390CFB1F5
           sudo apt-get update
-          sudo apt-get install -y mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
+          sudo apt-get install -y --allow-downgrades mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
 
       - name: Set up Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
- The workflow failed to run over the weekend because the machine it's running on has newer versions of the mongodb packages installed. I think we want to downgrade to our versions because to ensure a consistent env, so we're now passing the `--allow-downgrades` arg to `apt-get install` (see one of the failed runs here: https://github.com/open-covid-data/healthmap-gdo-temp/runs/748668598)

- I got warnings locally about not being able to install 2 of the packages because their public keys weren't available, so I added the `apt-key adv` line to retrieve those keys from a key server