### PR TITLE
handle empty names and display email

### DIFF
--- a/verification/curator-service/ui/src/components/Users.test.tsx
+++ b/verification/curator-service/ui/src/components/Users.test.tsx
@@ -1,6 +1,7 @@
-import Users from './Users';
+import { fireEvent, render, within } from '@testing-library/react';
+
 import React from 'react';
-import { render, fireEvent, within } from '@testing-library/react';
+import Users from './Users';
 import axios from 'axios';
 
 jest.mock('axios');
@@ -37,7 +38,7 @@ test('lists users', async () => {
         },
         {
             _id: 'abc321',
-            name: 'Bob Smith',
+            name: '',
             email: 'foo2@bar.com',
             roles: ['curator'],
         },
@@ -58,7 +59,9 @@ test('lists users', async () => {
         <Users user={emptyUser} onUserChange={() => {}} />,
     );
     expect(await findByText('Alice Smith')).toBeInTheDocument();
-    expect(await findByText('Bob Smith')).toBeInTheDocument();
+    expect(await findByText('foo@bar.com')).toBeInTheDocument();
+    expect(await findByText('Name not provided')).toBeInTheDocument();
+    expect(await findByText('foo2@bar.com')).toBeInTheDocument();
     expect(queryByText('Carol Smith')).not.toBeInTheDocument();
     expect(mockedAxios.get).toHaveBeenCalledWith('/api/users/');
 });

--- a/verification/curator-service/ui/src/components/Users.tsx
+++ b/verification/curator-service/ui/src/components/Users.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import axios from 'axios';
-import { createStyles, WithStyles, withStyles } from '@material-ui/core';
-import Select from '@material-ui/core/Select';
-import MenuItem from '@material-ui/core/MenuItem';
+import { WithStyles, createStyles, withStyles } from '@material-ui/core';
+
 import Chip from '@material-ui/core/Chip';
 import FormControl from '@material-ui/core/FormControl';
+import MenuItem from '@material-ui/core/MenuItem';
+import React from 'react';
+import Select from '@material-ui/core/Select';
+import axios from 'axios';
 
 interface ListResponse {
     users: User[];
@@ -113,7 +114,8 @@ class Users extends React.Component<Props, UsersState> {
                 <table className={classes.table}>
                     <thead>
                         <tr>
-                            <th className={classes.headerCell}>User</th>
+                            <th className={classes.headerCell}>Name</th>
+                            <th className={classes.headerCell}>Email</th>
                             <th className={classes.headerCell}>Roles</th>
                         </tr>
                     </thead>
@@ -124,7 +126,13 @@ class Users extends React.Component<Props, UsersState> {
                                     className={classes.cell}
                                     data-testid={user.name}
                                 >
-                                    {user.name}
+                                    {user.name || 'Name not provided'}
+                                </th>
+                                <th
+                                    className={classes.cell}
+                                    data-testid={user.email}
+                                >
+                                    {user.email}
                                 </th>
                                 <th
                                     className={classes.cell}


### PR DESCRIPTION
Some users (ingestion lambda API users for example) have no public name, show emails in the users list to help identify all users.

![image](https://user-images.githubusercontent.com/1255432/84489916-b46dde00-aca2-11ea-8d16-260b0b748ea2.png)
