### PR TITLE
update settigns json to not format on save

### DIFF
--- a/dev/.vscode/settings.json
+++ b/dev/.vscode/settings.json
@@ -11,16 +11,7 @@
     "javascript",
     "typescript"
   ],
-  "editor.formatOnSave": true,
-  "[javascript]": {
-    "editor.formatOnSave": false
-  },
-  "[typescript]": {
-    "editor.formatOnSave": false
-  },
-  "[markdown]": {
-    "editor.formatOnSave": false
-  },
+  "editor.formatOnSave": false,
   "editor.rulers": [
     80
   ],


### PR DESCRIPTION
Will pick up eslint actions and auto format instead which makes it consistent with npm lint --fix