### PR TITLE
add component to display geolocation information

### DIFF
--- a/verification/curator-service/ui/src/components/Location.test.tsx
+++ b/verification/curator-service/ui/src/components/Location.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+
+import Location from './Location';
+import React from 'react';
+
+test('shows location when passed location information', async () => {
+    render(
+        <Location
+            location={{
+                type: 'place',
+                country: 'United States',
+                adminArea1: 'Hillsborough County',
+                latitude: 80.45,
+                longitude: 27.9379,
+            }}
+        />,
+    );
+    expect(screen.getByText(/place/i)).toBeInTheDocument();
+    expect(screen.getByText(/united States/i)).toBeInTheDocument();
+    expect(screen.getByText(/Hillsborough County/i)).toBeInTheDocument();
+    expect(screen.getByText(/80.4500/i)).toBeInTheDocument();
+    expect(screen.getByText(/27.9379/i)).toBeInTheDocument();
+    expect(screen.getByText(/N\/A/i)).toBeInTheDocument();
+});
+
+test('shows empty defaults when location undefined', async () => {
+    render(<Location location={undefined} />);
+    expect(screen.getByText(/Country/i)).toBeInTheDocument();
+});

--- a/verification/curator-service/ui/src/components/Location.tsx
+++ b/verification/curator-service/ui/src/components/Location.tsx
@@ -1,0 +1,94 @@
+import { Typography, withStyles } from '@material-ui/core';
+
+import React from 'react';
+import { WithStyles } from '@material-ui/core/styles/withStyles';
+import { createStyles } from '@material-ui/core/styles';
+
+const styles = () =>
+    createStyles({
+        root: {
+            display: 'flex',
+            flexWrap: 'wrap',
+        },
+        column: {
+            marginRight: '1em',
+        },
+    });
+
+interface Location {
+    type: string;
+    country: string;
+    adminArea1?: string;
+    adminArea2?: string;
+    latitude: number;
+    longitude: number;
+}
+
+// Cf. https://material-ui.com/guides/typescript/#augmenting-your-props-using-withstyles
+interface Props extends WithStyles<typeof styles> {
+    location?: Location;
+}
+
+class Profile extends React.Component<Props, {}> {
+    render(): JSX.Element {
+        const { classes } = this.props;
+        return (
+            <div className={classes.root}>
+                <div className={classes.column}>
+                    <p>
+                        <Typography variant="caption">Location Type</Typography>
+                    </p>
+                    <p>{this.props.location?.type}</p>
+                </div>
+                <div className={classes.column}>
+                    <p>
+                        <Typography variant="caption">Country</Typography>
+                    </p>
+                    <p>{this.props.location?.country}</p>
+                </div>
+                <div className={classes.column}>
+                    <p>
+                        <Typography variant="caption">Admin area 1</Typography>
+                    </p>
+                    <p>
+                        {this.props.location?.adminArea1
+                            ? this.props.location.adminArea1
+                            : 'N/A'}
+                    </p>
+                </div>
+                <div className={classes.column}>
+                    <p>
+                        <Typography variant="caption">Admin area 2</Typography>
+                    </p>
+                    <p>
+                        {this.props.location?.adminArea2
+                            ? this.props.location.adminArea2
+                            : 'N/A'}
+                    </p>
+                </div>
+                <div className={classes.column}>
+                    <p>
+                        <Typography variant="caption">Latitude</Typography>
+                    </p>
+                    <p>
+                        {this.props.location?.latitude
+                            ? this.props.location.latitude.toFixed(4)
+                            : '-'}
+                    </p>
+                </div>
+                <div className={classes.column}>
+                    <p>
+                        <Typography variant="caption">Longitude</Typography>
+                    </p>
+                    <p>
+                        {this.props.location?.longitude
+                            ? this.props.location.longitude.toFixed(4)
+                            : '-'}
+                    </p>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default withStyles(styles, { withTheme: true })(Profile);


### PR DESCRIPTION
Not plugging it in yet in the new case form until we can query geolocation info from the curator service.

With content from mocks:
![image](https://user-images.githubusercontent.com/1255432/84760163-ee532300-afc7-11ea-8c6f-d111821d686e.png)

Without location:
![image](https://user-images.githubusercontent.com/1255432/84760228-01fe8980-afc8-11ea-900e-da27d2bb0bd8.png)
