### PR TITLE
use same site cookie strict for session cookie

### DIFF
--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -1,12 +1,13 @@
 import * as usersController from './controllers/users';
 
 import { AuthController, mustHaveAnyRole } from './controllers/auth';
-import { OpenApiValidator } from 'express-openapi-validator';
 import { Request, Response } from 'express';
 
 import AwsEventsClient from './clients/aws-events-client';
 import CasesController from './controllers/cases';
+import { OpenApiValidator } from 'express-openapi-validator';
 import SourcesController from './controllers/sources';
+import YAML from 'yamljs';
 import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
 import dotenv from 'dotenv';
@@ -18,7 +19,6 @@ import path from 'path';
 import session from 'express-session';
 import swaggerUi from 'swagger-ui-express';
 import validateEnv from './util/validate-env';
-import YAML from 'yamljs';
 
 const app = express();
 app.use(bodyParser.json());
@@ -64,6 +64,10 @@ app.use(
             mongooseConnection: mongoose.connection,
             secret: env.SESSION_COOKIE_KEY,
         }),
+        cookie: {
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+        },
     }),
 );
 const authController = new AuthController(env.AFTER_LOGIN_REDIRECT_URL);


### PR DESCRIPTION
I was originally going for a full blown csrf token based approach (https://github.com/open-covid-data/healthmap-gdo-temp/compare/csrf?expand=1) but this was waaaaay too involved imo and was breaking the ingestion pipeline calls that Alex wrote yesterday.

You can see here how same site cookie helps defend against CSRF: https://portswigger.net/web-security/csrf/samesite-cookies

We are not using a lax framework in terms of POST becoming GET (express doesn't do that kind of change itself) so I am fine with just relying on samesite cookies as a starting point or even staying like this long-term.

We can also think about moving to "lax" mode if navigation from other sites becomes impractical, for now there should be no issues like that.

![image](https://user-images.githubusercontent.com/1255432/84140901-9ca01b00-aa52-11ea-9c51-93b2a0af8a0f.png)
