### PR TITLE
Add India parser function SAM definition; trigger source parser lambdas in retrieval

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -13,7 +13,7 @@ SERVICE_ACCOUNT_CRED_FILE = "covid-19-map-277002-0943eeb6776b.json"
 SOURCE_ID_FIELD = "sourceId"
 TIME_FILEPART_FORMAT = "/%Y/%m/%d/%H%M/"
 
-lambda_client = boto3.client("lambda")
+lambda_client = boto3.client("lambda", region_name="us-east-1")
 s3_client = boto3.client("s3")
 
 

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -13,6 +13,7 @@ SERVICE_ACCOUNT_CRED_FILE = "covid-19-map-277002-0943eeb6776b.json"
 SOURCE_ID_FIELD = "sourceId"
 TIME_FILEPART_FORMAT = "/%Y/%m/%d/%H%M/"
 
+lambda_client = boto3.client("lambda")
 s3_client = boto3.client("s3")
 
 
@@ -53,12 +54,15 @@ def get_source_details(source_id, api_headers):
     Retrieves the content URL and format associated with the provided source ID.
     """
     try:
-        source_api_endpoint = f"{os.environ['SOURCE_API_URL']}/{source_id}"
+        source_api_endpoint = f"{os.environ['SOURCE_API_URL']}/sources/{source_id}"
         print(f"Requesting source configuration from {source_api_endpoint}")
         r = requests.get(source_api_endpoint, headers=api_headers)
         api_json = r.json()
         print(f"Received source API response: {api_json}")
-        return api_json["origin"]["url"], "JSON"
+        return api_json["origin"]["url"], "JSON", api_json.get(
+            "automation", {}).get(
+            "parser", {}).get(
+            "awsLambdaArn", "")
     except Exception as e:
         print(e)
         raise e
@@ -105,6 +109,19 @@ def upload_to_s3(file_name, s3_object_key):
         raise e
 
 
+def invoke_parser(parser_arn, s3_object_key):
+    payload = {"s3Bucket": OUTPUT_BUCKET, "s3Key": s3_object_key}
+    print(f"Invoking parser (ARN: {parser_arn}")
+    response = lambda_client.invoke(
+        FunctionName=parser_arn,
+        InvocationType='Event',
+        Payload=json.dumps(payload))
+    if "StatusCode" not in response or response["StatusCode"] != 202:
+        error_message = f"Parser invocation unsuccessful. Response: {response}"
+        print(error_message)
+        raise Exception(error_message)
+
+
 def lambda_handler(event, context):
     """Global ingestion retrieval function.
 
@@ -131,7 +148,9 @@ def lambda_handler(event, context):
 
     source_id = extract_source_id(event)
     auth_headers = obtain_api_credentials()
-    url, source_format = get_source_details(source_id, auth_headers)
+    url, source_format, parser_arn = get_source_details(source_id, auth_headers)
     file_name, s3_object_key = retrieve_content(source_id, url, source_format)
     upload_to_s3(file_name, s3_object_key)
+    if parser_arn:
+        invoke_parser(parser_arn, s3_object_key)
     return {"bucket": OUTPUT_BUCKET, "key": s3_object_key}

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -6,7 +6,7 @@ Parameters:
   SourceApiUrl:
     Type: String
     Description: Address at which to retrieve source details
-    Default: "http://localhost:3001/api/sources"
+    Default: "http://localhost:3001/api"
 
 Resources:
   RawSourcesBucket:
@@ -19,14 +19,30 @@ Resources:
       CodeUri: retrieval/
       Handler: retrieval.lambda_handler
       Runtime: python3.6
-      Description: Retrieve the executing machine IP
+      Description: Retrieve raw source content
       # Function's execution role
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
         - S3WritePolicy:
             BucketName: !Ref RawSourcesBucket
-      Timeout: 10 # Seconds
+      Timeout: 60 # Seconds
+      Environment:
+        Variables:
+          SOURCE_API_URL:
+            Ref: SourceApiUrl
+  IndiaParsingFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: parsing/india/
+      Handler: india.lambda_handler
+      Runtime: python3.6
+      Description: Parse case data for India
+      # Function's execution role
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSLambdaReadOnlyAccess
+      Timeout: 60 # Seconds
       Environment:
         Variables:
           SOURCE_API_URL:


### PR DESCRIPTION
Couple small notes:

- Small additional change to the retrieval function, so that I could generalize the SourceApiUrl SAM template param to work for both retrieval and parsing.
- Testing isn't super thorough for the AWS Lambda client. Gave it a fair shot, but it's a PITA to test -- even with the stub library I'm using to test s3 (`moto`). This code will probably change a few times in the next couple weeks, and be relatively stable thereafter, so I'm OK with saving the testing gore.