### PR TITLE
Bring demographics schema in line with data model standard spec

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -39,13 +39,18 @@
             "enum": [
               "Male",
               "Female",
-              "Other"
+              "Other",
+              "Unknown"
             ]
           },
-          "species": {
-            "enum": [
-              "Homo sapien"
-            ]
+          "profession": {
+            "bsonType": "string"
+          },
+          "nationality": {
+            "bsonType": "string"
+          },
+          "ethnicity": {
+            "bsonType": "string"
           }
         }
       },

--- a/data-serving/data-service/src/model/demographics.ts
+++ b/data-serving/data-service/src/model/demographics.ts
@@ -7,10 +7,6 @@ export enum Sex {
     Other = 'Other',
 }
 
-export enum Species {
-    HomoSapien = 'Homo sapien',
-}
-
 export const demographicsSchema = new mongoose.Schema({
     ageRange: {
         start: {
@@ -24,18 +20,20 @@ export const demographicsSchema = new mongoose.Schema({
             max: 300,
         },
     },
-    species: {
-        type: String,
-        enum: Object.values(Species),
-    },
     sex: {
         type: String,
         enum: Object.values(Sex),
     },
+    // TODO: The below 3 fields should be data dictionaries.
+    profession: String,
+    nationality: String,
+    ethnicity: String,
 });
 
 export type DemographicsDocument = mongoose.Document & {
     ageRange: Range<number>;
     sex: Sex;
-    species: Species;
+    profession: string;
+    nationality: string;
+    ethnicity: string;
 };

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -154,9 +154,7 @@ describe('DELETE', () => {
         const c = new Case(minimalCase);
         await c.save();
 
-        return await request(app)
-            .delete(`/api/cases/${c._id}`)
-            .expect(204);
+        return await request(app).delete(`/api/cases/${c._id}`).expect(204);
     });
     it('delete absent item should return 404 NOT FOUND', () => {
         return request(app)

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -5,7 +5,9 @@
             "end": 59.0
         },
         "sex": "Female",
-        "species": "Homo sapien"
+        "profession": "Horse trainer",
+        "nationality": "Swedish",
+        "ethnicity": "Other"
     },
     "location": {
         "id": "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",

--- a/data-serving/data-service/test/model/data/demographics.full.json
+++ b/data-serving/data-service/test/model/data/demographics.full.json
@@ -4,5 +4,7 @@
         "end": 29
     },
     "sex": "Female",
-    "species": "Homo sapien"
+    "profession": "Horse trainer",
+    "nationality": "Swedish",
+    "ethnicity": "Other"
 }

--- a/data-serving/data-service/test/model/demographics.test.ts
+++ b/data-serving/data-service/test/model/demographics.test.ts
@@ -50,19 +50,10 @@ describe('validate', () => {
         });
     });
 
-    it('an unknown species name is invalid', async () => {
-        return new Demographics({
-            ...fullModel,
-            ...{ species: 'Felis catus' },
-        }).validate((e) => {
-            expect(e.name).toBe(Error.ValidationError.name);
-        });
-    });
-
     it('an unknown sex is invalid', async () => {
         return new Demographics({
             ...fullModel,
-            ...{ sex: 'Also felis catus' },
+            ...{ sex: 'Some free text' },
         }).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -10,7 +10,9 @@
                 }
             },
             "sex": "Female",
-            "species": "Homo sapien"
+            "profession": "Horse trainer",
+            "nationality": "Swedish",
+            "ethnicity": "Other"
         },
         "location": {
             "id": "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",

--- a/data-serving/scripts/convert-data/README.md
+++ b/data-serving/scripts/convert-data/README.md
@@ -113,13 +113,19 @@ Fields that can't be converted include:
 
 We are backfilling fields including:
 
-- `demographics.species`: We are assuming that all reported cases have been in humans thus far, but are leaving the
-  option open for other species in future cases.
-
-- `revision.id` and `revision.notes`: We are treating each record as if it's on its first revision. It would be
-  extremely labor-intensive to reconstruct revision history from the source data, but it will baked into the new system.
+- `revision.id`: We are treating each record as if it's on its first revision. It would be extremely labor-intensive to
+  reconstruct revision history from the source data, but it will baked into the new system.
 
 > **Open question:** Do we want to backfill data or leave those fields empty for imported data?
+
+### Non-backfilled fields
+
+Some fields in the new schema cannot be backfilled because they are not present in the data we're converting, including:
+
+- `demographics.profession`
+- `demographics.nationality`
+- `demographics.ethnicity`
+- `revision.notes`
 
 ### Original fields archive
 

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -212,8 +212,7 @@ def convert_demographics(id: str, age: Any, sex: str) -> Dict[str, Any]:
             'end': {
               '$date': str
             },
-          'sex': str,
-          'species': str
+          'sex': str
         }
 
     '''


### PR DESCRIPTION
- Species has been nixed
- Profession, nationality, and ethnicity have been added: All optional string fields. In the future should be validated against a data dictionary.

In the future, profession and nationality will be validated against data dictionaries (no free text entry); ethnicity will have a data dictionary but the option to write in free text

