### PR TITLE
Bring revisionHistory schema in line with spec

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -332,23 +332,50 @@
         "bsonType": "object",
         "additionalProperties": false,
         "required": [
-          "id"
+          "revisionNumber"
         ],
         "properties": {
           "_id": {
             "bsonType": "objectId"
           },
-          "id": {
+          "revisionNumber": {
             "bsonType": "int"
           },
-          "moderator": {
-            "bsonType": "string"
+          "creationMetadata": {
+            "bsonType": "object",
+            "additionalProperties": false,
+            "properties": {
+              "_id": {
+                "bsonType": "objectId"
+              },
+              "curator": {
+                "bsonType": "string"
+              },
+              "date": {
+                "bsonType": "date"
+              },
+              "notes": {
+                "bsonType": "string"
+              }
+            }
           },
-          "date": {
-            "bsonType": "date"
-          },
-          "notes": {
-            "bsonType": "string"
+          "updateMetadata": {
+            "bsonType": "object",
+            "additionalProperties": false,
+            "properties": {
+              "_id": {
+                "bsonType": "objectId"
+              },
+              "curator": {
+                "bsonType": "string"
+              },
+              "date": {
+                "bsonType": "date"
+              },
+              "notes": {
+                "bsonType": "string"
+              }
+            }
           }
         }
       },

--- a/data-serving/data-service/src/model/revision-metadata.ts
+++ b/data-serving/data-service/src/model/revision-metadata.ts
@@ -1,17 +1,8 @@
 import { dateFieldInfo } from './date';
 import mongoose from 'mongoose';
 
-export const revisionMetadataSchema = new mongoose.Schema({
-    id: {
-        type: Number,
-        min: 0,
-        validate: {
-            validator: Number.isInteger,
-            message: '{VALUE} is not an integer value',
-        },
-        required: 'Enter a revision id',
-    },
-    moderator: {
+const editMetadataSchema = new mongoose.Schema({
+    curator: {
         type: String,
         required: 'Enter a revision moderator id',
     },
@@ -22,9 +13,39 @@ export const revisionMetadataSchema = new mongoose.Schema({
     notes: String,
 });
 
-export type RevisionMetadataDocument = mongoose.Document & {
-    id: number;
-    moderator: string;
+export const revisionMetadataSchema = new mongoose.Schema({
+    revisionNumber: {
+        type: Number,
+        min: 0,
+        validate: {
+            validator: Number.isInteger,
+            message: '{VALUE} is not an integer value',
+        },
+        required: 'Enter a revision id',
+    },
+    creationMetadata: {
+        type: editMetadataSchema,
+        required: 'Enter creation metadata',
+    },
+    updateMetadata: {
+        type: editMetadataSchema,
+        required: [
+            function (this: RevisionMetadataDocument): boolean {
+                return this.revisionNumber > 0 && !this.updateMetadata;
+            },
+            'Enter update metadata',
+        ],
+    },
+});
+
+type EditMetadataDocument = mongoose.Document & {
+    curator: string;
     date: Date;
     notes: string;
+};
+
+export type RevisionMetadataDocument = mongoose.Document & {
+    revisionNumber: number;
+    creationMetadata: EditMetadataDocument;
+    updateMetadata: EditMetadataDocument;
 };

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -123,10 +123,17 @@
     ],
     "notes": "Contact of a confirmed case at work.",
     "revisionMetadata": {
-        "id": 0,
-        "moderator": "abc123",
-        "date": "2020-01-03",
-        "notes": "initial data entry"
+        "revisionNumber": 1,
+        "creationMetadata": {
+            "curator": "abc123",
+            "date": "2020-01-03",
+            "notes": "initial data entry"
+        },
+        "updateMetadata": {
+            "curator": "xyz789",
+            "date": "2020-01-13",
+            "notes": "fix source error"
+        }
     },
     "importedCase": {
         "ID": "xyz",

--- a/data-serving/data-service/test/model/data/case.minimal.json
+++ b/data-serving/data-service/test/model/data/case.minimal.json
@@ -14,9 +14,11 @@
         }
     ],
     "revisionMetadata": {
-        "id": 0,
-        "moderator": "abc",
-        "date": "2020-01-03T05:00:00Z"
+        "revisionNumber": 0,
+        "creationMetadata": {
+            "curator": "abc123",
+            "date": "2020-01-03"
+        }
     },
     "location": {
         "country": "China"

--- a/data-serving/data-service/test/model/data/revision-metadata.full.json
+++ b/data-serving/data-service/test/model/data/revision-metadata.full.json
@@ -1,0 +1,13 @@
+{
+    "revisionNumber": 1,
+    "creationMetadata": {
+        "curator": "abc@email.com",
+        "date": "2020-01-10",
+        "notes": "Initial entry"
+    },
+    "updateMetadata": {
+        "curator": "xyz@email.com",
+        "date": "2020-01-15",
+        "notes": "Fix source error"
+    }
+}

--- a/data-serving/data-service/test/model/data/revision-metadata.minimal.json
+++ b/data-serving/data-service/test/model/data/revision-metadata.minimal.json
@@ -1,0 +1,7 @@
+{
+    "revisionNumber": 0,
+    "creationMetadata": {
+        "curator": "abc@email.com",
+        "date": "2020-01-10"
+    }
+}

--- a/data-serving/data-service/test/model/revision-metadata.test.ts
+++ b/data-serving/data-service/test/model/revision-metadata.test.ts
@@ -4,6 +4,8 @@ import {
 } from '../../src/model/revision-metadata';
 
 import { Error } from 'mongoose';
+import fullModel from './data/revision-metadata.full.json';
+import minimalModel from './data/revision-metadata.minimal.json';
 import mongoose from 'mongoose';
 
 const RevisionMetadata = mongoose.model<RevisionMetadataDocument>(
@@ -11,37 +13,21 @@ const RevisionMetadata = mongoose.model<RevisionMetadataDocument>(
     revisionMetadataSchema,
 );
 
-/** A sample document with the minimim required fields. */
-const minimalModel = {
-    id: 0,
-    moderator: 'm',
-    date: new Date(),
-};
-
 describe('validate', () => {
-    it('revision metadata without id is invalid', async () => {
-        const noId = { ...minimalModel };
-        delete noId.id;
+    it('revision metadata without revision number is invalid', async () => {
+        const noRevisionNumber = { ...minimalModel };
+        delete noRevisionNumber.revisionNumber;
 
-        return new RevisionMetadata(noId).validate((e) => {
+        return new RevisionMetadata(noRevisionNumber).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });
     });
 
-    it('revision metadata without moderator is invalid', async () => {
-        const noModerator = { ...minimalModel };
-        delete noModerator.moderator;
+    it('revision metadata without creation metadata is invalid', async () => {
+        const noCreationMetadata = { ...minimalModel };
+        delete noCreationMetadata.creationMetadata;
 
-        return new RevisionMetadata(noModerator).validate((e) => {
-            expect(e.name).toBe(Error.ValidationError.name);
-        });
-    });
-
-    it('revision metadata without date is invalid', async () => {
-        const noDate = { ...minimalModel };
-        delete noDate.date;
-
-        return new RevisionMetadata(noDate).validate((e) => {
+        return new RevisionMetadata(noCreationMetadata).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });
     });
@@ -49,8 +35,26 @@ describe('validate', () => {
     it('revision metadata with non-integer id invalid', async () => {
         return new RevisionMetadata({
             ...minimalModel,
-            ...{ id: 2.2 },
+            ...{ revisionNumber: 2.2 },
         }).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('revision edit metadata without date is invalid', async () => {
+        return new RevisionMetadata({
+            ...minimalModel,
+            ...{ creationMetadata: { revisionNumber: 0 } },
+        }).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
+    it('revision metadata beyond revision 0 without update metadata is invalid', async () => {
+        const noUpdateMetadata = { ...fullModel, ...{ revisionNumber: 1 } };
+        delete noUpdateMetadata.updateMetadata;
+
+        return new RevisionMetadata(noUpdateMetadata).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });
     });
@@ -60,9 +64,6 @@ describe('validate', () => {
     });
 
     it('fully specified revision metadata model is valid', async () => {
-        return new RevisionMetadata({
-            ...minimalModel,
-            notes: 'n',
-        }).validate();
+        return new RevisionMetadata(fullModel).validate();
     });
 });

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -176,16 +176,25 @@
         ],
         "notes": "Contact of a confirmed case at work.",
         "revisionMetadata": {
-            "id": {
-                "$numberInt": "0"
+            "revisionNumber": 1,
+            "creationMetadata": {
+                "curator": "abc123",
+                "date": {
+                    "$date": {
+                        "$numberLong": "1587614400000"
+                    }
+                },
+                "notes": "initial data entry"
             },
-            "moderator": "abc123",
-            "date": {
-                "$date": {
-                    "$numberLong": "1587614400000"
-                }
-            },
-            "notes": "initial data entry"
+            "updateMetadata": {
+                "curator": "xyz789",
+                "date": {
+                    "$date": {
+                        "$numberLong": "1587814400000"
+                    }
+                },
+                "notes": "fix source error"
+            }
         },
         "importedCase": {
             "ID": "idk",
@@ -222,8 +231,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -266,7 +277,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -325,7 +336,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-96587",
@@ -363,7 +374,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -423,7 +434,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-19007",
@@ -462,8 +473,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -506,8 +519,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -555,7 +570,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -597,7 +612,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -640,8 +655,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -684,8 +701,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -745,7 +764,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -787,7 +806,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -828,8 +847,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -872,8 +893,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -916,8 +939,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -960,8 +985,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -1002,7 +1029,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -1061,7 +1088,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-43612",
@@ -1098,7 +1125,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -1139,7 +1166,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -1180,7 +1207,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -1239,7 +1266,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-38568",
@@ -1282,7 +1309,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -1324,8 +1351,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -1368,8 +1397,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -1412,8 +1443,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -1472,7 +1505,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-44084",
@@ -1511,8 +1544,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -1560,7 +1595,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -1619,7 +1654,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-412234",
@@ -1656,7 +1691,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -1699,8 +1734,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -1741,7 +1778,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -1782,7 +1819,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "004-12633",
@@ -1819,8 +1856,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -1863,8 +1902,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -1923,7 +1964,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-52178",
@@ -1962,8 +2003,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2003,7 +2046,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2045,8 +2088,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2087,7 +2132,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2130,8 +2175,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2174,8 +2221,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2218,8 +2267,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2262,7 +2313,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2320,7 +2371,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-423045",
@@ -2356,7 +2407,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2400,7 +2451,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2443,7 +2494,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2502,7 +2553,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-34746",
@@ -2539,8 +2590,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2581,7 +2634,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2623,8 +2676,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2665,7 +2720,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2708,8 +2763,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2752,8 +2809,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2793,8 +2852,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -2853,7 +2914,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-411815",
@@ -2892,7 +2953,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "005-5341",
@@ -2930,7 +2991,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -2990,7 +3051,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3050,7 +3111,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-411927",
@@ -3089,8 +3150,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -3133,8 +3196,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -3177,8 +3242,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -3236,7 +3303,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-100545",
@@ -3273,8 +3340,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -3317,8 +3386,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -3361,7 +3432,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3409,7 +3480,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3452,8 +3523,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -3512,7 +3585,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-72191",
@@ -3551,8 +3624,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -3611,7 +3686,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-403465",
@@ -3655,7 +3730,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3703,7 +3778,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3751,7 +3826,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3792,7 +3867,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3839,7 +3914,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3882,7 +3957,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -3941,7 +4016,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-36369",
@@ -3978,8 +4053,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -4038,7 +4115,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-48030",
@@ -4077,8 +4154,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -4121,8 +4200,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -4170,7 +4251,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -4213,7 +4294,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -4256,8 +4337,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -4299,7 +4382,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -4340,7 +4423,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -4382,8 +4465,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -4426,8 +4511,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "CB"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "notes": "Details awaited",
         "sources": [
@@ -4472,7 +4559,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -4512,8 +4599,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -4556,8 +4645,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -4600,8 +4691,10 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "TR"
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
         },
         "sources": [
             {
@@ -4649,7 +4742,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "sources": [
             {
@@ -4708,7 +4801,7 @@
             }
         ],
         "revisionMetadata": {
-            "id": 0
+            "revisionNumber": 0
         },
         "importedCase": {
             "ID": "007-72165",

--- a/data-serving/scripts/convert-data/README.md
+++ b/data-serving/scripts/convert-data/README.md
@@ -56,7 +56,7 @@ The following fields are *not* lossy, although they require conversion to a new 
 - Clean up the source data in the case of obvious errors in the logs, e.g. ages in the thousands or dates with one too
   many or too few digits.
 
-- Use Sheets or GitHub history to infer `revision.date`.
+- Use Sheets or GitHub history to infer `revisionMetadata.date`.
 
 - De-duplicate events populated from the original outcome field with the others; ex. in some cases we have
   `events[name="deathOrDischarge"]`, from the `date_death_or_discharge` field, plus `events[name="death"]`
@@ -117,8 +117,8 @@ Fields that are not carrying over to the new schema, though they will be include
 
 We are backfilling fields including:
 
-- `revision.id`: We are treating each record as if it's on its first revision. It would be extremely labor-intensive to
-  reconstruct revision history from the source data, but it will baked into the new system.
+- `revisionMetadata.revisionNumber`: We are treating each record as if it's on its first revision. It would be extremely
+  labor-intensive to reconstruct revision history from the source data, but it will baked into the new system.
 
 > **Open question:** Do we want to backfill data or leave those fields empty for imported data?
 

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -333,11 +333,13 @@ def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[
         }
     '''
     revision_metadata = {
-        'id': 0
+        'revisionNumber': 0
     }
 
     if data_moderator_initials:
-        revision_metadata['moderator'] = str(data_moderator_initials)
+        revision_metadata['creationMetadata'] = {
+            'curator': str(data_moderator_initials)
+        }
 
     return revision_metadata
 

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -72,9 +72,11 @@ def parse_cases(raw_data_file):
         return [
             {
                 "revisionMetadata": {
-                    "id": 0,
-                    "moderator": "auto",
-                    "date": date.today().strftime("%m/%d/%Y")
+                    "revisionNumber": 0,
+                    "creationMetadata": {
+                        "curator": "auto",
+                        "date": date.today().strftime("%m/%d/%Y")
+                    }
                 },
                 "sources": [
                     {

--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -12,9 +12,11 @@ from unittest.mock import MagicMock
 _PARSED_CASE = (
     {
         "revisionMetadata": {
-            "id": 0,
-            "moderator": "auto",
-            "date": date.today().strftime("%m/%d/%Y")
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "auto",
+                "date": date.today().strftime("%m/%d/%Y")
+            }
         },
         "sources": [
             {

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -39,9 +39,11 @@ export function addCase(
                 },
             ],
             revisionMetadata: {
-                date: new Date().toJSON(),
-                id: 0,
-                moderator: 'test',
+                revisionNumber: 0,
+                creationMetadata: {
+                    curator: 'test',
+                    date: new Date().toJSON(),
+                }
             },
         },
     });

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -125,11 +125,11 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                 },
             ],
             revisionMetadata: {
-                date: new Date().toISOString(),
-                // TODO: change this id value. The current field is required to
-                // be an int, which we'll want to change in the finalized schema.
-                id: 0,
-                moderator: this.props.user.email,
+                revisionNumber: 0,
+                creationMetadata: {
+                    curator: this.props.user.email,
+                    date: new Date().toISOString(),
+                }
             },
         };
     }
@@ -285,7 +285,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 notes: c.notes,
                                                 sourceUrl:
                                                     c.sources &&
-                                                    c.sources.length > 0
+                                                        c.sources.length > 0
                                                         ? c.sources[0].url
                                                         : null,
                                             });

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -1,11 +1,11 @@
 import { Button, LinearProgress } from '@material-ui/core';
 import { Field, Form, Formik } from 'formik';
-import React from 'react';
 import { Select, TextField } from 'formik-material-ui';
 
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
+import React from 'react';
 import axios from 'axios';
 
 interface User {
@@ -34,7 +34,7 @@ interface FormValues {
 export default class NewCaseForm extends React.Component<
     Props,
     NewCaseFormState
-> {
+    > {
     constructor(props: Props) {
         super(props);
         this.state = {
@@ -64,9 +64,11 @@ export default class NewCaseForm extends React.Component<
                 ],
                 notes: values.notes,
                 revisionMetadata: {
-                    id: 0,
-                    moderator: this.props.user.email,
-                    date: new Date().toISOString(),
+                    revisionNumber: 0,
+                    creationMetadata: {
+                        curator: this.props.user.email,
+                        date: new Date().toISOString(),
+                    }
                 },
             });
             this.setState({ errorMessage: '' });


### PR DESCRIPTION
Would like your feedback on this one. This is my interpretation of the flat list of fields: 

`
RevisionData | Date of creation | Date | ISO 8601
-- | -- | -- | --
RevisionData | Created by | String | Curator username
RevisionData | Date of edit | Date | ISO 8601
RevisionData | Edit made by | String | Curator username
RevisionData | Edit details | Text | None
`

It seems like we want the current version of the case to show original creation metadata (date/curator/notes) -- but also show the latest edit, if any. I think those two are sub-documents that share a schema.

I also took this opportunity to s/id/revisionNumber to be clearer, and s/moderator/curator, since I pretty much only hear the latter term used.