### PR TITLE
Configure resource-based policy for Lambdas in update operations

### DIFF
--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -2,12 +2,10 @@ import { Request, Response } from 'express';
 import { Source, SourceDocument } from '../model/source';
 
 import AwsEventsClient from '../clients/aws-events-client';
-import AwsLambdaClient from '../clients/aws-lambda-client';
 
 export default class SourcesController {
     constructor(
         private readonly awsEventsClient: AwsEventsClient,
-        private readonly awsLambdaClient: AwsLambdaClient,
         private readonly retrievalFunctionArn: string,
     ) {}
 
@@ -178,11 +176,6 @@ export default class SourcesController {
                 source._id.toString(),
             );
             source.set('automation.schedule.awsRuleArn', createdRuleArn);
-            await this.awsLambdaClient.addInvokeFromEventPermission(
-                createdRuleArn,
-                this.retrievalFunctionArn,
-                source.toAwsRuleName(),
-            );
         }
     }
 

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -88,8 +88,11 @@ app.use(passport.session());
 app.use('/auth', authController.router);
 
 // Configure connection to AWS services.
-const awsEventsClient = new AwsEventsClient(env.AWS_SERVICE_REGION);
 const awsLambdaClient = new AwsLambdaClient(env.AWS_SERVICE_REGION);
+const awsEventsClient = new AwsEventsClient(
+    env.AWS_SERVICE_REGION,
+    awsLambdaClient,
+);
 
 // Configure curator API routes.
 const apiRouter = express.Router();
@@ -97,7 +100,6 @@ const apiRouter = express.Router();
 // Configure sources controller.
 const sourcesController = new SourcesController(
     awsEventsClient,
-    awsLambdaClient,
     env.GLOBAL_RETRIEVAL_FUNCTION_ARN,
 );
 apiRouter.get(


### PR DESCRIPTION
Moved the `AddPermission` invocation from the sources controller to the CloudWatch Events client, which covers us for update operations now, in addition to creations. Needing the permission is a result of creating the target -- so it's cleaner to make this call here. Keeping the `AwsLambdaClient` separate, because it's still a helpful abstraction and I'm anticipating calling it directly in a future PR.