### PR TITLE
Add full, authenticated retrieval using the Source API (for JSON content)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 # Log file for conversion warnings
 conversion_errors.tsv
 
+# Plausible GCP project service account credentials.
+# (Out of an abundance of caution.)
+covid-19-map-*.json
+
 # Cypress generates videos, do not store them in revision history.
 **/cypress/**/*.mp4
 **/cypress/**/*.png

--- a/ingestion/functions/ci-requirements.txt
+++ b/ingestion/functions/ci-requirements.txt
@@ -1,3 +1,5 @@
 boto3==1.13.3
+google==2.0.3
+google-auth==1.16.1
 moto==1.3.14
 requests-mock==1.8.0

--- a/ingestion/functions/retrieval/requirements.txt
+++ b/ingestion/functions/retrieval/requirements.txt
@@ -1,1 +1,3 @@
+google==2.0.3
+google-auth==1.16.1
 requests==2.23.0

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -70,7 +70,8 @@ def retrieve_content(source_id, url, source_format):
         data = None
         extension = None
         print(f"Downloading {source_format} content from {url}")
-        r = requests.get(url)
+        headers = {"user-agent": "GHDSI/1.0 (http://ghdsi.org)"}
+        r = requests.get(url, headers=headers)
         if source_format == "JSON":
             data = json.dumps(r.json(), indent=4)
             extension = "json"

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -1,10 +1,16 @@
 import boto3
+import json
+import os
 import requests
+import google.auth.transport.requests
+from google.oauth2 import service_account
 from datetime import datetime, timezone
 
 
-SOURCE_ID_FIELD = "sourceId"
+METADATA_BUCKET = "epid-ingestion"
 OUTPUT_BUCKET = "epid-sources-raw"
+SERVICE_ACCOUNT_CRED_FILE = "covid-19-map-277002-0943eeb6776b.json"
+SOURCE_ID_FIELD = "sourceId"
 TIME_FILEPART_FORMAT = "/%Y/%m/%d/%H%M/"
 
 s3_client = boto3.client("s3")
@@ -19,12 +25,63 @@ def extract_source_id(event):
     return event[SOURCE_ID_FIELD]
 
 
-def retrieve_content(source_id):
+def obtain_api_credentials():
+    """
+    Creates HTTP headers credentialed for access to the EPID Source API.
+    """
     try:
-        ip = requests.get("http://checkip.amazonaws.com/").text.strip()
-        key_filename_part = "ip.txt"
+        local_creds_file = "/tmp/creds.json"
+        print(
+            "Retrieving service account credentials from "
+            f"s3://{METADATA_BUCKET}/{SERVICE_ACCOUNT_CRED_FILE}")
+        s3_client.download_file(
+            METADATA_BUCKET, SERVICE_ACCOUNT_CRED_FILE, local_creds_file)
+        credentials = service_account.Credentials.from_service_account_file(
+            local_creds_file, scopes=["email"])
+        headers = {}
+        request = google.auth.transport.requests.Request()
+        credentials.refresh(request)
+        credentials.apply(headers)
+        return headers
+    except Exception as e:
+        print(e)
+        raise e
+
+
+def get_source_details(source_id, api_headers):
+    """
+    Retrieves the content URL and format associated with the provided source ID.
+    """
+    try:
+        source_api_endpoint = f"{os.environ['SOURCE_API_URL']}/{source_id}"
+        print(f"Requesting source configuration from {source_api_endpoint}")
+        r = requests.get(source_api_endpoint, headers=api_headers)
+        print(f"Received source API response: {r.json()}")
+        json = r.json()
+        return json["origin"]["url"], "JSON"
+    except Exception as e:
+        print(e)
+        raise e
+
+
+def retrieve_content(source_id, url, source_format):
+    """ Retrieves and locally persists the content at the provided URL. """
+    try:
+        data = None
+        extension = None
+        print(f"Downloading {source_format} content from {url}")
+        r = requests.get(url)
+        if source_format == "JSON":
+            data = json.dumps(r.json(), indent=4)
+            extension = "json"
+        else:
+            error_message = f"Unsupported source format: {source_format}"
+            print(error_message)
+            raise ValueError(error_message)
+
+        key_filename_part = f"content.{extension}"
         file = open(f"/tmp/{key_filename_part}", "w")
-        file.write(ip)
+        file.write(data)
         file.close()
         s3_object_key = (
             f"{source_id}"
@@ -41,8 +98,7 @@ def upload_to_s3(file_name, s3_object_key):
         s3_client.upload_file(
             file_name, OUTPUT_BUCKET, s3_object_key)
         print(
-            f"Uploaded source content to bucket {OUTPUT_BUCKET} "
-            f"with key {s3_object_key}")
+            f"Uploaded source content to s3://{OUTPUT_BUCKET}/{s3_object_key}")
     except Exception as e:
         print(e)
         raise e
@@ -50,10 +106,6 @@ def upload_to_s3(file_name, s3_object_key):
 
 def lambda_handler(event, context):
     """Global ingestion retrieval function.
-
-    Will be used to scrape source content and persist it to S3.
-    For now, extracts the source ID from the input event JSON, and persists the
-    executing machine IP in a (canonically keyed) dummy file in S3.
 
     Parameters
     ----------
@@ -77,6 +129,8 @@ def lambda_handler(event, context):
     """
 
     source_id = extract_source_id(event)
-    file_name, s3_object_key = retrieve_content(source_id)
+    auth_headers = obtain_api_credentials()
+    url, source_format = get_source_details(source_id, auth_headers)
+    file_name, s3_object_key = retrieve_content(source_id, url, source_format)
     upload_to_s3(file_name, s3_object_key)
     return {"bucket": OUTPUT_BUCKET, "key": s3_object_key}

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -56,9 +56,9 @@ def get_source_details(source_id, api_headers):
         source_api_endpoint = f"{os.environ['SOURCE_API_URL']}/{source_id}"
         print(f"Requesting source configuration from {source_api_endpoint}")
         r = requests.get(source_api_endpoint, headers=api_headers)
-        print(f"Received source API response: {r.json()}")
-        json = r.json()
-        return json["origin"]["url"], "JSON"
+        api_json = r.json()
+        print(f"Received source API response: {api_json}")
+        return api_json["origin"]["url"], "JSON"
     except Exception as e:
         print(e)
         raise e

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -95,6 +95,7 @@ def test_retrieve_content_persists_downloaded_json_locally(requests_mock):
     requests_mock.get(content_url, json={"data": "yes"})
     retrieval.retrieve_content(source_id, content_url, format)
     assert requests_mock.request_history[0].url == content_url
+    assert "GHDSI" in requests_mock.request_history[0].headers["user-agent"]
     with open("/tmp/content.json", "r") as f:
         assert json.load(f)["data"] == "yes"
 

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from moto import mock_s3
+from unittest.mock import MagicMock
 
 
 @pytest.fixture()
@@ -41,36 +42,94 @@ def invalid_event():
 
 
 @mock_s3
-def test_persist_supplied_source_id_to_s3(valid_event, requests_mock, s3):
+def test_lambda_handler_e2e(valid_event, requests_mock, s3):
     from retrieval import retrieval  # Import locally to avoid superseding mock
-    expected_s3_bucket = retrieval.OUTPUT_BUCKET
-    s3.create_bucket(Bucket=expected_s3_bucket)
-    requests_mock.get("http://checkip.amazonaws.com/", text="111.1.1.1")
+    retrieval.obtain_api_credentials = MagicMock(name="obtain_api_credentials")
+    s3.create_bucket(Bucket=retrieval.OUTPUT_BUCKET)
+    source_api_url = "http://foo.bar/"
+    origin_url = "http://bar.baz/"
+    os.environ["SOURCE_API_URL"] = source_api_url
+    requests_mock.get(
+        f"{source_api_url}/{valid_event['sourceId']}",
+        json={"origin": {"url": origin_url}})
+    requests_mock.get(origin_url, json={"data": "yes"})
 
     response = retrieval.lambda_handler(valid_event, "")
 
-    assert response["bucket"] == expected_s3_bucket
-    assert str.startswith(response["key"], valid_event["sourceId"])
-    assert s3.list_objects_v2(Bucket=expected_s3_bucket)['KeyCount'] == 1
+    expected_api_endpoint = f"{source_api_url}/{valid_event['sourceId']}"
+    assert requests_mock.request_history[0].url == expected_api_endpoint
+    assert requests_mock.request_history[1].url == origin_url
+    assert response["bucket"] == retrieval.OUTPUT_BUCKET
+    assert valid_event["sourceId"] in response["key"]
+
+
+def test_extract_source_id_returns_id_field(valid_event):
+    from retrieval import retrieval
+    assert retrieval.extract_source_id(valid_event) == valid_event["sourceId"]
+
+
+def test_extract_source_id_raises_error_if_event_lacks_id(invalid_event):
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    with pytest.raises(ValueError, match=retrieval.SOURCE_ID_FIELD):
+        retrieval.extract_source_id(invalid_event)
+
+
+def test_get_source_details_returns_url_and_json_format(requests_mock):
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    source_api_url = "http://foo.bar"
+    source_id = "id"
+    content_url = "http://bar.baz"
+    os.environ["SOURCE_API_URL"] = source_api_url
+    requests_mock.get(f"{source_api_url}/{source_id}",
+                      json={"origin": {"url": content_url}})
+    result = retrieval.get_source_details(source_id, {})
+    assert result[0] == content_url
+    assert result[1] == "JSON"
+
+
+def test_retrieve_content_persists_downloaded_json_locally(requests_mock):
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    source_id = "id"
+    content_url = "http://foo.bar/"
+    format = "JSON"
+    requests_mock.get(content_url, json={"data": "yes"})
+    retrieval.retrieve_content(source_id, content_url, format)
+    assert requests_mock.request_history[0].url == content_url
+    with open("/tmp/content.json", "r") as f:
+        assert json.load(f)["data"] == "yes"
+
+
+def test_retrieve_content_returns_local_and_s3_object_names(requests_mock):
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    source_id = "id"
+    content_url = "http://foo.bar/"
+    requests_mock.get(content_url, json={"data": "yes"})
+    result = retrieval.retrieve_content(source_id, content_url, "JSON")
+    assert "/tmp/" in result[0]
+    assert source_id in result[1]
+
+
+def test_retrieve_content_raises_error_for_non_json_format(requests_mock):
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    bad_format = "CSV"
+    content_url = "http://foo.bar/"
+    requests_mock.get(content_url)
+    with pytest.raises(ValueError, match=bad_format):
+        retrieval.retrieve_content("id", content_url, bad_format)
 
 
 @mock_s3
-def test_s3_object_contains_machine_ip(valid_event, requests_mock, s3):
+def test_upload_to_s3_writes_indicated_file_to_key(s3):
     from retrieval import retrieval  # Import locally to avoid superseding mock
+    local_file = "/tmp/data.txt"
+    expected_data = "This is data."
+    with open(local_file, "w") as f:
+        f.write(expected_data)
     expected_s3_bucket = retrieval.OUTPUT_BUCKET
     s3.create_bucket(Bucket=expected_s3_bucket)
-    expected_ip = "111.1.1.1"
-    requests_mock.get("http://checkip.amazonaws.com/", text=expected_ip)
-
-    response = retrieval.lambda_handler(valid_event, "")
-
+    expected_s3_key = "objectkey"
+    retrieval.upload_to_s3(local_file, expected_s3_key)
     actual_object = s3.get_object(
-        Bucket=expected_s3_bucket, Key=response["key"])
-    actual_ip = actual_object['Body'].read().decode("utf-8")
-    assert actual_ip == expected_ip
-
-
-def test_error_for_event_without_source_id(invalid_event, requests_mock):
-    from retrieval import retrieval  # Import locally to avoid superseding mock
-    with pytest.raises(ValueError, match=retrieval.SOURCE_ID_FIELD):
-        retrieval.lambda_handler(invalid_event, "")
+        Bucket=expected_s3_bucket, Key=expected_s3_key)
+    s3_data = actual_object['Body'].read().decode("utf-8")
+    assert s3_data == expected_data

--- a/ingestion/functions/retrieval/valid_scheduled_event.json
+++ b/ingestion/functions/retrieval/valid_scheduled_event.json
@@ -1,3 +1,3 @@
 {
-    "sourceId": "ExampleSourceId"
+    "sourceId": "5ede92d0121dc200280a8f48"
 }

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -2,6 +2,12 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: AWS Lambda functions for epid ingestion
 
+Parameters:
+  SourceApiUrl:
+    Type: String
+    Description: Address at which to retrieve source details
+    Default: "http://localhost:3001/api/sources"
+
 Resources:
   RawSourcesBucket:
     Type: AWS::S3::Bucket
@@ -21,6 +27,10 @@ Resources:
         - S3WritePolicy:
             BucketName: !Ref RawSourcesBucket
       Timeout: 10 # Seconds
+      Environment:
+        Variables:
+          SOURCE_API_URL:
+            Ref: SourceApiUrl
 
 # Declare values that can be imported to other CloudFormation stacks, or should
 # be made easily visible on the console.


### PR DESCRIPTION
Few notes:

- Per the title, just covering JSON for now. Not that it'll be difficult to add other formats, but starting with just the JSON to support the data API from India.
- Now that there's a fair amount more meat in the function, restructured tests around individual units (with one end-to-end happy path).
- Ended up storing service account credentials in S3. Bundling them into the Lambda package made it hard to keep the file hidden, and it didn't feel like encrypting individual fields in env variables was any better than using S3.