### PR TITLE
Remove resourced-based policy permissions in source API delete operations

### DIFF
--- a/verification/curator-service/api/src/clients/aws-events-client.ts
+++ b/verification/curator-service/api/src/clients/aws-events-client.ts
@@ -99,16 +99,14 @@ export default class AwsEventsClient {
         sourceId: string,
     ): Promise<void> => {
         try {
-            if (targetId) {
-                const removeTargetsParams = {
-                    Rule: ruleName,
-                    Ids: [targetId],
-                };
-                await this.cloudWatchEventsClient
-                    .removeTargets(removeTargetsParams)
-                    .promise();
-                await this.lambdaClient.removePermission(targetArn, sourceId);
-            }
+            const removeTargetsParams = {
+                Rule: ruleName,
+                Ids: [targetId],
+            };
+            await this.cloudWatchEventsClient
+                .removeTargets(removeTargetsParams)
+                .promise();
+            await this.lambdaClient.removePermission(targetArn, sourceId);
             const deleteRuleParams = { Name: ruleName };
             await this.cloudWatchEventsClient
                 .deleteRule(deleteRuleParams)

--- a/verification/curator-service/api/src/clients/aws-events-client.ts
+++ b/verification/curator-service/api/src/clients/aws-events-client.ts
@@ -40,6 +40,7 @@ export default class AwsEventsClient {
         targetArn?: string,
         targetId?: string,
         sourceId?: string,
+        statementId?: string,
     ): Promise<string> => {
         try {
             const putRuleParams = {
@@ -54,7 +55,7 @@ export default class AwsEventsClient {
                 response.RuleArn,
                 'AWS PutRule response missing RuleArn.',
             );
-            if (targetArn && targetId && sourceId) {
+            if (targetArn && targetId && sourceId && statementId) {
                 const putTargetsParams = {
                     Rule: ruleName,
                     Targets: [
@@ -71,7 +72,7 @@ export default class AwsEventsClient {
                 await this.lambdaClient.addInvokeFromEventPermission(
                     response.RuleArn,
                     targetArn,
-                    sourceId,
+                    statementId,
                 );
             }
             return response.RuleArn;
@@ -91,7 +92,12 @@ export default class AwsEventsClient {
      * For the full API definition, see:
      *   https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteRule.html
      */
-    deleteRule = async (ruleName: string, targetId?: string): Promise<void> => {
+    deleteRule = async (
+        ruleName: string,
+        targetId: string,
+        targetArn: string,
+        sourceId: string,
+    ): Promise<void> => {
         try {
             if (targetId) {
                 const removeTargetsParams = {
@@ -101,6 +107,7 @@ export default class AwsEventsClient {
                 await this.cloudWatchEventsClient
                     .removeTargets(removeTargetsParams)
                     .promise();
+                await this.lambdaClient.removePermission(targetArn, sourceId);
             }
             const deleteRuleParams = { Name: ruleName };
             await this.cloudWatchEventsClient

--- a/verification/curator-service/api/src/clients/aws-lambda-client.ts
+++ b/verification/curator-service/api/src/clients/aws-lambda-client.ts
@@ -1,5 +1,9 @@
+import {
+    AddPermissionRequest,
+    RemovePermissionRequest,
+} from 'aws-sdk/clients/lambda';
+
 import AWS from 'aws-sdk';
-import { AddPermissionRequest } from 'aws-sdk/clients/lambda';
 import assertString from '../util/assert-string';
 
 /**
@@ -47,5 +51,18 @@ export default class AwsLambdaClient {
             'AWS AddPermission response missing Statement.',
         );
         return response.Statement;
+    };
+
+    removePermission = async (
+        functionArn: string,
+        statementId: string,
+    ): Promise<void> => {
+        const removePermissionParams: RemovePermissionRequest = {
+            FunctionName: functionArn,
+            StatementId: statementId,
+        };
+        await this.lambdaClient
+            .removePermission(removePermissionParams)
+            .promise();
     };
 }

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -115,12 +115,15 @@ export default class SourcesController {
                     this.retrievalFunctionArn,
                     source.toAwsRuleTargetId(),
                     source._id.toString(),
+                    source.toAwsStatementId(),
                 );
                 source.set('automation.schedule.awsRuleArn', awsRuleArn);
             } else {
                 await this.awsEventsClient.deleteRule(
                     source.toAwsRuleName(),
                     source.toAwsRuleTargetId(),
+                    this.retrievalFunctionArn,
+                    source.toAwsStatementId(),
                 );
                 source.set('automation.schedule', undefined);
             }
@@ -174,6 +177,7 @@ export default class SourcesController {
                 this.retrievalFunctionArn,
                 source.toAwsRuleTargetId(),
                 source._id.toString(),
+                source.toAwsStatementId(),
             );
             source.set('automation.schedule.awsRuleArn', createdRuleArn);
         }
@@ -192,6 +196,8 @@ export default class SourcesController {
             await this.awsEventsClient.deleteRule(
                 source.toAwsRuleName(),
                 source.toAwsRuleTargetId(),
+                this.retrievalFunctionArn,
+                source.toAwsStatementId(),
             );
         }
         source.remove();

--- a/verification/curator-service/api/src/model/source.ts
+++ b/verification/curator-service/api/src/model/source.ts
@@ -23,6 +23,9 @@ const sourceSchema = new mongoose.Schema({
     },
 });
 
+sourceSchema.methods.toAwsStatementId = function (): string {
+    return this._id.toString();
+};
 sourceSchema.methods.toAwsRuleDescription = function (): string {
     return `Scheduled ingestion rule for source: ${this.name}`;
 };
@@ -42,6 +45,7 @@ export type SourceDocument = mongoose.Document & {
     format: string;
     automation: AutomationDocument;
 
+    toAwsStatementId(): string;
     toAwsRuleDescription(): string;
     toAwsRuleName(): string;
     toAwsRuleTargetId(): string;

--- a/verification/curator-service/api/test/model/source.test.ts
+++ b/verification/curator-service/api/test/model/source.test.ts
@@ -23,6 +23,10 @@ describe('validate', () => {
 });
 
 describe('custom instance methods', () => {
+    it('toAwsStatementId returns formatted source ID', () => {
+        const s = new Source(minimalSource);
+        expect(s.toAwsStatementId()).toContain(s._id);
+    });
     it('toAwsRuleDescription returns formatted source name', () => {
         const s = new Source(minimalSource);
         expect(s.toAwsRuleDescription()).toContain(s.name);

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -176,6 +176,7 @@ describe('PUT', () => {
             expect.any(String),
             source.toAwsRuleTargetId(),
             source._id.toString(),
+            source.toAwsStatementId(),
         );
     });
     it('should update AWS rule description on source rename', async () => {
@@ -257,6 +258,7 @@ describe('POST', () => {
             expect.any(String),
             createdSource.toAwsRuleTargetId(),
             createdSource._id.toString(),
+            createdSource.toAwsStatementId(),
         );
     });
     it('should not create invalid source', async () => {
@@ -274,7 +276,7 @@ describe('DELETE', () => {
         await curatorRequest.delete(`/api/sources/${source.id}`).expect(204);
         expect(mockDeleteRule).not.toHaveBeenCalled();
     });
-    it('should delete corresponding AWS rule and target if source contains ruleArn', async () => {
+    it('should delete corresponding AWS rule (et al.) if source contains ruleArn', async () => {
         const source = await new Source({
             name: 'test-source',
             origin: { url: 'http://foo.bar' },
@@ -289,6 +291,8 @@ describe('DELETE', () => {
         expect(mockDeleteRule).toHaveBeenCalledWith(
             source.toAwsRuleName(),
             source.toAwsRuleTargetId(),
+            expect.any(String),
+            source.toAwsStatementId(),
         );
     });
     it('should not be able to delete a non existent source', (done) => {


### PR DESCRIPTION
Based on #270 -- diff here is from the 3rd commit onwards.