### PR TITLE
Bring location schema in line with spec

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -82,7 +82,7 @@
               "Admin3",
               "Admin2",
               "Admin1",
-              "Admin0"
+              "Country"
             ]
           },
           "geometry": {
@@ -225,7 +225,7 @@
                     "Admin3",
                     "Admin2",
                     "Admin1",
-                    "Admin0"
+                    "Country"
                   ]
                 },
                 "geometry": {

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -76,6 +76,9 @@
           "place": {
             "bsonType": "string"
           },
+          "name": {
+            "bsonType": "string"
+          },
           "geoResolution": {
             "enum": [
               "Point",
@@ -217,6 +220,9 @@
                   "bsonType": "string"
                 },
                 "place": {
+                  "bsonType": "string"
+                },
+                "name": {
                   "bsonType": "string"
                 },
                 "geoResolution": {

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -61,9 +61,6 @@
           "_id": {
             "bsonType": "objectId"
           },
-          "id": {
-            "bsonType": "string"
-          },
           "country": {
             "bsonType": "string"
           },
@@ -73,8 +70,20 @@
           "administrativeAreaLevel2": {
             "bsonType": "string"
           },
-          "locality": {
+          "administrativeAreaLevel3": {
             "bsonType": "string"
+          },
+          "place": {
+            "bsonType": "string"
+          },
+          "geoResolution": {
+            "enum": [
+              "Point",
+              "Admin3",
+              "Admin2",
+              "Admin1",
+              "Admin0"
+            ]
           },
           "geometry": {
             "bsonType": "object",
@@ -195,9 +204,6 @@
                 "_id": {
                   "bsonType": "objectId"
                 },
-                "id": {
-                  "bsonType": "string"
-                },
                 "country": {
                   "bsonType": "string"
                 },
@@ -207,8 +213,20 @@
                 "administrativeAreaLevel2": {
                   "bsonType": "string"
                 },
-                "locality": {
+                "administrativeAreaLevel3": {
                   "bsonType": "string"
+                },
+                "place": {
+                  "bsonType": "string"
+                },
+                "geoResolution": {
+                  "enum": [
+                    "Point",
+                    "Admin3",
+                    "Admin2",
+                    "Admin1",
+                    "Admin0"
+                  ]
                 },
                 "geometry": {
                   "bsonType": "object",
@@ -389,7 +407,13 @@
           "ID": {
             "bsonType": "string"
           },
+          "city": {
+            "bsonType": "string"
+          },
           "province": {
+            "bsonType": "string"
+          },
+          "country": {
             "bsonType": "string"
           },
           "geo_resolution": {
@@ -420,12 +444,6 @@
             "bsonType": "string"
           },
           "location": {
-            "bsonType": "string"
-          },
-          "admin3": {
-            "bsonType": "string"
-          },
-          "country_new": {
             "bsonType": "string"
           },
           "admin_id": {

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -1,11 +1,13 @@
 import mongoose from 'mongoose';
 
+// See https://en.wikipedia.org/wiki/List_of_administrative_divisions_by_country
+// for an explanation of each level of resolution.
 export enum GeoResolution {
-    Point = 'Point', // Lat/long coordinates
-    Admin3 = 'Admin3', // ~City
-    Admin2 = 'Admin2', // ~County
-    Admin1 = 'Admin1', // ~Province
-    Admin0 = 'Admin0', // Country
+    Point = 'Point',
+    Admin3 = 'Admin3',
+    Admin2 = 'Admin2',
+    Admin1 = 'Admin1',
+    Admin0 = 'Admin0',
 }
 
 const fieldRequiredValidator = [

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -1,5 +1,13 @@
 import mongoose from 'mongoose';
 
+export enum GeoResolution {
+    Point = 'Point', // Lat/long coordinates
+    Admin3 = 'Admin3', // ~City
+    Admin2 = 'Admin2', // ~County
+    Admin1 = 'Admin1', // ~Province
+    Admin0 = 'Admin0', // Country
+}
+
 const fieldRequiredValidator = [
     function (this: LocationDocument): boolean {
         return (
@@ -7,15 +15,15 @@ const fieldRequiredValidator = [
             this.country == null &&
             this.administrativeAreaLevel1 == null &&
             this.administrativeAreaLevel2 == null &&
-            this.locality == null
+            this.administrativeAreaLevel3 == null &&
+            this.place == null
         );
     },
     'One of country, administrativeAreaLevel1, administrativeAreaLevel2, ' +
-        'or locality is required',
+        'administrativeAreaLevel3, or place is required',
 ];
 
 export const locationSchema = new mongoose.Schema({
-    id: String,
     country: {
         type: String,
         required: fieldRequiredValidator,
@@ -28,9 +36,18 @@ export const locationSchema = new mongoose.Schema({
         type: String,
         required: fieldRequiredValidator,
     },
-    locality: {
+    administrativeAreaLevel3: {
         type: String,
         required: fieldRequiredValidator,
+    },
+    place: {
+        type: String,
+        required: fieldRequiredValidator,
+    },
+    geoResolution: {
+        type: String,
+        enum: Object.values(GeoResolution),
+        required: true,
     },
     geometry: {
         latitude: {
@@ -70,10 +87,11 @@ interface Geometry {
 }
 
 export type LocationDocument = mongoose.Document & {
-    id: string;
     country: string;
     administrativeAreaLevel1: string;
     administrativeAreaLevel2: string;
-    locality: string;
+    administrativeAreaLevel3: string;
+    place: string;
+    geoResolution: GeoResolution;
     geometry: Geometry;
 };

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -7,7 +7,7 @@ export enum GeoResolution {
     Admin3 = 'Admin3',
     Admin2 = 'Admin2',
     Admin1 = 'Admin1',
-    Admin0 = 'Admin0',
+    Country = 'Country',
 }
 
 const fieldRequiredValidator = [

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -17,12 +17,11 @@ const fieldRequiredValidator = [
             this.country == null &&
             this.administrativeAreaLevel1 == null &&
             this.administrativeAreaLevel2 == null &&
-            this.administrativeAreaLevel3 == null &&
-            this.place == null
+            this.administrativeAreaLevel3 == null
         );
     },
     'One of country, administrativeAreaLevel1, administrativeAreaLevel2, ' +
-        'administrativeAreaLevel3, or place is required',
+        'or administrativeAreaLevel3 is required',
 ];
 
 export const locationSchema = new mongoose.Schema({
@@ -42,10 +41,7 @@ export const locationSchema = new mongoose.Schema({
         type: String,
         required: fieldRequiredValidator,
     },
-    place: {
-        type: String,
-        required: fieldRequiredValidator,
-    },
+    place: String,
     geoResolution: {
         type: String,
         enum: Object.values(GeoResolution),

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -41,7 +41,10 @@ export const locationSchema = new mongoose.Schema({
         type: String,
         required: fieldRequiredValidator,
     },
+    // Place represents a precise location, such as an establishment or POI.
     place: String,
+    // A human-readable name of the location.
+    name: String,
     geoResolution: {
         type: String,
         enum: Object.values(GeoResolution),
@@ -90,6 +93,7 @@ export type LocationDocument = mongoose.Document & {
     administrativeAreaLevel2: string;
     administrativeAreaLevel3: string;
     place: string;
+    name: string;
     geoResolution: GeoResolution;
     geometry: Geometry;
 };

--- a/data-serving/data-service/src/model/revision-metadata.ts
+++ b/data-serving/data-service/src/model/revision-metadata.ts
@@ -30,8 +30,8 @@ export const revisionMetadataSchema = new mongoose.Schema({
     updateMetadata: {
         type: editMetadataSchema,
         required: function (this: RevisionMetadataDocument): boolean {
-                return this.revisionNumber > 0;
-            },
+            return this.revisionNumber > 0;
+        },
     },
 });
 

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -10,11 +10,10 @@
         "ethnicity": "Other"
     },
     "location": {
-        "id": "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",
         "country": "France",
         "administrativeAreaLevel1": "Île-de-France",
         "administrativeAreaLevel2": "Paris",
-        "locality": "Paris",
+        "geoResolution": "Admin2",
         "geometry": {
             "latitude": 2.3522219,
             "longitude": 48.85661400000001
@@ -84,10 +83,11 @@
     "travelHistory": [
         {
             "location": {
-                "id": "ChIJb_KF3fiuLjQRECJYbKzJwjk",
                 "country": "China",
                 "administrativeAreaLevel1": "Hubei",
-                "locality": "Wuhan",
+                "administrativeAreaLevel2": "Wuhan City",
+                "administrativeAreaLevel3": "Wuchang District",
+                "geoResolution": "Admin3",
                 "geometry": {
                     "latitude": 30.592849,
                     "longitude": 114.305539

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -13,6 +13,7 @@
         "country": "France",
         "administrativeAreaLevel1": "Île-de-France",
         "administrativeAreaLevel2": "Paris",
+        "name": "Wuhan",
         "geoResolution": "Admin2",
         "geometry": {
             "latitude": 2.3522219,
@@ -87,6 +88,7 @@
                 "administrativeAreaLevel1": "Hubei",
                 "administrativeAreaLevel2": "Wuhan City",
                 "administrativeAreaLevel3": "Wuchang District",
+                "name": "Wuhan",
                 "geoResolution": "Admin3",
                 "geometry": {
                     "latitude": 30.592849,

--- a/data-serving/data-service/test/model/data/case.minimal.json
+++ b/data-serving/data-service/test/model/data/case.minimal.json
@@ -21,6 +21,7 @@
         }
     },
     "location": {
-        "country": "China"
+        "country": "China",
+        "geoResolution": "Admin0"
     }
 }

--- a/data-serving/data-service/test/model/data/case.minimal.json
+++ b/data-serving/data-service/test/model/data/case.minimal.json
@@ -22,6 +22,6 @@
     },
     "location": {
         "country": "China",
-        "geoResolution": "Admin0"
+        "geoResolution": "Country"
     }
 }

--- a/data-serving/data-service/test/model/data/location.full.json
+++ b/data-serving/data-service/test/model/data/location.full.json
@@ -5,6 +5,7 @@
     "administrativeAreaLevel3": "Brooklyn",
     "place": "Kings County Hospital Center",
     "geoResolution": "Point",
+    "name": "Kings County Hospital Center",
     "geometry": {
         "latitude": 40.6809611,
         "longitude": -73.9740028

--- a/data-serving/data-service/test/model/data/location.full.json
+++ b/data-serving/data-service/test/model/data/location.full.json
@@ -1,11 +1,12 @@
 {
-    "id": "abc",
     "country": "United States",
     "administrativeAreaLevel1": "New York",
     "administrativeAreaLevel2": "Kings County",
-    "locality": "Brooklyn",
+    "administrativeAreaLevel3": "Brooklyn",
+    "place": "Kings County Hospital Center",
+    "geoResolution": "Point",
     "geometry": {
-        "latitude": 40.6,
-        "longitude": -73.9
+        "latitude": 40.6809611,
+        "longitude": -73.9740028
     }
 }

--- a/data-serving/data-service/test/model/data/location.minimal.json
+++ b/data-serving/data-service/test/model/data/location.minimal.json
@@ -1,3 +1,4 @@
 {
-    "locality": "Brooklyn"
+    "place": "Kings County Hospital Center",
+    "geo_resolution": "Point"
 }

--- a/data-serving/data-service/test/model/data/travel.full.json
+++ b/data-serving/data-service/test/model/data/travel.full.json
@@ -5,6 +5,7 @@
         "administrativeAreaLevel2": "Kings County",
         "administrativeAreaLevel3": "Brooklyn",
         "place": "Kings County Hospital Center",
+        "name": "Kings County Hospital Center",
         "geoResolution": "Point",
         "geometry": {
             "latitude": 40.6809611,

--- a/data-serving/data-service/test/model/data/travel.full.json
+++ b/data-serving/data-service/test/model/data/travel.full.json
@@ -1,13 +1,14 @@
 {
     "location": {
-        "id": "abc",
         "country": "United States",
         "administrativeAreaLevel1": "New York",
         "administrativeAreaLevel2": "Kings County",
-        "locality": "Brooklyn",
+        "administrativeAreaLevel3": "Brooklyn",
+        "place": "Kings County Hospital Center",
+        "geoResolution": "Point",
         "geometry": {
-            "latitude": 40.6,
-            "longitude": -73.9
+            "latitude": 40.6809611,
+            "longitude": -73.9740028
         }
     },
     "dateRange": {

--- a/data-serving/data-service/test/model/location.test.ts
+++ b/data-serving/data-service/test/model/location.test.ts
@@ -23,7 +23,7 @@ describe('validate', () => {
     it('a location with only country is valid', async () => {
         return new Location({
             country: 'United States',
-            geoResolution: 'Admin0',
+            geoResolution: 'Country',
         }).validate();
     });
 

--- a/data-serving/data-service/test/model/location.test.ts
+++ b/data-serving/data-service/test/model/location.test.ts
@@ -48,13 +48,6 @@ describe('validate', () => {
         }).validate();
     });
 
-    it('a location with only place is valid', async () => {
-        return new Location({
-            place: 'Kings County Hospital Center',
-            geoResolution: 'Point',
-        }).validate();
-    });
-
     it('a latitude without a longitude is invalid', async () => {
         return new Location({
             ...minimalModel,

--- a/data-serving/data-service/test/model/location.test.ts
+++ b/data-serving/data-service/test/model/location.test.ts
@@ -14,24 +14,45 @@ describe('validate', () => {
         });
     });
 
+    it('a location without a geo resolution is invalid', async () => {
+        return new Location({ country: 'United States' }).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
     it('a location with only country is valid', async () => {
-        return new Location({ country: 'United States' }).validate();
+        return new Location({
+            country: 'United States',
+            geoResolution: 'Admin0',
+        }).validate();
     });
 
     it('a location with only administrativeAreaLevel1 is valid', async () => {
         return new Location({
             administrativeAreaLevel1: 'New York',
+            geoResolution: 'Admin1',
         }).validate();
     });
 
     it('a location with only administrativeAreaLevel2 is valid', async () => {
         return new Location({
             administrativeAreaLevel2: 'Kings County',
+            geoResolution: 'Admin2',
         }).validate();
     });
 
-    it('a location with only locality is valid', async () => {
-        return new Location({ locality: 'Brooklyn' }).validate();
+    it('a location with only administrativeAreaLevel3 is valid', async () => {
+        return new Location({
+            administrativeAreaLevel3: 'Brooklyn',
+            geoResolution: 'Admin3',
+        }).validate();
+    });
+
+    it('a location with only place is valid', async () => {
+        return new Location({
+            place: 'Kings County Hospital Center',
+            geoResolution: 'Point',
+        }).validate();
     });
 
     it('a latitude without a longitude is invalid', async () => {

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -15,11 +15,11 @@
             "ethnicity": "Other"
         },
         "location": {
-            "id": "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",
             "country": "France",
             "administrativeAreaLevel1": "Île-de-France",
             "administrativeAreaLevel2": "Paris",
-            "locality": "Paris",
+            "administrativeAreaLevel3": "Paris",
+            "geoResolution": "Admin3",
             "geometry": {
                 "latitude": {
                     "$numberDouble": "2.3522219"
@@ -125,10 +125,10 @@
         "travelHistory": [
             {
                 "location": {
-                    "id": "ChIJb_KF3fiuLjQRECJYbKzJwjk",
                     "country": "China",
                     "administrativeAreaLevel1": "Hubei",
-                    "locality": "Wuhan",
+                    "administrativeAreaLevel2": "Wuhan City",
+                    "geoResolution": "Admin2",
                     "geometry": {
                         "latitude": {
                             "$numberDouble": "30.592849"
@@ -208,2417 +208,13 @@
     },
     {
         "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Toscana",
-            "administrativeAreaLevel2": "Arezzo",
-            "locality": "Arezzo",
-            "geometry": {
-                "latitude": 43.53554000000001,
-                "longitude": 11.85784
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-31T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-31T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200331.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-240664",
-            "province": "Toscana",
-            "geo_resolution": "admin2",
-            "date_confirmation": "31.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "1217.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "New York",
-            "administrativeAreaLevel2": "Nassau County",
-            "locality": "Nassau County",
-            "geometry": {
-                "latitude": 40.7399465,
-                "longitude": -73.588254
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-20T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-20T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
-            }
-        ],
-        "importedCase": {
-            "ID": "006-14962",
-            "province": "New York",
-            "geo_resolution": "admin2",
-            "date_confirmation": "20.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "6494.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 15.0,
-                "end": 34.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Straubing-Bogen",
-            "geometry": {
-                "latitude": 48.986026710000026,
-                "longitude": 12.686403735000054
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-29T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-29T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-96587",
-            "province": "Bayern",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "29.03.2020",
-            "date_confirmation": "02.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11901.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "New York",
-            "locality": "New York City",
-            "geometry": {
-                "latitude": 40.661,
-                "longitude": -73.944
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
-            }
-        ],
-        "importedCase": {
-            "ID": "000-1-38512",
-            "province": "New York",
-            "geo_resolution": "point",
-            "date_confirmation": "19.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "6555.0"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 15.0,
-                "end": 34.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "administrativeAreaLevel1": "Bremen",
-            "administrativeAreaLevel2": "Bremen",
-            "locality": "Bremen",
-            "geometry": {
-                "latitude": 53.1198,
-                "longitude": 8.780351
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-22T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-22T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-19007",
-            "province": "Bremen",
-            "geo_resolution": "admin2",
-            "date_onset_symptoms": "22.03.2020",
-            "date_confirmation": "03.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "1739.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Emilia-Romagna",
-            "administrativeAreaLevel2": "Parma",
-            "locality": "Parma",
-            "geometry": {
-                "latitude": 44.67171,
-                "longitude": 10.04892
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-06T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-06T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200406.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-264998",
-            "province": "Emilia-Romagna",
-            "geo_resolution": "admin2",
-            "date_confirmation": "06.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "6911.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Lombardia",
-            "administrativeAreaLevel2": "Bergamo",
-            "locality": "Bergamo",
-            "geometry": {
-                "latitude": 45.79841,
-                "longitude": 9.79008
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200325.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-208282",
-            "province": "Lombardia",
-            "geo_resolution": "admin2",
-            "date_confirmation": "25.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "1530.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 60.0,
-                "end": 69.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Belgium",
-            "locality": "Limburg",
-            "geometry": {
-                "latitude": 50.991423310000066,
-                "longitude": 5.429156289000048
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-04T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-54854",
-            "province": "Flanders",
-            "geo_resolution": "point",
-            "date_confirmation": "04.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11422.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "New York",
-            "locality": "New York City",
-            "geometry": {
-                "latitude": 40.661,
-                "longitude": -73.944
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
-            }
-        ],
-        "importedCase": {
-            "ID": "006-27203",
-            "province": "New York",
-            "geo_resolution": "point",
-            "date_confirmation": "25.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "6555.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-360434",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "25.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Volga",
-            "administrativeAreaLevel2": "Orenburg Oblast",
-            "locality": "Orenburg Oblast",
-            "geometry": {
-                "latitude": 51.7634,
-                "longitude": 54.6188
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-19T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-19T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-4941",
-            "province": "Volga",
-            "geo_resolution": "admin2",
-            "date_confirmation": "19.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6797.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 80.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "administrativeAreaLevel1": "Hamburg",
-            "administrativeAreaLevel2": "Hamburg",
-            "locality": "Hamburg",
-            "geometry": {
-                "latitude": 53.54661,
-                "longitude": 10.02072
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-24T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-24T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://npgeo-corona-npgeo-de.hub.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0?page=4784"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-390766",
-            "province": "Hamburg",
-            "geo_resolution": "admin2",
-            "date_onset_symptoms": "24.04.2020",
-            "date_confirmation": "24.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "3952.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "New York",
-            "geometry": {
-                "latitude": 43.0140874,
-                "longitude": -75.646457
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
-            }
-        ],
-        "importedCase": {
-            "ID": "006-41295",
-            "province": "New York",
-            "geo_resolution": "admin1",
-            "date_confirmation": "27.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "658.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "locality": "Monza e della Brianza",
-            "geometry": {
-                "latitude": 45.19346451864605,
-                "longitude": 9.174283044139255
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200405.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-262746",
-            "province": "Lombardia",
-            "geo_resolution": "point",
-            "date_confirmation": "05.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "10779.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Lombardia",
-            "administrativeAreaLevel2": "Lecco",
-            "locality": "Lecco",
-            "geometry": {
-                "latitude": 45.90438,
-                "longitude": 9.387806
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-30T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-30T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200330.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-235287",
-            "province": "Lombardia",
-            "geo_resolution": "admin2",
-            "date_confirmation": "30.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "5344.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Lombardia",
-            "administrativeAreaLevel2": "Milano",
-            "locality": "Milano",
-            "geometry": {
-                "latitude": 45.46589,
-                "longitude": 9.121072
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-10T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-10T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200310.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-149918",
-            "province": "Lombardia",
-            "geo_resolution": "admin2",
-            "date_confirmation": "10.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "6195.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-06T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-06T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-482887",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "06.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Iran",
-            "administrativeAreaLevel1": "Alborz",
-            "geometry": {
-                "latitude": 35.9491,
-                "longitude": 50.8178391
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-05T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-05T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "other": "Iran Ministry of Health"
-            }
-        ],
-        "importedCase": {
-            "ID": "002-16222",
-            "province": "Alborz",
-            "geo_resolution": "admin1",
-            "date_confirmation": "05.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Iran",
-            "admin_id": "266.0",
-            "travel_history_binary": "True"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Olpe",
-            "geometry": {
-                "latitude": 51.028860000000066,
-                "longitude": 7.8469800000000305
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-43612",
-            "province": "Nordrhein-Westfalen",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "04.04.2020",
-            "date_confirmation": "04.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11782.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "China",
-            "administrativeAreaLevel1": "Jiangsu",
-            "geometry": {
-                "latitude": 32.9902,
-                "longitude": 119.4564
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-01-30T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-01-30T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://m.weibo.cn/status/4467077106746964"
-            }
-        ],
-        "importedCase": {
-            "ID": "002-4160",
-            "province": "Jiangsu",
-            "geo_resolution": "admin1",
-            "date_confirmation": "30.01.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "China",
-            "admin_id": "507.0",
-            "travel_history_binary": "True"
-        }
-    },
-    {
-        "location": {
-            "country": "South Korea",
-            "administrativeAreaLevel1": "Daegu",
-            "geometry": {
-                "latitude": 35.78134,
-                "longitude": 128.58
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-02-28T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-02-28T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "http://ncov.mohw.go.kr/tcmBoardView.do?brdId=&brdGubun=&dataGubun=&ncvContSeq=353219&contSeq=353219&board_id=&gubun=ALL"
-            }
-        ],
-        "importedCase": {
-            "ID": "002-12759",
-            "province": "Daegu",
-            "geo_resolution": "admin1",
-            "date_confirmation": "28.02.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "South Korea",
-            "admin_id": "392.0",
-            "travel_history_binary": "True"
-        }
-    },
-    {
-        "location": {
-            "country": "Sweden",
-            "administrativeAreaLevel1": "Vastra Gotaland",
-            "geometry": {
-                "latitude": 58.2528,
-                "longitude": 13.0596
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-09T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-09T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://www.folkhalsomyndigheten.se/smittskydd-beredskap/utbrott/aktuella-utbrott/covid-19/bekraftade-fall-i-sverige"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-544031",
-            "province": "Vastra Gotaland",
-            "geo_resolution": "admin1",
-            "date_confirmation": "09.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Sweden",
-            "admin_id": "910.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Herford",
-            "geometry": {
-                "latitude": 52.11641000000003,
-                "longitude": 8.669290000000046
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-13T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-13T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-38568",
-            "province": "Nordrhein-Westfalen",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "13.03.2020",
-            "date_confirmation": "19.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11769.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 60.0,
-                "end": 69.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Belgium",
-            "geometry": {
-                "latitude": 50.64709000000001,
-                "longitude": 4.6585730000000005
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-85464",
-            "geo_resolution": "admin0",
-            "date_confirmation": "07.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "22.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Piemonte",
-            "administrativeAreaLevel2": "Torino",
-            "locality": "Torino",
-            "geometry": {
-                "latitude": 45.14739,
-                "longitude": 7.443546
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-12T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200412.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-290527",
-            "province": "Piemonte",
-            "geo_resolution": "admin2",
-            "date_confirmation": "12.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "8737.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Lombardia",
-            "administrativeAreaLevel2": "Bergamo",
-            "locality": "Bergamo",
-            "geometry": {
-                "latitude": 45.79841,
-                "longitude": 9.79008
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-15T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-15T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200315.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-161811",
-            "province": "Lombardia",
-            "geo_resolution": "admin2",
-            "date_confirmation": "15.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "1530.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-453849",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "03.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Siegen-Wittgenstein",
-            "geometry": {
-                "latitude": 50.93775097300005,
-                "longitude": 8.194929822000063
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-14T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-14T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-44084",
-            "province": "Nordrhein-Westfalen",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "14.03.2020",
-            "date_confirmation": "19.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11783.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Far Eastern",
-            "administrativeAreaLevel2": "Yakutia",
-            "locality": "Yakutia",
-            "geometry": {
-                "latitude": 62.0397,
-                "longitude": 129.7422
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-30T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-30T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-431122",
-            "province": "Far Eastern",
-            "geo_resolution": "admin2",
-            "date_confirmation": "30.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "9702.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 50.0,
-                "end": 59.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Belgium",
-            "locality": "Liege",
-            "geometry": {
-                "latitude": 50.645490000000045,
-                "longitude": 5.572500000000048
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-59015",
-            "province": "Wallonia",
-            "geo_resolution": "point",
-            "date_confirmation": "03.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11421.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Munchen",
-            "geometry": {
-                "latitude": 48.13641000000007,
-                "longitude": 11.577540000000054
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-18T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-18T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-18T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-18T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-412234",
-            "province": "Bayern",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "18.04.2020",
-            "date_confirmation": "18.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11873.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "New Jersey",
-            "geometry": {
-                "latitude": 40.2030102,
-                "longitude": -74.67119699999998
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://www.nj.gov/health/cd/topics/covid2019_dashboard.shtml"
-            }
-        ],
-        "importedCase": {
-            "ID": "005-12865",
-            "province": "New Jersey",
-            "geo_resolution": "admin1",
-            "date_confirmation": "21.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "655.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Volga",
-            "administrativeAreaLevel2": "Chuvashia",
-            "locality": "Chuvashia",
-            "geometry": {
-                "latitude": 55.5596,
-                "longitude": 46.9284
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-447424",
-            "province": "Volga",
-            "geo_resolution": "admin2",
-            "date_confirmation": "02.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "2285.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "California",
-            "geometry": {
-                "latitude": 37.3802002,
-                "longitude": -119.67788
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://www.mercurynews.com/2020/03/20/map-coronavirus-cases-in-california-by-county/"
-            }
-        ],
-        "importedCase": {
-            "ID": "005-23909",
-            "province": "California",
-            "geo_resolution": "admin1",
-            "date_confirmation": "24.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "340.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Ecuador",
-            "locality": "Samborondon",
-            "geometry": {
-                "latitude": -2.0873135,
-                "longitude": -79.87281879999998
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-20T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-20T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "004-12633",
-            "province": "Guayas",
-            "geo_resolution": "admin2",
-            "date_confirmation": "20.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "10325.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-16T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-16T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-315979",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "16.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-497600",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "07.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 15.0,
-                "end": 34.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Waldeck-Frankenberg",
-            "geometry": {
-                "latitude": 51.19043169800005,
-                "longitude": 8.888739099000079
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-15T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-15T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-52178",
-            "province": "Hessen",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "07.04.2020",
-            "date_confirmation": "15.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11808.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-23T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-23T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-350595",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "23.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "South Africa",
-            "geometry": {
-                "latitude": -29.122,
-                "longitude": 25.03147
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "other": "github.com/dsfsi/covid19za"
-            }
-        ],
-        "importedCase": {
-            "ID": "001-24306",
-            "geo_resolution": "admin0",
-            "date_confirmation": "08.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "South Africa",
-            "admin_id": "207.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Emilia-Romagna",
-            "administrativeAreaLevel2": "Rimini",
-            "locality": "Rimini",
-            "geometry": {
-                "latitude": 43.97877,
-                "longitude": 12.55585
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-28T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-28T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200328.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-224061",
-            "province": "Emilia-Romagna",
-            "geo_resolution": "admin2",
-            "date_confirmation": "28.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "7548.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Iran",
-            "administrativeAreaLevel1": "Mazandaran",
-            "geometry": {
-                "latitude": 36.3777482,
-                "longitude": 52.3663753
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-02-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-02-27T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "other": "Iran Ministry of Health"
-            }
-        ],
-        "importedCase": {
-            "ID": "002-13224",
-            "province": "Mazandaran",
-            "geo_resolution": "admin1",
-            "date_confirmation": "27.02.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Iran",
-            "admin_id": "604.0",
-            "travel_history_binary": "True"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-444526",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "02.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-04T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-462073",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "04.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Piemonte",
-            "administrativeAreaLevel2": "Torino",
-            "locality": "Torino",
-            "geometry": {
-                "latitude": 45.14739,
-                "longitude": 7.443546
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-10T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-10T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200410.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-282205",
-            "province": "Piemonte",
-            "geo_resolution": "admin2",
-            "date_confirmation": "10.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "8737.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "China",
-            "administrativeAreaLevel1": "Hubei",
-            "administrativeAreaLevel2": "Wuhan City",
-            "locality": "Wuhan City",
-            "geometry": {
-                "latitude": 30.62506,
-                "longitude": 114.3421
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-02-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-02-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "http://wjw.hubei.gov.cn/fbjd/dtyw/202002/t20200209_2021930.shtml"
-            }
-        ],
-        "importedCase": {
-            "ID": "000-2-8112",
-            "province": "Hubei",
-            "geo_resolution": "admin2",
-            "date_confirmation": "08.02.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "China",
-            "admin_id": "9390.0"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Mittelsachsen",
-            "geometry": {
-                "latitude": 50.95592462600007,
-                "longitude": 13.137635153000073
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-09T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-09T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-13T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-13T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-423045",
-            "province": "Sachsen",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "09.03.2020",
-            "date_confirmation": "13.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11627.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Egypt",
-            "geometry": {
-                "latitude": 26.66796,
-                "longitude": 29.77867
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-10T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-10T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_daily_reports/"
-            },
-            {
-                "other": "daily totals confirmed on https://www.worldometers.info/coronavirus/"
-            }
-        ],
-        "importedCase": {
-            "ID": "001-27781",
-            "geo_resolution": "admin0",
-            "date_confirmation": "10.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Egypt",
-            "admin_id": "66.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "New York",
-            "locality": "New York City",
-            "geometry": {
-                "latitude": 40.661,
-                "longitude": -73.944
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
-            }
-        ],
-        "importedCase": {
-            "ID": "006-10285",
-            "province": "New York",
-            "geo_resolution": "point",
-            "date_confirmation": "21.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "6555.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "New York",
-            "administrativeAreaLevel2": "Nassau County",
-            "locality": "Nassau County",
-            "geometry": {
-                "latitude": 40.7399465,
-                "longitude": -73.588254
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
-            }
-        ],
-        "importedCase": {
-            "ID": "006-23069",
-            "province": "New York",
-            "geo_resolution": "admin2",
-            "date_confirmation": "24.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "6494.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Borken",
-            "geometry": {
-                "latitude": 51.84209000000004,
-                "longitude": 6.856130000000063
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-12T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-20T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-20T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-34746",
-            "province": "Nordrhein-Westfalen",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "12.03.2020",
-            "date_confirmation": "20.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11762.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "locality": "Volgograd Oblast",
-            "geometry": {
-                "latitude": 49.634811522000064,
-                "longitude": 44.14392145600005
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-04T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-467578",
-            "province": "South",
-            "geo_resolution": "point",
-            "date_confirmation": "04.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "10858.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Belgium",
             "administrativeAreaLevel1": "Flanders",
+            "country": "Belgium",
             "geometry": {
-                "latitude": 51.03874,
+                "latitude": 51.038740000000004,
                 "longitude": 4.240024
-            }
+            },
+            "geoResolution": "Admin1"
         },
         "events": [
             {
@@ -2642,791 +238,34 @@
             }
         ],
         "importedCase": {
-            "ID": "000-1-30888",
+            "ID": "000-1-30931",
             "province": "Flanders",
-            "geo_resolution": "admin1",
+            "country": "Belgium",
             "date_confirmation": "17.03.2020",
             "chronic_disease_binary": "False",
-            "country_new": "Belgium",
             "admin_id": "422.0"
         }
     },
     {
         "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-22T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-22T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-344793",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "22.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Sweden",
-            "administrativeAreaLevel1": "Stockholm",
-            "geometry": {
-                "latitude": 59.6025,
-                "longitude": 18.1384
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-20T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-20T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://www.folkhalsomyndigheten.se/smittskydd-beredskap/utbrott/aktuella-utbrott/covid-19/bekraftade-fall-i-sverige"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-532848",
-            "province": "Stockholm",
-            "geo_resolution": "admin1",
-            "date_confirmation": "20.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Sweden",
-            "admin_id": "845.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-24T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-354426",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "24.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "North Western",
-            "administrativeAreaLevel2": "Saint Petersburg",
-            "locality": "Saint Petersburg",
-            "geometry": {
-                "latitude": 59.9311,
-                "longitude": 30.3609
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-04T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-467173",
-            "province": "North Western",
-            "geo_resolution": "admin2",
-            "date_confirmation": "04.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "7726.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "geometry": {
-                "latitude": 40.41955000000007,
-                "longitude": -3.6919599999999377
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-23T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-23T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://en.wikipedia.org/wiki/2020_coronavirus_pandemic_in_Spain"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-41893",
-            "province": "Madrid",
-            "geo_resolution": "point",
-            "date_confirmation": "23.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Spain",
-            "admin_id": "583.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Munchen",
-            "geometry": {
-                "latitude": 48.13641000000007,
-                "longitude": 11.577540000000054
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-411815",
-            "province": "Bayern",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "24.03.2020",
-            "date_confirmation": "24.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11873.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "Michigan",
-            "administrativeAreaLevel2": "Wayne County",
-            "locality": "Wayne County",
-            "geometry": {
-                "latitude": 42.2844327,
-                "longitude": -83.287789
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-18T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-18T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "005-5341",
-            "province": "Michigan",
-            "geo_resolution": "admin2",
-            "date_confirmation": "18.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "9139.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "China",
+            "administrativeAreaLevel2": "Suizhou City",
             "administrativeAreaLevel1": "Hubei",
-            "administrativeAreaLevel2": "Huanggang City",
-            "locality": "Huanggang City",
-            "geometry": {
-                "latitude": 30.71988,
-                "longitude": 115.3378
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-02-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-02-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "http://wjw.hubei.gov.cn/fbjd/dtyw/202002/t20200204_2018742.shtml"
-            }
-        ],
-        "importedCase": {
-            "ID": "000-2-14422",
-            "province": "Hubei",
-            "geo_resolution": "admin2",
-            "date_confirmation": "03.02.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "China",
-            "admin_id": "4363.0"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 60.0,
-                "end": 79.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "administrativeAreaLevel1": "Hamburg",
-            "administrativeAreaLevel2": "Hamburg",
-            "locality": "Hamburg",
-            "geometry": {
-                "latitude": 53.54661,
-                "longitude": 10.02072
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://npgeo-corona-npgeo-de.hub.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0?page=4344"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-390526",
-            "province": "Hamburg",
-            "geo_resolution": "admin2",
-            "date_onset_symptoms": "02.04.2020",
-            "date_confirmation": "02.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "3952.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Munchen",
-            "geometry": {
-                "latitude": 48.13641000000007,
-                "longitude": 11.577540000000054
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-411927",
-            "province": "Bayern",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "27.03.2020",
-            "date_confirmation": "27.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11873.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-503169",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "08.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-06T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-06T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-486724",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "06.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "North Western",
-            "administrativeAreaLevel2": "Saint Petersburg",
-            "locality": "Saint Petersburg",
-            "geometry": {
-                "latitude": 59.9311,
-                "longitude": 30.3609
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-509378",
-            "province": "North Western",
-            "geo_resolution": "admin2",
-            "date_confirmation": "08.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "7726.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 80.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Tirschenreuth",
-            "geometry": {
-                "latitude": 49.89956103600008,
-                "longitude": 12.200041080000062
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-14T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-14T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-100545",
-            "province": "Bayern",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "14.03.2020",
-            "date_confirmation": "27.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11556.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "France",
-            "administrativeAreaLevel1": "Normandy",
-            "geometry": {
-                "latitude": 48.8799,
-                "longitude": 0.1713
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-23T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-23T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://www.santepubliquefrance.fr/maladies-et-traumatismes/maladies-et-infections-respiratoires/infection-a-coronavirus/articles/infection-au-nouveau-coronavirus-sars-cov-2-covid-19-france-et-monde"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-32545",
-            "province": "Normandy",
-            "geo_resolution": "admin1",
-            "date_confirmation": "23.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "France",
-            "admin_id": "669.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Piemonte",
-            "administrativeAreaLevel2": "Cuneo",
-            "locality": "Cuneo",
-            "geometry": {
-                "latitude": 44.47886,
-                "longitude": 7.593507000000002
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200404.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-257796",
-            "province": "Piemonte",
-            "geo_resolution": "admin2",
-            "date_confirmation": "04.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "2549.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
             "country": "China",
-            "administrativeAreaLevel1": "Hunan",
-            "administrativeAreaLevel2": "Shaoyang City",
-            "locality": "Shaoyang City",
             "geometry": {
-                "latitude": 26.91525,
-                "longitude": 110.8759
-            }
+                "latitude": 31.8296,
+                "longitude": 113.4236
+            },
+            "geoResolution": "Admin2"
         },
         "events": [
             {
                 "name": "confirmed",
                 "dateRange": {
                     "start": {
-                        "$date": "2020-02-01T00:00:00Z"
+                        "$date": "2020-02-06T00:00:00Z"
                     },
                     "end": {
-                        "$date": "2020-02-01T00:00:00Z"
+                        "$date": "2020-02-06T00:00:00Z"
                     }
                 }
             }
@@ -3436,45 +275,37 @@
         },
         "sources": [
             {
-                "url": "http://wjw.hunan.gov.cn/wjw/xxgk/gzdt/zyxw_1/202002/t20200202_11167499.html"
+                "url": "http://wjw.hubei.gov.cn/fbjd/dtyw/202002/t20200207_2020605.shtml"
             }
         ],
         "importedCase": {
-            "ID": "002-5378",
-            "province": "Hunan",
-            "geo_resolution": "admin2",
-            "date_confirmation": "01.02.2020",
+            "ID": "000-2-11904",
+            "city": "Suizhou City",
+            "province": "Hubei",
+            "country": "China",
+            "date_confirmation": "06.02.2020",
             "chronic_disease_binary": "False",
-            "country_new": "China",
-            "admin_id": "8030.0",
-            "travel_history_binary": "True"
+            "admin_id": "8400.0"
         }
     },
     {
-        "demographics": {
-            "ageRange": {
-                "start": 20.0,
-                "end": 29.0
-            },
-            "sex": "Female"
-        },
         "location": {
-            "country": "Belgium",
-            "locality": "Hainaut",
+            "country": "Egypt",
             "geometry": {
-                "latitude": 50.46958109700007,
-                "longitude": 3.9595308820000237
-            }
+                "latitude": 26.667959999999997,
+                "longitude": 29.77867
+            },
+            "geoResolution": "Country"
         },
         "events": [
             {
                 "name": "confirmed",
                 "dateRange": {
                     "start": {
-                        "$date": "2020-04-09T00:00:00Z"
+                        "$date": "2020-05-01T00:00:00Z"
                     },
                     "end": {
-                        "$date": "2020-04-09T00:00:00Z"
+                        "$date": "2020-05-01T00:00:00Z"
                     }
                 }
             }
@@ -3484,102 +315,39 @@
         },
         "sources": [
             {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-88636",
-            "province": "Wallonia",
-            "geo_resolution": "point",
-            "date_confirmation": "09.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11420.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "North Western",
-            "administrativeAreaLevel2": "Murmansk Oblast",
-            "locality": "Murmansk Oblast",
-            "geometry": {
-                "latitude": 67.8443,
-                "longitude": 35.0884
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-456578",
-            "province": "North Western",
-            "geo_resolution": "admin2",
-            "date_confirmation": "03.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6401.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Breisgau-Hochschwarzwald",
-            "geometry": {
-                "latitude": 47.924874977000066,
-                "longitude": 7.925899284000025
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-20T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-20T00:00:00Z"
-                    }
-                }
+                "url": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_daily_reports/"
             },
             {
+                "other": "daily totals confirmed on https://www.worldometers.info/coronavirus/"
+            }
+        ],
+        "importedCase": {
+            "ID": "001-13766",
+            "country": "Egypt",
+            "date_confirmation": "01.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "66.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Egypt",
+            "geometry": {
+                "latitude": 26.667959999999997,
+                "longitude": 29.77867
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
                 "name": "confirmed",
                 "dateRange": {
                     "start": {
-                        "$date": "2020-03-24T00:00:00Z"
+                        "$date": "2020-05-23T00:00:00Z"
                     },
                     "end": {
-                        "$date": "2020-03-24T00:00:00Z"
+                        "$date": "2020-05-23T00:00:00Z"
                     }
                 }
             }
@@ -3587,902 +355,20 @@
         "revisionMetadata": {
             "revisionNumber": 0
         },
-        "importedCase": {
-            "ID": "007-72191",
-            "province": "Baden-Wurttemberg",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "20.03.2020",
-            "date_confirmation": "24.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11859.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-27T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
         "sources": [
             {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-373893",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "27.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 15.0,
-                "end": 34.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Ludwigsburg",
-            "geometry": {
-                "latitude": 48.89417000000003,
-                "longitude": 9.191860000000077
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    }
-                }
+                "url": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_daily_reports/"
             },
             {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-403465",
-            "province": "Baden-Wurttemberg",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "24.03.2020",
-            "date_confirmation": "02.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11846.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 70.0,
-                "end": 79.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Belgium",
-            "locality": "Oost Vlaanderen",
-            "geometry": {
-                "latitude": 51.035848489000045,
-                "longitude": 3.8154783380000485
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
+                "other": "daily totals confirmed on https://www.worldometers.info/coronavirus/"
             }
         ],
         "importedCase": {
-            "ID": "003-71457",
-            "province": "Flanders",
-            "geo_resolution": "point",
-            "date_confirmation": "25.03.2020",
+            "ID": "001-34696",
+            "country": "Egypt",
+            "date_confirmation": "23.05.2020",
             "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11425.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 70.0,
-                "end": 79.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Belgium",
-            "locality": "Namur",
-            "geometry": {
-                "latitude": 50.465730000000065,
-                "longitude": 4.861820000000023
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-82039",
-            "province": "Wallonia",
-            "geo_resolution": "point",
-            "date_confirmation": "03.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11424.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 80.0,
-                "end": 89.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Belgium",
-            "locality": "Namur",
-            "geometry": {
-                "latitude": 50.465730000000065,
-                "longitude": 4.861820000000023
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-23T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-23T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-56985",
-            "province": "Wallonia",
-            "geo_resolution": "point",
-            "date_confirmation": "23.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11424.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "administrativeAreaLevel1": "Catalonia",
-            "geometry": {
-                "latitude": 41.80377410000001,
-                "longitude": 1.530937
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://en.wikipedia.org/wiki/2020_coronavirus_pandemic_in_Spain"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-7105",
-            "province": "Catalonia",
-            "geo_resolution": "admin1",
-            "date_confirmation": "21.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Spain",
-            "admin_id": "354.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 90.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Belgium",
-            "locality": "Brussels",
-            "geometry": {
-                "latitude": 50.844390000000026,
-                "longitude": 4.356090000000052
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-80066",
-            "province": "Brussels",
-            "geo_resolution": "point",
-            "date_confirmation": "02.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11419.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United Kingdom",
-            "administrativeAreaLevel1": "Wales",
-            "administrativeAreaLevel2": "Cardiff and Vale",
-            "locality": "Cardiff and Vale",
-            "geometry": {
-                "latitude": 51.506759,
-                "longitude": -3.190244
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://covid19-phwstatement.nhs.wales/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-47946",
-            "province": "Wales",
-            "geo_resolution": "admin2",
-            "date_confirmation": "25.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United Kingdom",
-            "admin_id": "1963.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 60.0,
-                "end": 79.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Recklinghausen",
-            "geometry": {
-                "latitude": 51.613600000000076,
-                "longitude": 7.193260000000067
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-23T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-23T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-16T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-16T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-36369",
-            "province": "Nordrhein-Westfalen",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "23.03.2020",
-            "date_confirmation": "16.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11764.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "locality": "Trieste",
-            "geometry": {
-                "latitude": 45.65757000000008,
-                "longitude": 13.772690000000068
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200319.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-176018",
-            "province": "Friuli Venezia Giulia",
-            "geo_resolution": "point",
-            "date_confirmation": "19.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "10797.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "sex": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "locality": "Main-Kinzig-Kreis",
-            "geometry": {
-                "latitude": 50.24388802900006,
-                "longitude": 9.285990463000076
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-22T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-22T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-48030",
-            "province": "Hessen",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "22.03.2020",
-            "date_confirmation": "26.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11794.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Lombardia",
-            "administrativeAreaLevel2": "Bergamo",
-            "locality": "Bergamo",
-            "geometry": {
-                "latitude": 45.79841,
-                "longitude": 9.79008
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-09T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-09T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200309.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-148228",
-            "province": "Lombardia",
-            "geo_resolution": "admin2",
-            "date_confirmation": "09.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "1530.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Abruzzo",
-            "administrativeAreaLevel2": "Teramo",
-            "locality": "Teramo",
-            "geometry": {
-                "latitude": 42.64614,
-                "longitude": 13.7265
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200326.csv"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-211673",
-            "province": "Abruzzo",
-            "geo_resolution": "admin2",
-            "date_confirmation": "26.03.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "8584.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 50.0,
-                "end": 59.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Belgium",
-            "locality": "Limburg",
-            "geometry": {
-                "latitude": 50.991423310000066,
-                "longitude": 5.429156289000048
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-86147",
-            "province": "Flanders",
-            "geo_resolution": "point",
-            "date_confirmation": "07.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11422.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United States",
-            "administrativeAreaLevel1": "Washington",
-            "administrativeAreaLevel2": "Pierce County",
-            "locality": "Pierce County",
-            "geometry": {
-                "latitude": 47.0235763,
-                "longitude": -122.10213
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-02-19T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-02-19T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://www.doh.wa.gov/Emergencies/Coronavirus"
-            }
-        ],
-        "importedCase": {
-            "ID": "005-6432",
-            "province": "Washington",
-            "geo_resolution": "admin2",
-            "date_confirmation": "19.02.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "United States",
-            "admin_id": "7026.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-494807",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "07.05.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Canada",
-            "administrativeAreaLevel1": "British Columbia",
-            "locality": "Vancouver",
-            "geometry": {
-                "latitude": 49.25,
-                "longitude": -123.1
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-19T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "http://www.bccdc.ca/about/news-stories/stories/2020/information-on-novel-coronavirus"
-            }
-        ],
-        "importedCase": {
-            "ID": "005-7081",
-            "province": "British Columbia",
-            "geo_resolution": "point",
-            "date_confirmation": "19.03.2020",
-            "chronic_disease_binary": "False",
-            "location": "Vancouver",
-            "country_new": "Canada",
-            "admin_id": "8912.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "South Africa",
-            "geometry": {
-                "latitude": -29.122,
-                "longitude": 25.03147
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-27T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "other": "github.com/dsfsi/covid19za"
-            }
-        ],
-        "importedCase": {
-            "ID": "001-20428",
-            "geo_resolution": "admin0",
-            "date_confirmation": "27.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "South Africa",
-            "admin_id": "207.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "Central",
-            "administrativeAreaLevel2": "Moscow",
-            "locality": "Moscow",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR"
-            }
-        },
-        "sources": [
-            {
-                "other": "stopcoronavirus.rf"
-            }
-        ],
-        "importedCase": {
-            "ID": "007-295634",
-            "province": "Central",
-            "geo_resolution": "admin2",
-            "date_confirmation": "05.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "6363.0",
+            "admin_id": "66.0",
             "travel_history_binary": "False"
         }
     },
@@ -4490,19 +376,20 @@
         "location": {
             "country": "India",
             "geometry": {
-                "latitude": 23.79775953100005,
-                "longitude": 87.98640557800007
-            }
+                "latitude": 31.532380000000046,
+                "longitude": 75.90799000000004
+            },
+            "geoResolution": "Point"
         },
         "events": [
             {
                 "name": "confirmed",
                 "dateRange": {
                     "start": {
-                        "$date": "2020-04-14T00:00:00Z"
+                        "$date": "2020-05-02T00:00:00Z"
                     },
                     "end": {
-                        "$date": "2020-04-14T00:00:00Z"
+                        "$date": "2020-05-02T00:00:00Z"
                     }
                 }
             },
@@ -4516,44 +403,661 @@
                 "curator": "TR"
             }
         },
-        "notes": "Details awaited",
         "sources": [
             {
-                "other": "mohfw.gov.in"
+                "url": "https://twitter.com/kbssidhu1961/status/1256564562511294464"
             }
         ],
         "importedCase": {
-            "ID": "002-31631",
-            "province": "West Bengal",
-            "geo_resolution": "point",
-            "date_confirmation": "14.04.2020",
+            "ID": "002-103628",
+            "city": "Hoshiarpur",
+            "province": "Punjab",
+            "country": "India",
+            "date_confirmation": "02.05.2020",
             "chronic_disease_binary": "False",
             "outcome": "Hospitalized",
-            "country_new": "India",
-            "admin_id": "11155.0",
+            "admin_id": "12396.0",
             "travel_history_binary": "False"
         }
     },
     {
         "location": {
-            "country": "China",
-            "administrativeAreaLevel1": "Hubei",
-            "administrativeAreaLevel2": "Xiaogan City",
-            "locality": "Xiaogan City",
+            "country": "India",
             "geometry": {
-                "latitude": 31.12046,
-                "longitude": 113.8795
-            }
+                "latitude": 18.940170000000023,
+                "longitude": 72.83483000000007
+            },
+            "geoResolution": "Point"
         },
         "events": [
             {
                 "name": "confirmed",
                 "dateRange": {
                     "start": {
-                        "$date": "2020-01-28T00:00:00Z"
+                        "$date": "2020-05-07T00:00:00Z"
                     },
                     "end": {
-                        "$date": "2020-01-28T00:00:00Z"
+                        "$date": "2020-05-07T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://twitter.com/rajeshtope11/status/1258456341321932801"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-124558",
+            "city": "Mumbai",
+            "province": "Maharashtra",
+            "country": "India",
+            "date_confirmation": "07.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "10992.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 18.940170000000023,
+                "longitude": 72.83483000000007
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-12T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-12T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://twitter.com/ANI/status/1260230293786488832?s=20"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-145488",
+            "city": "Mumbai",
+            "province": "Maharashtra",
+            "country": "India",
+            "date_confirmation": "12.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "10992.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 23.027760000000058,
+                "longitude": 72.60027000000008
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-16T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-16T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "notes": "6587 Test done one Vegetable Seller,Milk Daily Vendor,Medical Store Vendor,Begger within week and found positive",
+        "sources": [
+            {
+                "url": "https://twitter.com/PIBAhmedabad/status/1261669285484793857"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-166417",
+            "city": "Ahmedabad",
+            "province": "Gujarat",
+            "country": "India",
+            "date_confirmation": "16.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "11047.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 19.03681000000006,
+                "longitude": 73.01582000000008
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-19T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-19T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "importedCase": {
+            "ID": "002-187347",
+            "province": "Maharashtra",
+            "country": "India",
+            "date_confirmation": "19.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "10997.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 19.995030000000042,
+                "longitude": 73.79647000000006
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-21T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-21T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "importedCase": {
+            "ID": "002-208276",
+            "city": "Nashik",
+            "province": "Maharashtra",
+            "country": "India",
+            "date_confirmation": "21.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "12305.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 30.15483757800007,
+                "longitude": 79.20756428100003
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-24T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-24T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://twitter.com/ANI/status/1264494948105064451"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-229205",
+            "province": "Uttarakhand",
+            "country": "India",
+            "date_confirmation": "24.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "11098.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 18.504220000000032,
+                "longitude": 73.85302000000007
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-26T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-26T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://t.me/indiacovid/5601"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-250134",
+            "city": "Pune",
+            "province": "Maharashtra",
+            "country": "India",
+            "date_confirmation": "26.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "10986.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 19.200000000000045,
+                "longitude": 72.96667000000008
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-28T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-28T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Recovered"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://phdmah.maps.arcgis.com/apps/opsdashboard/index.html#/2cc0055832264c5296890745e9ea415c"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-271064",
+            "city": "Thane",
+            "province": "Maharashtra",
+            "country": "India",
+            "date_confirmation": "28.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Recovered",
+            "admin_id": "11099.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Haryana",
+            "country": "India",
+            "geometry": {
+                "latitude": 28.456,
+                "longitude": 77.029
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-30T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-30T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "http://www.nhmharyana.gov.in/WriteReadData/userfiles/file/CoronaVirus/Bulletin%20of%20COVID%2019%20as%20on%2030-05-20%20Evening.pdf"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-291995",
+            "city": "Gurugram",
+            "province": "Haryana",
+            "country": "India",
+            "date_confirmation": "30.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "3855.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 10.510820000000024,
+                "longitude": 76.21121000000005
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-06-01T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-06-01T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "http://dhs.kerala.gov.in/wp-content/uploads/2020/06/Daily-Bulletin-HFWD-English-June-1.pdf"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-312923",
+            "city": "Thrissur",
+            "province": "Kerala",
+            "country": "India",
+            "date_confirmation": "01.06.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "10970.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 19.03681000000006,
+                "longitude": 73.01582000000008
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-23T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-23T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://twitter.com/ANI/status/1253342199225307136"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-43805",
+            "province": "Maharashtra",
+            "country": "India",
+            "date_confirmation": "23.04.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "10997.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 28.39247000000006,
+                "longitude": 77.31276000000008
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-15T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-15T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Hospitalized"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "http://www.nhmharyana.gov.in/WriteReadData/userfiles/file/CoronaVirus/Evening%20Bulletin%2015-05-2020.pdf"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-64737",
+            "city": "Faridabad",
+            "province": "Haryana",
+            "country": "India",
+            "date_confirmation": "15.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Hospitalized",
+            "admin_id": "11050.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "India",
+            "geometry": {
+                "latitude": 17.332740000000058,
+                "longitude": 76.84035000000006
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-29T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-29T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "Recovered"
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://twitter.com/DHFWKA/status/1266343452779745280"
+            }
+        ],
+        "importedCase": {
+            "ID": "002-85667",
+            "city": "Kalaburagi",
+            "province": "Karnataka",
+            "country": "India",
+            "date_confirmation": "29.05.2020",
+            "chronic_disease_binary": "False",
+            "outcome": "Recovered",
+            "admin_id": "10995.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 50.0,
+                "end": 59.0
+            },
+            "sex": "Female"
+        },
+        "location": {
+            "country": "Belgium",
+            "geometry": {
+                "latitude": 50.99142331000007,
+                "longitude": 5.429156289000048
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-02T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-02T00:00:00Z"
                     }
                 }
             }
@@ -4563,27 +1067,29 @@
         },
         "sources": [
             {
-                "url": "http://news.163.com/special/epidemic/?spssid=7283291fcdba1d8c2d13ee3da2cfb760&spsw=7&spss=other#map_block"
+                "url": "https://epistat.wiv-isp.be/Covid/"
             }
         ],
         "importedCase": {
-            "ID": "000-2-2416",
-            "province": "Hubei",
-            "geo_resolution": "admin2",
-            "date_confirmation": "28.01.2020",
+            "ID": "003-106599",
+            "city": "Limburg",
+            "province": "Flanders",
+            "country": "Belgium",
+            "date_confirmation": "02.05.2020",
             "chronic_disease_binary": "False",
-            "country_new": "China",
-            "admin_id": "9519.0"
+            "admin_id": "11422.0",
+            "travel_history_binary": "False"
         }
     },
     {
         "location": {
-            "country": "Austria",
             "administrativeAreaLevel1": "Carinthia",
+            "country": "Austria",
             "geometry": {
                 "latitude": 46.7222,
                 "longitude": 14.1806
-            }
+            },
+            "geoResolution": "Admin1"
         },
         "events": [
             {
@@ -4610,36 +1116,654 @@
             }
         ],
         "importedCase": {
-            "ID": "003-29716",
+            "ID": "003-29718",
             "province": "Carinthia",
-            "geo_resolution": "admin1",
+            "country": "Austria",
             "date_confirmation": "23.03.2020",
             "chronic_disease_binary": "False",
-            "country_new": "Austria",
             "admin_id": "346.0",
             "travel_history_binary": "False"
         }
     },
     {
         "location": {
-            "country": "Italy",
-            "administrativeAreaLevel1": "Lombardia",
-            "administrativeAreaLevel2": "Milano",
-            "locality": "Milano",
+            "administrativeAreaLevel3": "Derby",
+            "administrativeAreaLevel2": "Derbyshire",
+            "administrativeAreaLevel1": "England",
+            "country": "United Kingdom",
             "geometry": {
-                "latitude": 45.46589,
-                "longitude": 9.121072
-            }
+                "latitude": 52.916667000000004,
+                "longitude": -1.466667
+            },
+            "geoResolution": "Admin3"
         },
         "events": [
             {
                 "name": "confirmed",
                 "dateRange": {
                     "start": {
-                        "$date": "2020-04-10T00:00:00Z"
+                        "$date": "2020-03-27T00:00:00Z"
                     },
                     "end": {
-                        "$date": "2020-04-10T00:00:00Z"
+                        "$date": "2020-03-27T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://www.arcgis.com/apps/opsdashboard/index.html#/f94c3c90da5b4e9f9a0b19484dd4bb14"
+            }
+        ],
+        "importedCase": {
+            "ID": "003-50648",
+            "city": "Derby,Derbyshire",
+            "province": "England",
+            "country": "United Kingdom",
+            "date_confirmation": "27.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "2757.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 80.0,
+                "end": 89.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Belgium",
+            "geometry": {
+                "latitude": 50.87268300100004,
+                "longitude": 4.590656390000049
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-25T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-25T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://epistat.wiv-isp.be/Covid/"
+            }
+        ],
+        "importedCase": {
+            "ID": "003-71578",
+            "city": "Vlaams Brabant",
+            "province": "Flanders",
+            "country": "Belgium",
+            "date_confirmation": "25.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11415.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 70.0,
+                "end": 79.0
+            },
+            "sex": "Female"
+        },
+        "location": {
+            "country": "Belgium",
+            "geometry": {
+                "latitude": 50.64549000000005,
+                "longitude": 5.572500000000048
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-11T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-11T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://epistat.wiv-isp.be/Covid/"
+            }
+        ],
+        "importedCase": {
+            "ID": "003-92507",
+            "city": "Liege",
+            "province": "Wallonia",
+            "country": "Belgium",
+            "date_confirmation": "11.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11421.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 41.0,
+                "end": 41.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Mexico",
+            "geometry": {
+                "latitude": 19.431940000000054,
+                "longitude": -99.13314999999994
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-06T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-06T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-24T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-24T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "004-23437",
+            "province": "Ciudad de Mexico",
+            "country": "Mexico",
+            "date_onset_symptoms": "24.03.2020",
+            "date_confirmation": "06.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "13753.0",
+            "travel_history_binary": "True"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 24.0,
+                "end": 24.0
+            },
+            "sex": "Female"
+        },
+        "location": {
+            "geometry": {
+                "latitude": 19.433332999999998,
+                "longitude": -98.166667
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-12T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-12T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "004-44367",
+            "province": "Tlaxcala",
+            "country": "Mexico",
+            "date_onset_symptoms": "05.04.2020",
+            "date_confirmation": "12.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "871.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Georgia",
+            "country": "United States",
+            "geometry": {
+                "latitude": 32.6758789,
+                "longitude": -83.455974
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-24T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-24T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://dph.georgia.gov/covid-19-daily-status-report"
+            }
+        ],
+        "importedCase": {
+            "ID": "005-24979",
+            "province": "Georgia",
+            "country": "United States",
+            "date_confirmation": "24.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "442.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Vermont",
+            "country": "United States",
+            "geometry": {
+                "latitude": 44.0842428,
+                "longitude": -72.662174
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-26T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-26T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://www.healthvermont.gov/response/infectious-disease/2019-novel-coronavirus"
+            }
+        ],
+        "importedCase": {
+            "ID": "005-45908",
+            "province": "Vermont",
+            "country": "United States",
+            "date_confirmation": "26.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "914.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "New York",
+            "country": "United States",
+            "geometry": {
+                "latitude": 40.661,
+                "longitude": -73.944
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-18T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-18T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
+            }
+        ],
+        "importedCase": {
+            "ID": "006-1463",
+            "city": "New York City",
+            "province": "New York",
+            "country": "United States",
+            "date_confirmation": "18.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6555.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "New York",
+            "country": "United States",
+            "geometry": {
+                "latitude": 40.661,
+                "longitude": -73.944
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-19T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-19T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
+            }
+        ],
+        "importedCase": {
+            "ID": "006-3556",
+            "city": "New York City",
+            "province": "New York",
+            "country": "United States",
+            "date_confirmation": "19.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6555.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "New York",
+            "country": "United States",
+            "geometry": {
+                "latitude": 40.661,
+                "longitude": -73.944
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-21T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-21T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases"
+            }
+        ],
+        "importedCase": {
+            "ID": "006-9402",
+            "city": "New York City",
+            "province": "New York",
+            "country": "United States",
+            "date_confirmation": "21.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6555.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 15.0,
+                "end": 34.0
+            },
+            "sex": "Female"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 49.71795000000003,
+                "longitude": 11.060560000000066
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-26T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-26T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-29T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-29T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-102033",
+            "city": "Forchheim",
+            "province": "Bayern",
+            "country": "Germany",
+            "date_onset_symptoms": "26.03.2020",
+            "date_confirmation": "29.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11561.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 60.0,
+                "end": 79.0
+            },
+            "sex": "Female"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 49.47317000000004,
+                "longitude": 10.990650000000073
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-104126",
+            "city": "Furth",
+            "province": "Bayern",
+            "country": "Germany",
+            "date_onset_symptoms": "05.04.2020",
+            "date_confirmation": "05.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11568.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 35.0,
+                "end": 59.0
+            },
+            "sex": "Female"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 49.491667696000036,
+                "longitude": 11.369378423000057
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-29T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-29T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-01T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-01T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-106219",
+            "city": "Nurnberger Land",
+            "province": "Bayern",
+            "country": "Germany",
+            "date_onset_symptoms": "29.03.2020",
+            "date_confirmation": "01.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11573.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "La Rioja",
+            "country": "Spain",
+            "geometry": {
+                "latitude": 42.275643200000005,
+                "longitude": -2.5175644
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-19T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-19T00:00:00Z"
                     }
                 }
             }
@@ -4652,30 +1776,606 @@
         },
         "sources": [
             {
-                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200410.csv"
+                "url": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv"
             }
         ],
         "importedCase": {
-            "ID": "007-281268",
-            "province": "Lombardia",
-            "geo_resolution": "admin2",
-            "date_confirmation": "10.04.2020",
+            "ID": "007-1083119",
+            "province": "La Rioja",
+            "country": "Spain",
+            "date_confirmation": "19.04.2020",
             "chronic_disease_binary": "False",
-            "country_new": "Italy",
-            "admin_id": "6195.0",
+            "admin_id": "548.0",
             "travel_history_binary": "False"
         }
     },
     {
         "location": {
-            "country": "Russia",
-            "administrativeAreaLevel1": "North Caucasian",
-            "administrativeAreaLevel2": "Chechnya",
-            "locality": "Chechnya",
+            "country": "Austria",
             "geometry": {
-                "latitude": 43.4023,
-                "longitude": 45.7187
+                "latitude": 47.066670000000045,
+                "longitude": 15.433330000000069
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-15T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-15T00:00:00Z"
+                    }
+                }
             }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://github.com/statistikat/coronaDAT/raw/master/archive/20200415/data/20200415_230000.rds"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-1104048",
+            "city": "Graz(Stadt)",
+            "province": "Styria",
+            "country": "Austria",
+            "date_confirmation": "15.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "12125.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 15.0,
+                "end": 34.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 52.46991999105596,
+                "longitude": 13.368389936090363
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-26T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-26T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-17T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-17T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-117344",
+            "city": "Berlin Tempelhof-Schoneberg",
+            "province": "Berlin",
+            "country": "Germany",
+            "date_onset_symptoms": "17.03.2020",
+            "date_confirmation": "26.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11615.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 25.0,
+                "end": 25.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Czech Republic",
+            "geometry": {
+                "latitude": 50.07913000000008,
+                "longitude": 14.433020000000056
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-29T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-29T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://onemocneni-aktualne.mzcr.cz/api/v2/covid-19"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-138274",
+            "province": "Prague",
+            "country": "Czech Republic",
+            "date_confirmation": "29.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11672.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 35.0,
+                "end": 59.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 53.24088033500004,
+                "longitude": 7.478432309000027
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-22T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-22T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-20T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-20T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://npgeo-corona-npgeo-de.hub.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0?page=26"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-159203",
+            "city": "Leer",
+            "province": "Niedersachsen",
+            "country": "Germany",
+            "date_onset_symptoms": "20.05.2020",
+            "date_confirmation": "22.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11729.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Bergamo",
+            "administrativeAreaLevel1": "Lombardia",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 45.79841,
+                "longitude": 9.79008
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-07T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-07T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200307.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-180133",
+            "city": "Bergamo",
+            "province": "Lombardia",
+            "country": "Italy",
+            "date_confirmation": "07.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "1530.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Alessandria",
+            "administrativeAreaLevel1": "Piemonte",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 44.8304,
+                "longitude": 8.663941000000001
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-16T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-16T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200316.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-201062",
+            "city": "Alessandria",
+            "province": "Piemonte",
+            "country": "Italy",
+            "date_confirmation": "16.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "1051.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Bergamo",
+            "administrativeAreaLevel1": "Lombardia",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 45.79841,
+                "longitude": 9.79008
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-21T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-21T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200321.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-221993",
+            "city": "Bergamo",
+            "province": "Lombardia",
+            "country": "Italy",
+            "date_confirmation": "21.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "1530.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Bergamo",
+            "administrativeAreaLevel1": "Lombardia",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 45.79841,
+                "longitude": 9.79008
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-25T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-25T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200325.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-242922",
+            "city": "Bergamo",
+            "province": "Lombardia",
+            "country": "Italy",
+            "date_confirmation": "25.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "1530.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Parma",
+            "administrativeAreaLevel1": "Emilia-Romagna",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 44.67171,
+                "longitude": 10.048919999999999
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-29T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-29T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200329.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-263852",
+            "city": "Parma",
+            "province": "Emilia-Romagna",
+            "country": "Italy",
+            "date_confirmation": "29.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6911.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Teramo",
+            "administrativeAreaLevel1": "Abruzzo",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 42.64614,
+                "longitude": 13.7265
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-03T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-03T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200403.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-284782",
+            "city": "Teramo",
+            "province": "Abruzzo",
+            "country": "Italy",
+            "date_confirmation": "03.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "8584.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Ferrara",
+            "administrativeAreaLevel1": "Emilia-Romagna",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 44.78979,
+                "longitude": 11.848339999999999
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-08T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-08T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200408.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-305710",
+            "city": "Ferrara",
+            "province": "Emilia-Romagna",
+            "country": "Italy",
+            "date_confirmation": "08.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "3294.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Moscow",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 55.7558,
+                "longitude": 37.6173
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-28T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-28T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "other": "stopcoronavirus.rf"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-326640",
+            "city": "Moscow",
+            "province": "Central",
+            "country": "Russia",
+            "date_confirmation": "28.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6363.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Moscow",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 55.7558,
+                "longitude": 37.6173
+            },
+            "geoResolution": "Admin2"
         },
         "events": [
             {
@@ -4702,61 +2402,13 @@
             }
         ],
         "importedCase": {
-            "ID": "007-314362",
-            "province": "North Caucasian",
-            "geo_resolution": "admin2",
+            "ID": "007-347570",
+            "city": "Moscow",
+            "province": "Central",
+            "country": "Russia",
             "date_confirmation": "15.04.2020",
             "chronic_disease_binary": "False",
-            "country_new": "Russia",
-            "admin_id": "2159.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 50.0,
-                "end": 59.0
-            },
-            "sex": "Female"
-        },
-        "location": {
-            "country": "Belgium",
-            "locality": "Limburg",
-            "geometry": {
-                "latitude": 50.991423310000066,
-                "longitude": 5.429156289000048
-            }
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0
-        },
-        "sources": [
-            {
-                "url": "https://epistat.wiv-isp.be/Covid/"
-            }
-        ],
-        "importedCase": {
-            "ID": "003-86142",
-            "province": "Flanders",
-            "geo_resolution": "point",
-            "date_confirmation": "07.04.2020",
-            "chronic_disease_binary": "False",
-            "country_new": "Belgium",
-            "admin_id": "11422.0",
+            "admin_id": "6363.0",
             "travel_history_binary": "False"
         }
     },
@@ -4770,21 +2422,21 @@
         },
         "location": {
             "country": "Germany",
-            "locality": "Breisgau-Hochschwarzwald",
             "geometry": {
-                "latitude": 47.924874977000066,
-                "longitude": 7.925899284000025
-            }
+                "latitude": 52.150090000000034,
+                "longitude": 7.338950000000068
+            },
+            "geoResolution": "Point"
         },
         "events": [
             {
                 "name": "onsetSymptoms",
                 "dateRange": {
                     "start": {
-                        "$date": "2020-03-13T00:00:00Z"
+                        "$date": "2020-03-12T00:00:00Z"
                     },
                     "end": {
-                        "$date": "2020-03-13T00:00:00Z"
+                        "$date": "2020-03-12T00:00:00Z"
                     }
                 }
             },
@@ -4792,10 +2444,10 @@
                 "name": "confirmed",
                 "dateRange": {
                     "start": {
-                        "$date": "2020-03-18T00:00:00Z"
+                        "$date": "2020-03-27T00:00:00Z"
                     },
                     "end": {
-                        "$date": "2020-03-18T00:00:00Z"
+                        "$date": "2020-03-27T00:00:00Z"
                     }
                 }
             }
@@ -4804,14 +2456,2275 @@
             "revisionNumber": 0
         },
         "importedCase": {
-            "ID": "007-72165",
-            "province": "Baden-Wurttemberg",
-            "geo_resolution": "point",
-            "date_onset_symptoms": "13.03.2020",
-            "date_confirmation": "18.03.2020",
+            "ID": "007-36850",
+            "city": "Steinfurt",
+            "province": "Nordrhein-Westfalen",
+            "country": "Germany",
+            "date_onset_symptoms": "12.03.2020",
+            "date_confirmation": "27.03.2020",
             "chronic_disease_binary": "False",
-            "country_new": "Germany",
-            "admin_id": "11859.0",
+            "admin_id": "11765.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 60.0,
+                "end": 79.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 51.77347000000003,
+                "longitude": 9.382520000000056
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-04T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-04T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-02T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-02T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-38943",
+            "city": "Hoxter",
+            "province": "Nordrhein-Westfalen",
+            "country": "Germany",
+            "date_onset_symptoms": "02.04.2020",
+            "date_confirmation": "04.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11770.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Samara Oblast",
+            "administrativeAreaLevel1": "Volga",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 53.4184,
+                "longitude": 50.4726
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-27T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-27T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "other": "stopcoronavirus.rf"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-410358",
+            "city": "Samara Oblast",
+            "province": "Volga",
+            "country": "Russia",
+            "date_confirmation": "27.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "7746.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 15.0,
+                "end": 34.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 50.66152000000005,
+                "longitude": 6.785460000000057
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-03T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-03T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-03T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-03T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-431288",
+            "city": "Euskirchen",
+            "province": "Nordrhein-Westfalen",
+            "country": "Germany",
+            "date_onset_symptoms": "03.04.2020",
+            "date_confirmation": "03.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11754.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 35.0,
+                "end": 59.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 49.48551510200008,
+                "longitude": 11.801326620000054
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-23T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-23T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-31T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-31T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-452217",
+            "city": "Amberg-Sulzbach",
+            "province": "Bayern",
+            "country": "Germany",
+            "date_onset_symptoms": "23.03.2020",
+            "date_confirmation": "31.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11906.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Russia",
+            "geometry": {
+                "latitude": 66.12193000000008,
+                "longitude": 76.67390000000006
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-01T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-01T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "other": "stopcoronavirus.rf"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-473147",
+            "city": "Yamalo-Nenets AO",
+            "province": "Ural",
+            "country": "Russia",
+            "date_confirmation": "01.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "10878.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Moscow Oblast",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 55.3404,
+                "longitude": 38.2918
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-04T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-04T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "other": "stopcoronavirus.rf"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-494077",
+            "city": "Moscow Oblast",
+            "province": "Central",
+            "country": "Russia",
+            "date_confirmation": "04.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6362.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Moscow Oblast",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 55.3404,
+                "longitude": 38.2918
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-06T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-06T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "other": "stopcoronavirus.rf"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-515005",
+            "city": "Moscow Oblast",
+            "province": "Central",
+            "country": "Russia",
+            "date_confirmation": "06.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6362.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Ivanovo Oblast",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 57.1057,
+                "longitude": 41.483000000000004
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-08T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-08T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "other": "stopcoronavirus.rf"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-535936",
+            "city": "Ivanovo Oblast",
+            "province": "Central",
+            "country": "Russia",
+            "date_confirmation": "08.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "4552.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Russia",
+            "geometry": {
+                "latitude": 54.97775000000007,
+                "longitude": 83.04563000000007
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-09T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-09T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "other": "stopcoronavirus.rf"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-556866",
+            "city": "Novosibirsk Oblast",
+            "province": "Siberia",
+            "country": "Russia",
+            "date_confirmation": "09.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "10855.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Vastra Gotaland",
+            "country": "Sweden",
+            "geometry": {
+                "latitude": 58.2528,
+                "longitude": 13.0596
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-04T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-04T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "sources": [
+            {
+                "url": "https://www.folkhalsomyndigheten.se/smittskydd-beredskap/utbrott/aktuella-utbrott/covid-19/bekraftade-fall-i-sverige"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-577796",
+            "province": "Vastra Gotaland",
+            "country": "Sweden",
+            "date_confirmation": "04.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "910.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Italy",
+            "geometry": {
+                "latitude": 45.165410000000065,
+                "longitude": 10.79242000000005
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-18T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-18T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200418.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-598725",
+            "city": "Mantova",
+            "province": "Lombardia",
+            "country": "Italy",
+            "date_confirmation": "18.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "10799.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Frosinone",
+            "administrativeAreaLevel1": "Lazio",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 41.616609999999994,
+                "longitude": 13.53626
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-26T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-26T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200426.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-619654",
+            "city": "Frosinone",
+            "province": "Lazio",
+            "country": "Italy",
+            "date_confirmation": "26.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "3401.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Biella",
+            "administrativeAreaLevel1": "Piemonte",
+            "country": "Italy",
+            "geometry": {
+                "latitude": 45.58365,
+                "longitude": 8.095951
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-09T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-09T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200509.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-640583",
+            "city": "Biella",
+            "province": "Piemonte",
+            "country": "Italy",
+            "date_confirmation": "09.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "1570.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Moscow",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 55.7558,
+                "longitude": 37.6173
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-11T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-11T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-661512",
+            "city": "Moscow",
+            "province": "Central",
+            "country": "Russia",
+            "date_confirmation": "11.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6363.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Oryol Oblast",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 52.7856,
+                "longitude": 36.9242
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-13T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-13T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-682442",
+            "city": "Oryol Oblast",
+            "province": "Central",
+            "country": "Russia",
+            "date_confirmation": "13.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6805.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Moscow",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 55.7558,
+                "longitude": 37.6173
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-15T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-15T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-703371",
+            "city": "Moscow",
+            "province": "Central",
+            "country": "Russia",
+            "date_confirmation": "15.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6363.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Moscow",
+            "administrativeAreaLevel1": "Central",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 55.7558,
+                "longitude": 37.6173
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-17T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-17T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-724300",
+            "city": "Moscow",
+            "province": "Central",
+            "country": "Russia",
+            "date_confirmation": "17.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6363.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Saint Petersburg",
+            "administrativeAreaLevel1": "North Western",
+            "country": "Russia",
+            "geometry": {
+                "latitude": 59.9311,
+                "longitude": 30.3609
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-19T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-19T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-745230",
+            "city": "Saint Petersburg",
+            "province": "North Western",
+            "country": "Russia",
+            "date_confirmation": "19.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "7726.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Gard",
+            "administrativeAreaLevel1": "Occitanie",
+            "country": "France",
+            "geometry": {
+                "latitude": 43.99449,
+                "longitude": 4.179802
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "admissionHospital",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-01T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-01T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-766160",
+            "city": "Gard",
+            "province": "Occitanie",
+            "country": "France",
+            "date_admission_hospital": "01.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "3532.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Oise",
+            "administrativeAreaLevel1": "Hauts-de-France",
+            "country": "France",
+            "geometry": {
+                "latitude": 49.41089,
+                "longitude": 2.4245240000000003
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "admissionHospital",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-08T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-08T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-787090",
+            "city": "Oise",
+            "province": "Hauts-de-France",
+            "country": "France",
+            "date_admission_hospital": "08.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6738.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Paris",
+            "administrativeAreaLevel1": "Ile-de-France",
+            "country": "France",
+            "geometry": {
+                "latitude": 48.85666,
+                "longitude": 2.342325
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "admissionHospital",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-07T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-07T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-808019",
+            "city": "Paris",
+            "province": "Ile-de-France",
+            "country": "France",
+            "date_admission_hospital": "07.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6904.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 35.0,
+                "end": 59.0
+            },
+            "sex": "Male"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 48.13641000000007,
+                "longitude": 11.577540000000056
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-22T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-22T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-22T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-22T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-82895",
+            "city": "Munchen",
+            "province": "Bayern",
+            "country": "Germany",
+            "date_onset_symptoms": "22.03.2020",
+            "date_confirmation": "22.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11873.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "demographics": {
+            "ageRange": {
+                "start": 35.0,
+                "end": 59.0
+            },
+            "sex": "Female"
+        },
+        "location": {
+            "country": "Germany",
+            "geometry": {
+                "latitude": 48.209598131000064,
+                "longitude": 12.705121404000067
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-28T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-28T00:00:00Z"
+                    }
+                }
+            },
+            {
+                "name": "onsetSymptoms",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-11T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-11T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0
+        },
+        "importedCase": {
+            "ID": "007-84988",
+            "city": "Altotting",
+            "province": "Bayern",
+            "country": "Germany",
+            "date_onset_symptoms": "11.03.2020",
+            "date_confirmation": "28.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "11875.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Baleares",
+            "country": "Spain",
+            "geometry": {
+                "latitude": 39.574690999999994,
+                "longitude": 2.91291179
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-31T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-31T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-870808",
+            "province": "Baleares",
+            "country": "Spain",
+            "date_confirmation": "31.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "307.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Castilla-La Mancha",
+            "country": "Spain",
+            "geometry": {
+                "latitude": 39.5934269,
+                "longitude": -3.0036282
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-24T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-24T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-891738",
+            "province": "Castilla La Mancha",
+            "country": "Spain",
+            "date_confirmation": "24.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "350.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Castilla y Leon",
+            "country": "Spain",
+            "geometry": {
+                "latitude": 41.767612299999996,
+                "longitude": -4.7805168
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-19T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-19T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-912667",
+            "province": "Castilla y Leon",
+            "country": "Spain",
+            "date_confirmation": "19.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "351.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Spain",
+            "geometry": {
+                "latitude": 41.79850998500007,
+                "longitude": 1.5289057830000274
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-31T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-31T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-933597",
+            "province": "Cataluna",
+            "country": "Spain",
+            "date_confirmation": "31.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "12077.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Spain",
+            "geometry": {
+                "latitude": 41.79850998500007,
+                "longitude": 1.5289057830000274
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-17T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-17T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-954526",
+            "province": "Cataluna",
+            "country": "Spain",
+            "date_confirmation": "17.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "12077.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Spain",
+            "geometry": {
+                "latitude": 41.43312000000003,
+                "longitude": 1.8611000000000217
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-03-27T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-03-27T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-975456",
+            "province": "C. Valenciana",
+            "country": "Spain",
+            "date_confirmation": "27.03.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "12079.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Galicia",
+            "country": "Spain",
+            "geometry": {
+                "latitude": 42.7623342,
+                "longitude": -7.9114304
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-12T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-12T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "TR"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv"
+            }
+        ],
+        "importedCase": {
+            "ID": "007-996386",
+            "province": "Galicia",
+            "country": "Spain",
+            "date_confirmation": "12.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "434.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Turkey",
+            "geometry": {
+                "latitude": 39.10205,
+                "longitude": 35.17355
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-25T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-25T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/turkey/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-117314",
+            "country": "Turkey",
+            "date_confirmation": "25.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "229.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Turkey",
+            "geometry": {
+                "latitude": 39.10205,
+                "longitude": 35.17355
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-04T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-04T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/turkey/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-138244",
+            "country": "Turkey",
+            "date_confirmation": "04.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "229.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Turkey",
+            "geometry": {
+                "latitude": 39.10205,
+                "longitude": 35.17355
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-16T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-16T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/turkey/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-159174",
+            "country": "Turkey",
+            "date_confirmation": "16.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "229.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Ukraine",
+            "geometry": {
+                "latitude": 49.09008,
+                "longitude": 31.36637
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-28T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-28T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/ukraine/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-180102",
+            "country": "Ukraine",
+            "date_confirmation": "28.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "234.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Belarus",
+            "geometry": {
+                "latitude": 53.59231,
+                "longitude": 28.065179999999998
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-24T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-24T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/belarus/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-201031",
+            "country": "Belarus",
+            "date_confirmation": "24.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "21.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Belarus",
+            "geometry": {
+                "latitude": 53.59231,
+                "longitude": 28.065179999999998
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-17T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-17T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/belarus/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-221962",
+            "country": "Belarus",
+            "date_confirmation": "17.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "21.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Ireland",
+            "geometry": {
+                "latitude": 53.207069999999995,
+                "longitude": -8.149569999999999
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-18T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-18T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.gov.ie/en/news/7e0924-latest-updates-on-covid-19-coronavirus/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-242892",
+            "country": "Ireland",
+            "date_confirmation": "18.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "106.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "Buckinghamshire",
+            "administrativeAreaLevel1": "England",
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 51.833333,
+                "longitude": -0.833333
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-01T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-01T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.data.gov.uk/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-263821",
+            "city": "Buckinghamshire",
+            "province": "England",
+            "country": "United Kingdom",
+            "date_confirmation": "01.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "1799.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel1": "Wales",
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 52.3458,
+                "longitude": -3.7631099999999997
+            },
+            "geoResolution": "Admin1"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://covid19-phwstatement.nhs.wales/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-284751",
+            "province": "Wales",
+            "country": "United Kingdom",
+            "date_confirmation": "05.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "927.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel3": "Westminster",
+            "administrativeAreaLevel2": "Greater London",
+            "administrativeAreaLevel1": "England",
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 51.494721999999996,
+                "longitude": -0.135278
+            },
+            "geoResolution": "Admin3"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-10T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-10T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.data.gov.uk/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-305680",
+            "city": "Westminster,Greater London",
+            "province": "England",
+            "country": "United Kingdom",
+            "date_confirmation": "10.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "9242.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Turkey",
+            "geometry": {
+                "latitude": 39.10205,
+                "longitude": 35.17355
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-04T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-04T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/turkey/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-32661",
+            "country": "Turkey",
+            "date_confirmation": "04.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "229.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Turkey",
+            "geometry": {
+                "latitude": 39.10205,
+                "longitude": 35.17355
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-04T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-04T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/turkey/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-34754",
+            "country": "Turkey",
+            "date_confirmation": "04.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "229.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Turkey",
+            "geometry": {
+                "latitude": 39.10205,
+                "longitude": 35.17355
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-05T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/turkey/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-36847",
+            "country": "Turkey",
+            "date_confirmation": "05.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "229.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel3": "York",
+            "administrativeAreaLevel2": "North Yorkshire",
+            "administrativeAreaLevel1": "England",
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 53.958332999999996,
+                "longitude": -1.080278
+            },
+            "geoResolution": "Admin3"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-21T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-21T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.data.gov.uk/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-3894",
+            "city": "York,North Yorkshire",
+            "province": "England",
+            "country": "United Kingdom",
+            "date_confirmation": "21.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "9919.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 54.37002,
+                "longitude": -2.95214
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-02T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-02T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.data.gov.uk/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-410327",
+            "country": "United Kingdom",
+            "date_confirmation": "02.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "236.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "administrativeAreaLevel2": "North Yorkshire",
+            "administrativeAreaLevel1": "England",
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 54.166667000000004,
+                "longitude": -1.333333
+            },
+            "geoResolution": "Admin2"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-07T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-07T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.data.gov.uk/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-431257",
+            "city": "North Yorkshire",
+            "province": "England",
+            "country": "United Kingdom",
+            "date_confirmation": "07.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "6662.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 54.37002,
+                "longitude": -2.95214
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-12T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-12T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.data.gov.uk/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-452187",
+            "country": "United Kingdom",
+            "date_confirmation": "12.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "236.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 54.37002,
+                "longitude": -2.95214
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-19T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-19T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.data.gov.uk/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-473116",
+            "country": "United Kingdom",
+            "date_confirmation": "19.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "236.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Turkey",
+            "geometry": {
+                "latitude": 39.10205,
+                "longitude": 35.17355
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-09T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-09T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/turkey/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-51059",
+            "country": "Turkey",
+            "date_confirmation": "09.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "229.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "United Kingdom",
+            "geometry": {
+                "latitude": 50.85550000000006,
+                "longitude": -0.9859199999999646
+            },
+            "geoResolution": "Point"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-05-09T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-05-09T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://coronavirus.data.gov.uk/#category=utlas&map=rate"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-7199",
+            "city": "Havant,Hampshire",
+            "province": "England",
+            "country": "United Kingdom",
+            "date_confirmation": "09.05.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "14106.0",
+            "travel_history_binary": "False"
+        }
+    },
+    {
+        "location": {
+            "country": "Turkey",
+            "geometry": {
+                "latitude": 39.10205,
+                "longitude": 35.17355
+            },
+            "geoResolution": "Country"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange": {
+                    "start": {
+                        "$date": "2020-04-18T00:00:00Z"
+                    },
+                    "end": {
+                        "$date": "2020-04-18T00:00:00Z"
+                    }
+                }
+            }
+        ],
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "ZW"
+            }
+        },
+        "sources": [
+            {
+                "url": "https://www.worldometers.info/coronavirus/country/turkey/"
+            }
+        ],
+        "importedCase": {
+            "ID": "008-92919",
+            "country": "Turkey",
+            "date_confirmation": "18.04.2020",
+            "chronic_disease_binary": "False",
+            "admin_id": "229.0",
             "travel_history_binary": "False"
         }
     }

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -20,6 +20,7 @@
             "administrativeAreaLevel2": "Paris",
             "administrativeAreaLevel3": "Paris",
             "geoResolution": "Admin3",
+            "name": "Paris",
             "geometry": {
                 "latitude": {
                     "$numberDouble": "2.3522219"

--- a/data-serving/scripts/convert-data/README.md
+++ b/data-serving/scripts/convert-data/README.md
@@ -24,8 +24,8 @@ Errors will be written to `conversion_errors.tsv`.
 A few fields can't be converted losslessly because they need to be normalized upon insertion into the new data format.
 All of the original values are strings; some of the target representations are bools, ints, floats, or enums.
 Additionally, the new schema has validation rules and invalid values, e.g. an age over 300. When a value can't be
-successfully converted, the failure is logged in `convert_data.log` and the value for that field is dropped (though
-again, the original value is archived in the approrpiate `originalCase` field).
+successfully converted, the failure is logged in `conversion_errors.tsv` and the value for that field is dropped (though
+again, the original value is archived in the appropriate `originalCase` field).
 
 The following fields are lossy:
 
@@ -34,6 +34,7 @@ The following fields are lossy:
 - `travelHistory.location`: This field is highly unstructured, and includes lists of locations, free-form text, and
   locations of all (unmarked) granularity.
 - `travelHistory.dateRange`: As with `events[name='onsetSymptoms']`, the date format varies.
+- `location.geoResolution`: Some values don't match the enum values.
 
 > **Open question:** How much effort should be put into converting these fields? What are the requirements and use cases
 > for the line-list data?
@@ -79,7 +80,6 @@ Fields that are being converted include:
 - `events`
 - `location`
 - `notes`
-- `outbreakSpecifics`
 - `pathogens`
 - `revisionMetadata`
 - `source`
@@ -88,19 +88,6 @@ Fields that are being converted include:
 
 Fields that can't be converted include:
 
-- `travelHistory.purpose`: The existing travel history fields -- `travel_history_dates`, `travel_history_location`, and
-  `travel_history_binary` do not encompass this data (or at least not in a structured way), but we may want to include
-  it going forward.
-
-- `location.id`: Although the original data has a location id, we may not use the same geocoding system going forward,
-  so these ids have been archived in the `originalCase` field but not ported to `location.id`.
-
-- `revision.date`: The source data does not include the date on which the data was ingested (or updated). The new system
-  will support this.
-
-- `source.id` and `pathogens.sequenceSource.id`: Sources may have ids to link them to the new `sources` collection; it's
-  possible that we may be able to backfill this later once that dataset is developed and we can cross-reference by URL.
-
 Fields that are not carrying over to the new schema, though they will be included in `importedCase`:
 
 - Fields that were relevant early on in the outbreak, but aren't tracked any longer: `lives_in_Wuhan`,
@@ -108,10 +95,9 @@ Fields that are not carrying over to the new schema, though they will be include
 
 - Fields supplanted by new values: `ID`
 
-- Non-normalized or redunant location fields, including `province`, `geo_resolution`, `location`, `admin3`,
-  `country_new`, `admin_id`
+- Non-normalized or redundant location fields, including `city`, `province`, `country`
   
-- Fields whose values can be imputed from other fields: `geo_resolution`, `chronic_disease_binary`
+- Fields whose values can be imputed from other fields: `chronic_disease_binary`, `travel_history_binary`
 
 ### Backfilled fields
 
@@ -119,8 +105,6 @@ We are backfilling fields including:
 
 - `revisionMetadata.revisionNumber`: We are treating each record as if it's on its first revision. It would be extremely
   labor-intensive to reconstruct revision history from the source data, but it will baked into the new system.
-
-> **Open question:** Do we want to backfill data or leave those fields empty for imported data?
 
 ### Non-backfilled fields
 
@@ -130,10 +114,11 @@ Some fields in the new schema cannot be backfilled because they are not present 
 - `demographics.nationality`
 - `demographics.ethnicity`
 - `revision.notes`
+- `revision.date`
+- `travelHistory.purpose`
+- `source.id` and `pathogens.sequenceSource.id`
 
 ### Original fields archive
 
 All nonempty fields from the original dataset are archived for posterity as fields of the same name in the new schema's
 `importedCase` document.
-
-> **Open question:** Should those fields that are 100% losslessly converted be removed from this archive?

--- a/data-serving/scripts/convert-data/constants.py
+++ b/data-serving/scripts/convert-data/constants.py
@@ -19,12 +19,11 @@ GEOCODER_REPO_PATH = 'code/sheet_cleaner/geocoding'
 # TODO(khmoran): Exclude 'outcome' once the curator UI transitions to using the
 # new events-based outcome field.
 LOSSY_FIELDS = [
-    'ID', 'province', 'geo_resolution', 'date_onset_symptoms',
+    'ID', 'city', 'province', 'country', 'date_onset_symptoms',
     'date_admission_hospital', 'date_confirmation', 'travel_history_dates',
     'travel_history_location', 'reported_market_exposure',
-    'chronic_disease_binary', 'outcome', 'location', 'admin3', 'country_new',
-    'admin_id', 'travel_history_binary', 'lives_in_Wuhan'
-]
+    'chronic_disease_binary', 'outcome', 'admin_id', 'travel_history_binary',
+    'lives_in_Wuhan']
 
 '''
 A mapping from the source's sheet id to its name. The source of truth is at
@@ -115,3 +114,8 @@ COMMON_LOCATION_ABBREVIATIONS = {
 
 ''' Valid values for sex field. '''
 VALID_SEXES = ['female', 'male', 'other']
+
+''' Value values for geographical resolution. '''
+VALID_GEO_RESOLUTIONS = {
+    'point', 'admin3', 'admin2', 'admin1', 'admin0'
+}

--- a/data-serving/scripts/convert-data/constants.py
+++ b/data-serving/scripts/convert-data/constants.py
@@ -117,5 +117,9 @@ VALID_SEXES = ['female', 'male', 'other']
 
 ''' Value values for geographical resolution. '''
 VALID_GEO_RESOLUTIONS = {
-    'point', 'admin3', 'admin2', 'admin1', 'admin0'
+    'point': 'point',
+    'admin3': 'admin3',
+    'admin2': 'admin2',
+    'admin1': 'admin1',
+    'admin0': 'country'
 }

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -98,10 +98,12 @@ def convert(infile: str, outfile: str, geocoder: Any,
 
                 json_case['location'] = convert_location(
                     csv_case['ID'],
-                    csv_case['country'],
-                    csv_case['admin1'],
+                    csv_case['location'],
+                    csv_case['admin3'],
                     csv_case['admin2'],
-                    csv_case['city'],
+                    csv_case['admin1'],
+                    csv_case['country_new'],
+                    csv_case['geo_resolution'],
                     csv_case['latitude'],
                     csv_case['longitude'])
 

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -9,7 +9,7 @@ Converters log errors thrown by the parsers, since they have the context on
 which row failed to convert.
 '''
 
-from parsers import (parse_age, parse_bool, parse_date,
+from parsers import (parse_age, parse_bool, parse_date, parse_geo_resolution,
                      parse_latitude, parse_list, parse_location_list,
                      parse_longitude, parse_range, parse_sex, parse_string_list)
 from typing import Any, Callable, Dict, List
@@ -235,9 +235,9 @@ def convert_demographics(id: str, age: Any, sex: str) -> Dict[str, Any]:
     return demographics or None
 
 
-def convert_location(id: str, country: str, adminL1: str,
-                     adminL2: str, locality: str, latitude: float,
-                     longitude: float) -> Dict[str, Any]:
+def convert_location(id: str, location: str, admin3: str, admin2: str,
+                     admin1: str, country: str, geo_resolution: str,
+                     latitude: float, longitude: float) -> Dict[str, Any]:
     '''
     Converts location fields to a location object.
 
@@ -250,26 +250,31 @@ def convert_location(id: str, country: str, adminL1: str,
           'country': str,
           'administrativeAreaLevel1': str,
           'administrativeAreaLevel2': str,
-          'locality': str,
+          'administrativeAreaLevel3': str,
+          'place': str,
+          'geo_resolution': str,
           'geometry': {
-          'latitude': float,
-          'longitude': float
+            'latitude': float,
+            'longitude': float
           }
         }
     '''
     location = {}
 
+    if location:
+        location['place'] = str(location)
+
+    if admin3:
+        location['administrativeAreaLevel3'] = str(admin3)
+
+    if admin2:
+        location['administrativeAreaLevel2'] = str(admin2)
+
+    if admin1:
+        location['administrativeAreaLevel1'] = str(admin1)
+
     if country:
         location['country'] = str(country)
-
-    if adminL1:
-        location['administrativeAreaLevel1'] = str(adminL1)
-
-    if adminL2:
-        location['administrativeAreaLevel2'] = str(adminL2)
-
-    if locality:
-        location['locality'] = str(locality)
 
     geometry = {}
 
@@ -289,6 +294,14 @@ def convert_location(id: str, country: str, adminL1: str,
 
     if geometry:
         location['geometry'] = geometry
+
+    try:
+        parsed_geo_resolution = parse_geo_resolution(geo_resolution)
+        if parsed_longitude is not None:
+            location['geoResolution'] = parsed_geo_resolution
+    except ValueError as e:
+        log_error(id, 'geo_resolution',
+                  'location.geoResolution', geo_resolution, e)
 
     return location
 

--- a/data-serving/scripts/convert-data/parsers.py
+++ b/data-serving/scripts/convert-data/parsers.py
@@ -341,10 +341,11 @@ def parse_geo_resolution(value: Any) -> str:
     if not value:
         return None
 
-    if str(value).lower() not in VALID_GEO_RESOLUTIONS:
+    geo_resolution = VALID_GEO_RESOLUTIONS.get(str(value).lower())
+    if not geo_resolution:
         raise ValueError('geo resolution not in enum')
 
-    return str(value).capitalize()
+    return geo_resolution.capitalize()
 
 
 def parse_string_list(value: Any) -> List[str]:

--- a/data-serving/scripts/convert-data/parsers.py
+++ b/data-serving/scripts/convert-data/parsers.py
@@ -17,7 +17,8 @@ import numbers
 import math
 import datetime
 from typing import Any, Callable, Dict, List, Tuple
-from constants import COMMON_LOCATION_ABBREVIATIONS, VALID_SEXES
+from constants import (COMMON_LOCATION_ABBREVIATIONS,
+                       VALID_GEO_RESOLUTIONS, VALID_SEXES)
 from utils import trim_string_list
 from geocode_util import lookup_location
 
@@ -217,8 +218,13 @@ def parse_location(geocoder: Any, value: Any) -> Dict[str, Any]:
         result['administrativeAreaLevel1'] = geocode_result.admin1
     if geocode_result.admin2:
         result['administrativeAreaLevel2'] = geocode_result.admin2
-    if geocode_result.admin3 or geocode_result.location:
-        result['locality'] = geocode_result.admin3 or geocode_result.location
+    if geocode_result.admin3:
+        result['administrativeAreaLevel3'] = geocode_result.admin3
+    if geocode_result.location:
+        result['place'] = geocode_result.location
+    if geocode_result.geo_resolution:
+        result['geoResolution'] = parse_geo_resolution(
+            geocode_result.geo_resolution)
 
     return result
 
@@ -316,6 +322,29 @@ def parse_longitude(value: Any) -> float:
         raise ValueError('longitude outside of valid range')
 
     return longitude
+
+
+def parse_geo_resolution(value: Any) -> str:
+    '''
+    Parses a geo resolution enum value from the input.
+
+    Parameters:
+      value: Value representing a geo resolution, expected to be one of "place",
+        "adminAreaL1", "adminAreaL2", or "country."
+
+    Raises:
+      ValueError: The value is not in the geo resolution enum.
+    Returns:
+      None: When the input value is empty or a string indicating n/a.
+      str: When the value is present and successfully parsed.
+    '''
+    if not value:
+        return None
+
+    if str(value).lower() not in VALID_GEO_RESOLUTIONS:
+        raise ValueError('geo resolution not in enum')
+
+    return str(value).capitalize()
 
 
 def parse_string_list(value: Any) -> List[str]:

--- a/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
+++ b/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
@@ -94,7 +94,7 @@ main() {
     convert_data
     setup_db
     import_data
-    cleanup
+    #cleanup
 
     print 'Fin!'
 }

--- a/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
+++ b/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
@@ -94,7 +94,7 @@ main() {
     convert_data
     setup_db
     import_data
-    #cleanup
+    cleanup
 
     print 'Fin!'
 }

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -23,7 +23,7 @@ export function addCase(
         body: {
             location: {
                 country: country,
-                geoResolution: 'Admin0'
+                geoResolution: 'Country'
             },
             events: [
                 {

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -23,7 +23,7 @@ export function addCase(
         body: {
             location: {
                 country: country,
-                geoResolution: 'Country'
+                geoResolution: 'Country',
             },
             events: [
                 {

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -23,6 +23,7 @@ export function addCase(
         body: {
             location: {
                 country: country,
+                geoResolution: 'Admin0'
             },
             events: [
                 {
@@ -43,7 +44,7 @@ export function addCase(
                 creationMetadata: {
                     curator: 'test',
                     date: new Date().toJSON(),
-                }
+                },
             },
         },
     });

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -34,6 +34,8 @@ it('loads and displays cases', async () => {
                 country: 'France',
                 administrativeAreaLevel1: 'some admin 1',
                 administrativeAreaLevel2: 'some admin 2',
+                // TODO: Infer the geo resolution from the location.
+                geoResolution: 'Admin2',
             },
             events: [
                 {
@@ -86,6 +88,7 @@ it('API errors are displayed', async () => {
             },
             location: {
                 country: 'France',
+                geoResolution: 'Admin0',
             },
             events: [
                 {
@@ -139,6 +142,7 @@ it('can delete a row', async () => {
             },
             location: {
                 country: 'France',
+                geoResolution: 'Admin0',
             },
             events: [
                 {
@@ -246,6 +250,7 @@ it('can add a row', async () => {
         },
         location: {
             country: 'France',
+            geoResolution: 'Admin0',
         },
         events: [
             {
@@ -305,6 +310,7 @@ it('can edit a row', async () => {
             },
             location: {
                 country: 'France',
+                geoResolution: 'Admin0',
             },
             events: [
                 {
@@ -354,6 +360,7 @@ it('can edit a row', async () => {
             },
             location: {
                 country: 'France',
+                geoResolution: 'Admin0',
             },
             events: [
                 {
@@ -416,6 +423,7 @@ it('cannot edit data as a reader only', async () => {
             },
             location: {
                 country: 'France',
+                geoResolution: 'Admin0',
             },
             events: [
                 {

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -88,7 +88,7 @@ it('API errors are displayed', async () => {
             },
             location: {
                 country: 'France',
-                geoResolution: 'Admin0',
+                geoResolution: 'Country',
             },
             events: [
                 {
@@ -142,7 +142,7 @@ it('can delete a row', async () => {
             },
             location: {
                 country: 'France',
-                geoResolution: 'Admin0',
+                geoResolution: 'Country',
             },
             events: [
                 {
@@ -250,7 +250,7 @@ it('can add a row', async () => {
         },
         location: {
             country: 'France',
-            geoResolution: 'Admin0',
+            geoResolution: 'Country',
         },
         events: [
             {
@@ -310,7 +310,7 @@ it('can edit a row', async () => {
             },
             location: {
                 country: 'France',
-                geoResolution: 'Admin0',
+                geoResolution: 'Country',
             },
             events: [
                 {
@@ -360,7 +360,7 @@ it('can edit a row', async () => {
             },
             location: {
                 country: 'France',
-                geoResolution: 'Admin0',
+                geoResolution: 'Country',
             },
             events: [
                 {
@@ -423,7 +423,7 @@ it('cannot edit data as a reader only', async () => {
             },
             location: {
                 country: 'France',
-                geoResolution: 'Admin0',
+                geoResolution: 'Country',
             },
             events: [
                 {

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -121,6 +121,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                 country: rowData.country,
                 administrativeAreaLevel1: rowData.adminArea1,
                 administrativeAreaLevel2: rowData.adminArea2,
+                // TODO: Infer the geo resolution from the location.
+                geoResolution: 'Admin2',
             },
             events: [
                 {
@@ -135,7 +137,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                 creationMetadata: {
                     curator: this.props.user.email,
                     date: new Date().toISOString(),
-                }
+                },
             },
         };
     }
@@ -307,7 +309,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 notes: c.notes,
                                                 sourceUrl:
                                                     c.sources &&
-                                                        c.sources.length > 0
+                                                    c.sources.length > 0
                                                         ? c.sources[0].url
                                                         : null,
                                             });

--- a/verification/curator-service/ui/src/components/NewCaseForm.test.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.test.tsx
@@ -56,7 +56,7 @@ it('submits case ok', async () => {
         },
         location: {
             country: '',
-            geoResolution: 'Admin0',
+            geoResolution: 'Country',
         },
         revisionMetadata: {
             revisionNumber: 0,

--- a/verification/curator-service/ui/src/components/NewCaseForm.test.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.test.tsx
@@ -56,6 +56,7 @@ it('submits case ok', async () => {
         },
         location: {
             country: '',
+            geoResolution: 'Admin0',
         },
         revisionMetadata: {
             revisionNumber: 0,

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -132,13 +132,13 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                 }}
             ></CheckCircleIcon>
         ) : (
-                    <RadioButtonUncheckedIcon
-                        style={{
-                            color: grey[500],
-                            margin: '0.25em 0.5em',
-                        }}
-                    ></RadioButtonUncheckedIcon>
-                );
+            <RadioButtonUncheckedIcon
+                style={{
+                    color: grey[500],
+                    margin: '0.25em 0.5em',
+                }}
+            ></RadioButtonUncheckedIcon>
+        );
     }
 
     scrollTo(name: string): void {
@@ -168,159 +168,159 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     values,
                     errors,
                 }): JSX.Element => (
-                        <div className={classes.container}>
-                            <nav className={classes.tableOfContents}>
-                                <div
-                                    className={classes.tableOfContentsRow}
-                                    onClick={(): void =>
-                                        this.scrollTo('demographics')
-                                    }
-                                >
-                                    {this.tableOfContentsIcon({
-                                        isChecked: values.sex !== undefined,
-                                        hasError: errors.sex !== undefined,
-                                    })}
+                    <div className={classes.container}>
+                        <nav className={classes.tableOfContents}>
+                            <div
+                                className={classes.tableOfContentsRow}
+                                onClick={(): void =>
+                                    this.scrollTo('demographics')
+                                }
+                            >
+                                {this.tableOfContentsIcon({
+                                    isChecked: values.sex !== undefined,
+                                    hasError: errors.sex !== undefined,
+                                })}
                                 Demographics
                             </div>
-                                <div
-                                    className={classes.tableOfContentsRow}
-                                    onClick={(): void => this.scrollTo('location')}
-                                >
-                                    {this.tableOfContentsIcon({
-                                        isChecked: values.country.trim() !== '',
-                                        hasError: errors.country !== undefined,
-                                    })}
+                            <div
+                                className={classes.tableOfContentsRow}
+                                onClick={(): void => this.scrollTo('location')}
+                            >
+                                {this.tableOfContentsIcon({
+                                    isChecked: values.country.trim() !== '',
+                                    hasError: errors.country !== undefined,
+                                })}
                                 Location
                             </div>
-                                <div
-                                    className={classes.tableOfContentsRow}
-                                    onClick={(): void => this.scrollTo('events')}
-                                >
-                                    {this.tableOfContentsIcon({
-                                        isChecked: values.confirmedDate !== null,
-                                        hasError:
-                                            errors.confirmedDate !== undefined,
-                                    })}
+                            <div
+                                className={classes.tableOfContentsRow}
+                                onClick={(): void => this.scrollTo('events')}
+                            >
+                                {this.tableOfContentsIcon({
+                                    isChecked: values.confirmedDate !== null,
+                                    hasError:
+                                        errors.confirmedDate !== undefined,
+                                })}
                                 Events
                             </div>
-                                <div
-                                    className={classes.tableOfContentsRow}
-                                    onClick={(): void => this.scrollTo('source')}
-                                >
-                                    {this.tableOfContentsIcon({
-                                        isChecked: values.sourceUrl.trim() !== '',
-                                        hasError: errors.sourceUrl !== undefined,
-                                    })}
+                            <div
+                                className={classes.tableOfContentsRow}
+                                onClick={(): void => this.scrollTo('source')}
+                            >
+                                {this.tableOfContentsIcon({
+                                    isChecked: values.sourceUrl.trim() !== '',
+                                    hasError: errors.sourceUrl !== undefined,
+                                })}
                                 Source
                             </div>
-                                <div
-                                    className={classes.tableOfContentsRow}
-                                    onClick={(): void => this.scrollTo('notes')}
-                                >
-                                    {this.tableOfContentsIcon({
-                                        isChecked: values.notes.trim() !== '',
-                                        hasError: errors.notes !== undefined,
-                                    })}
+                            <div
+                                className={classes.tableOfContentsRow}
+                                onClick={(): void => this.scrollTo('notes')}
+                            >
+                                {this.tableOfContentsIcon({
+                                    isChecked: values.notes.trim() !== '',
+                                    hasError: errors.notes !== undefined,
+                                })}
                                 Notes
                             </div>
-                            </nav>
-                            <div className={classes.form}>
-                                <Form>
-                                    <Scroll.Element name="demographics">
-                                        <fieldset>
-                                            <legend>Demographics</legend>
-                                            <FormControl>
-                                                <InputLabel htmlFor="sex">
-                                                    Sex
+                        </nav>
+                        <div className={classes.form}>
+                            <Form>
+                                <Scroll.Element name="demographics">
+                                    <fieldset>
+                                        <legend>Demographics</legend>
+                                        <FormControl>
+                                            <InputLabel htmlFor="sex">
+                                                Sex
                                             </InputLabel>
-                                                <Field
-                                                    as="select"
-                                                    name="sex"
-                                                    type="text"
-                                                    component={Select}
-                                                >
-                                                    <MenuItem
-                                                        value={undefined}
-                                                    ></MenuItem>
-                                                    <MenuItem value={'Female'}>
-                                                        Female
-                                                </MenuItem>
-                                                    <MenuItem value={'Male'}>
-                                                        Male
-                                                </MenuItem>
-                                                </Field>
-                                            </FormControl>
-                                        </fieldset>
-                                    </Scroll.Element>
-                                    <Scroll.Element name="location">
-                                        <fieldset>
-                                            <legend>Location</legend>
                                             <Field
-                                                label="Country"
-                                                name="country"
+                                                as="select"
+                                                name="sex"
                                                 type="text"
-                                                component={TextField}
-                                            />
-                                        </fieldset>
-                                    </Scroll.Element>
-                                    <Scroll.Element name="events">
-                                        <fieldset>
-                                            <legend>Events</legend>
-                                            <MuiPickersUtilsProvider
-                                                utils={DateFnsUtils}
+                                                component={Select}
                                             >
-                                                <Field
-                                                    name="confirmedDate"
-                                                    label="Date confirmed"
-                                                    format="yyyy/MM/dd"
-                                                    maxDate={new Date()}
-                                                    minDate={new Date('2019/12/01')}
-                                                    component={KeyboardDatePicker}
-                                                />
-                                            </MuiPickersUtilsProvider>
-                                        </fieldset>
-                                    </Scroll.Element>
-                                    <Scroll.Element name="source">
-                                        <fieldset>
-                                            <legend>Source</legend>
+                                                <MenuItem
+                                                    value={undefined}
+                                                ></MenuItem>
+                                                <MenuItem value={'Female'}>
+                                                    Female
+                                                </MenuItem>
+                                                <MenuItem value={'Male'}>
+                                                    Male
+                                                </MenuItem>
+                                            </Field>
+                                        </FormControl>
+                                    </fieldset>
+                                </Scroll.Element>
+                                <Scroll.Element name="location">
+                                    <fieldset>
+                                        <legend>Location</legend>
+                                        <Field
+                                            label="Country"
+                                            name="country"
+                                            type="text"
+                                            component={TextField}
+                                        />
+                                    </fieldset>
+                                </Scroll.Element>
+                                <Scroll.Element name="events">
+                                    <fieldset>
+                                        <legend>Events</legend>
+                                        <MuiPickersUtilsProvider
+                                            utils={DateFnsUtils}
+                                        >
                                             <Field
-                                                label="Source URL"
-                                                name="sourceUrl"
-                                                type="text"
-                                                placeholder="https://..."
-                                                component={TextField}
+                                                name="confirmedDate"
+                                                label="Date confirmed"
+                                                format="yyyy/MM/dd"
+                                                maxDate={new Date()}
+                                                minDate={new Date('2019/12/01')}
+                                                component={KeyboardDatePicker}
                                             />
-                                        </fieldset>
-                                    </Scroll.Element>
-                                    <Scroll.Element name="notes">
-                                        <fieldset>
-                                            <legend>Notes</legend>
-                                            <Field
-                                                label="Notes"
-                                                name="notes"
-                                                type="text"
-                                                component={TextField}
-                                            />
-                                        </fieldset>
-                                    </Scroll.Element>
-                                    {isSubmitting && <LinearProgress />}
-                                    <br />
-                                    <Button
-                                        variant="contained"
-                                        color="primary"
-                                        data-testid="submit"
-                                        disabled={isSubmitting}
-                                        onClick={submitForm}
-                                    >
-                                        Submit case
+                                        </MuiPickersUtilsProvider>
+                                    </fieldset>
+                                </Scroll.Element>
+                                <Scroll.Element name="source">
+                                    <fieldset>
+                                        <legend>Source</legend>
+                                        <Field
+                                            label="Source URL"
+                                            name="sourceUrl"
+                                            type="text"
+                                            placeholder="https://..."
+                                            component={TextField}
+                                        />
+                                    </fieldset>
+                                </Scroll.Element>
+                                <Scroll.Element name="notes">
+                                    <fieldset>
+                                        <legend>Notes</legend>
+                                        <Field
+                                            label="Notes"
+                                            name="notes"
+                                            type="text"
+                                            component={TextField}
+                                        />
+                                    </fieldset>
+                                </Scroll.Element>
+                                {isSubmitting && <LinearProgress />}
+                                <br />
+                                <Button
+                                    variant="contained"
+                                    color="primary"
+                                    data-testid="submit"
+                                    disabled={isSubmitting}
+                                    onClick={submitForm}
+                                >
+                                    Submit case
                                 </Button>
-                                    {this.state.errorMessage && (
-                                        <h3>{this.state.errorMessage as string}</h3>
-                                    )}
-                                </Form>
-                            </div>
+                                {this.state.errorMessage && (
+                                    <h3>{this.state.errorMessage as string}</h3>
+                                )}
+                            </Form>
                         </div>
-                    )}
+                    </div>
+                )}
             </Formik>
         );
     }

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -77,7 +77,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                 location: {
                     country: values.country,
                     // TODO: Infer the geo resolution from the location.
-                    geoResolution: 'Admin0',
+                    geoResolution: 'Country',
                 },
                 events: {
                     name: 'confirmed',
@@ -132,13 +132,13 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                 }}
             ></CheckCircleIcon>
         ) : (
-            <RadioButtonUncheckedIcon
-                style={{
-                    color: grey[500],
-                    margin: '0.25em 0.5em',
-                }}
-            ></RadioButtonUncheckedIcon>
-        );
+                    <RadioButtonUncheckedIcon
+                        style={{
+                            color: grey[500],
+                            margin: '0.25em 0.5em',
+                        }}
+                    ></RadioButtonUncheckedIcon>
+                );
     }
 
     scrollTo(name: string): void {
@@ -168,159 +168,159 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     values,
                     errors,
                 }): JSX.Element => (
-                    <div className={classes.container}>
-                        <nav className={classes.tableOfContents}>
-                            <div
-                                className={classes.tableOfContentsRow}
-                                onClick={(): void =>
-                                    this.scrollTo('demographics')
-                                }
-                            >
-                                {this.tableOfContentsIcon({
-                                    isChecked: values.sex !== undefined,
-                                    hasError: errors.sex !== undefined,
-                                })}
+                        <div className={classes.container}>
+                            <nav className={classes.tableOfContents}>
+                                <div
+                                    className={classes.tableOfContentsRow}
+                                    onClick={(): void =>
+                                        this.scrollTo('demographics')
+                                    }
+                                >
+                                    {this.tableOfContentsIcon({
+                                        isChecked: values.sex !== undefined,
+                                        hasError: errors.sex !== undefined,
+                                    })}
                                 Demographics
                             </div>
-                            <div
-                                className={classes.tableOfContentsRow}
-                                onClick={(): void => this.scrollTo('location')}
-                            >
-                                {this.tableOfContentsIcon({
-                                    isChecked: values.country.trim() !== '',
-                                    hasError: errors.country !== undefined,
-                                })}
+                                <div
+                                    className={classes.tableOfContentsRow}
+                                    onClick={(): void => this.scrollTo('location')}
+                                >
+                                    {this.tableOfContentsIcon({
+                                        isChecked: values.country.trim() !== '',
+                                        hasError: errors.country !== undefined,
+                                    })}
                                 Location
                             </div>
-                            <div
-                                className={classes.tableOfContentsRow}
-                                onClick={(): void => this.scrollTo('events')}
-                            >
-                                {this.tableOfContentsIcon({
-                                    isChecked: values.confirmedDate !== null,
-                                    hasError:
-                                        errors.confirmedDate !== undefined,
-                                })}
+                                <div
+                                    className={classes.tableOfContentsRow}
+                                    onClick={(): void => this.scrollTo('events')}
+                                >
+                                    {this.tableOfContentsIcon({
+                                        isChecked: values.confirmedDate !== null,
+                                        hasError:
+                                            errors.confirmedDate !== undefined,
+                                    })}
                                 Events
                             </div>
-                            <div
-                                className={classes.tableOfContentsRow}
-                                onClick={(): void => this.scrollTo('source')}
-                            >
-                                {this.tableOfContentsIcon({
-                                    isChecked: values.sourceUrl.trim() !== '',
-                                    hasError: errors.sourceUrl !== undefined,
-                                })}
+                                <div
+                                    className={classes.tableOfContentsRow}
+                                    onClick={(): void => this.scrollTo('source')}
+                                >
+                                    {this.tableOfContentsIcon({
+                                        isChecked: values.sourceUrl.trim() !== '',
+                                        hasError: errors.sourceUrl !== undefined,
+                                    })}
                                 Source
                             </div>
-                            <div
-                                className={classes.tableOfContentsRow}
-                                onClick={(): void => this.scrollTo('notes')}
-                            >
-                                {this.tableOfContentsIcon({
-                                    isChecked: values.notes.trim() !== '',
-                                    hasError: errors.notes !== undefined,
-                                })}
+                                <div
+                                    className={classes.tableOfContentsRow}
+                                    onClick={(): void => this.scrollTo('notes')}
+                                >
+                                    {this.tableOfContentsIcon({
+                                        isChecked: values.notes.trim() !== '',
+                                        hasError: errors.notes !== undefined,
+                                    })}
                                 Notes
                             </div>
-                        </nav>
-                        <div className={classes.form}>
-                            <Form>
-                                <Scroll.Element name="demographics">
-                                    <fieldset>
-                                        <legend>Demographics</legend>
-                                        <FormControl>
-                                            <InputLabel htmlFor="sex">
-                                                Sex
+                            </nav>
+                            <div className={classes.form}>
+                                <Form>
+                                    <Scroll.Element name="demographics">
+                                        <fieldset>
+                                            <legend>Demographics</legend>
+                                            <FormControl>
+                                                <InputLabel htmlFor="sex">
+                                                    Sex
                                             </InputLabel>
+                                                <Field
+                                                    as="select"
+                                                    name="sex"
+                                                    type="text"
+                                                    component={Select}
+                                                >
+                                                    <MenuItem
+                                                        value={undefined}
+                                                    ></MenuItem>
+                                                    <MenuItem value={'Female'}>
+                                                        Female
+                                                </MenuItem>
+                                                    <MenuItem value={'Male'}>
+                                                        Male
+                                                </MenuItem>
+                                                </Field>
+                                            </FormControl>
+                                        </fieldset>
+                                    </Scroll.Element>
+                                    <Scroll.Element name="location">
+                                        <fieldset>
+                                            <legend>Location</legend>
                                             <Field
-                                                as="select"
-                                                name="sex"
+                                                label="Country"
+                                                name="country"
                                                 type="text"
-                                                component={Select}
-                                            >
-                                                <MenuItem
-                                                    value={undefined}
-                                                ></MenuItem>
-                                                <MenuItem value={'Female'}>
-                                                    Female
-                                                </MenuItem>
-                                                <MenuItem value={'Male'}>
-                                                    Male
-                                                </MenuItem>
-                                            </Field>
-                                        </FormControl>
-                                    </fieldset>
-                                </Scroll.Element>
-                                <Scroll.Element name="location">
-                                    <fieldset>
-                                        <legend>Location</legend>
-                                        <Field
-                                            label="Country"
-                                            name="country"
-                                            type="text"
-                                            component={TextField}
-                                        />
-                                    </fieldset>
-                                </Scroll.Element>
-                                <Scroll.Element name="events">
-                                    <fieldset>
-                                        <legend>Events</legend>
-                                        <MuiPickersUtilsProvider
-                                            utils={DateFnsUtils}
-                                        >
-                                            <Field
-                                                name="confirmedDate"
-                                                label="Date confirmed"
-                                                format="yyyy/MM/dd"
-                                                maxDate={new Date()}
-                                                minDate={new Date('2019/12/01')}
-                                                component={KeyboardDatePicker}
+                                                component={TextField}
                                             />
-                                        </MuiPickersUtilsProvider>
-                                    </fieldset>
-                                </Scroll.Element>
-                                <Scroll.Element name="source">
-                                    <fieldset>
-                                        <legend>Source</legend>
-                                        <Field
-                                            label="Source URL"
-                                            name="sourceUrl"
-                                            type="text"
-                                            placeholder="https://..."
-                                            component={TextField}
-                                        />
-                                    </fieldset>
-                                </Scroll.Element>
-                                <Scroll.Element name="notes">
-                                    <fieldset>
-                                        <legend>Notes</legend>
-                                        <Field
-                                            label="Notes"
-                                            name="notes"
-                                            type="text"
-                                            component={TextField}
-                                        />
-                                    </fieldset>
-                                </Scroll.Element>
-                                {isSubmitting && <LinearProgress />}
-                                <br />
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    data-testid="submit"
-                                    disabled={isSubmitting}
-                                    onClick={submitForm}
-                                >
-                                    Submit case
+                                        </fieldset>
+                                    </Scroll.Element>
+                                    <Scroll.Element name="events">
+                                        <fieldset>
+                                            <legend>Events</legend>
+                                            <MuiPickersUtilsProvider
+                                                utils={DateFnsUtils}
+                                            >
+                                                <Field
+                                                    name="confirmedDate"
+                                                    label="Date confirmed"
+                                                    format="yyyy/MM/dd"
+                                                    maxDate={new Date()}
+                                                    minDate={new Date('2019/12/01')}
+                                                    component={KeyboardDatePicker}
+                                                />
+                                            </MuiPickersUtilsProvider>
+                                        </fieldset>
+                                    </Scroll.Element>
+                                    <Scroll.Element name="source">
+                                        <fieldset>
+                                            <legend>Source</legend>
+                                            <Field
+                                                label="Source URL"
+                                                name="sourceUrl"
+                                                type="text"
+                                                placeholder="https://..."
+                                                component={TextField}
+                                            />
+                                        </fieldset>
+                                    </Scroll.Element>
+                                    <Scroll.Element name="notes">
+                                        <fieldset>
+                                            <legend>Notes</legend>
+                                            <Field
+                                                label="Notes"
+                                                name="notes"
+                                                type="text"
+                                                component={TextField}
+                                            />
+                                        </fieldset>
+                                    </Scroll.Element>
+                                    {isSubmitting && <LinearProgress />}
+                                    <br />
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        data-testid="submit"
+                                        disabled={isSubmitting}
+                                        onClick={submitForm}
+                                    >
+                                        Submit case
                                 </Button>
-                                {this.state.errorMessage && (
-                                    <h3>{this.state.errorMessage as string}</h3>
-                                )}
-                            </Form>
+                                    {this.state.errorMessage && (
+                                        <h3>{this.state.errorMessage as string}</h3>
+                                    )}
+                                </Form>
+                            </div>
                         </div>
-                    </div>
-                )}
+                    )}
             </Formik>
         );
     }

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -76,6 +76,8 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                 },
                 location: {
                     country: values.country,
+                    // TODO: Infer the geo resolution from the location.
+                    geoResolution: 'Admin0',
                 },
                 events: {
                     name: 'confirmed',

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -172,15 +172,15 @@ class SourceTable extends React.Component<Props, SourceTableState> {
             },
             automation: rowData.awsScheduleExpression
                 ? {
-                    parser: rowData.awsLambdaArn
-                        ? {
-                            awsLambdaArn: rowData.awsLambdaArn,
-                        }
-                        : undefined,
-                    schedule: {
-                        awsScheduleExpression: rowData.awsScheduleExpression,
-                    },
-                }
+                      parser: rowData.awsLambdaArn
+                          ? {
+                                awsLambdaArn: rowData.awsLambdaArn,
+                            }
+                          : undefined,
+                      schedule: {
+                          awsScheduleExpression: rowData.awsScheduleExpression,
+                      },
+                  }
                 : undefined,
         };
     }
@@ -200,16 +200,16 @@ class SourceTable extends React.Component<Props, SourceTableState> {
             },
             automation: rowData.awsScheduleExpression
                 ? {
-                    parser: rowData.awsLambdaArn
-                        ? {
-                            awsLambdaArn: rowData.awsLambdaArn,
-                        }
-                        : undefined,
-                    schedule: {
-                        awsRuleArn: rowData.awsRuleArn,
-                        awsScheduleExpression: rowData.awsScheduleExpression,
-                    },
-                }
+                      parser: rowData.awsLambdaArn
+                          ? {
+                                awsLambdaArn: rowData.awsLambdaArn,
+                            }
+                          : undefined,
+                      schedule: {
+                          awsRuleArn: rowData.awsRuleArn,
+                          awsScheduleExpression: rowData.awsScheduleExpression,
+                      },
+                  }
                 : undefined,
         };
     }


### PR DESCRIPTION
Sorry as usual for the large diff :\ womp womp -- some of it is autoformatting though

Major changes:

- Remove location.id field; @attwad thinks we won't need it (and I agree)
- Add enum field `location.geoResolution`, and modify the converter to populate it (for location and travelHistory.location)
- Replace `location.locality` with `location.administrativeArea3` -- we do need this to be able to fully specify locations, and it is present in current data (it's not in the spec, though I'll see if Stephen wants to add it; even so, would rather not lose this precision even if we're not going to export this field)
- Add `location.place`: A POI, like a hospital
- Add `location.name`: A human-readable, short name for the location
- In the converter, use all the fields that are populated by the geocoder, instead of the curator input (more normalized)

`geoResolution` will be required for new data, since it can always be imputed from the other location fields, and location is required.

TESTED=Tested the full pipeline of convert data --> apply new schema --> import data, no validation errors