### PR TITLE
add files that will be used for async fetch of suggestions in new case form

### DIFF
--- a/suggest/README.md
+++ b/suggest/README.md
@@ -1,0 +1,3 @@
+# Autocomplete suggestions
+
+This directory contains files that serve as autocomplete suggestions for various input forms.

--- a/suggest/nationalities.txt
+++ b/suggest/nationalities.txt
@@ -1,0 +1,225 @@
+Afghan
+Albanian
+Algerian
+American
+Andorran
+Angolan
+Anguillan
+Argentine
+Armenian
+Australian
+Austrian
+Azerbaijani
+Bahamian
+Bahraini
+Bangladeshi
+Barbadian
+Belarusian
+Belgian
+Belizean
+Beninese
+Bermudian
+Bhutanese
+Bolivian
+Botswanan
+Brazilian
+British
+British Virgin Islander
+Bruneian
+Bulgarian
+Burkinan
+Burmese
+Burundian
+Cambodian
+Cameroonian
+Canadian
+Cape Verdean
+Cayman Islander
+Central African
+Chadian
+Chilean
+Chinese
+Citizen of Antigua and Barbuda
+Citizen of Bosnia and Herzegovina
+Citizen of Guinea-Bissau
+Citizen of Kiribati
+Citizen of Seychelles
+Citizen of the Dominican Republic
+Citizen of Vanuatu
+Colombian
+Comoran
+Congolese (Congo)
+Congolese (DRC)
+Cook Islander
+Costa Rican
+Croatian
+Cuban
+Cymraes
+Cymro
+Cypriot
+Czech
+Danish
+Djiboutian
+Dominican
+Dutch
+East Timorese
+Ecuadorean
+Egyptian
+Emirati
+English
+Equatorial Guinean
+Eritrean
+Estonian
+Ethiopian
+Faroese
+Fijian
+Filipino
+Finnish
+French
+Gabonese
+Gambian
+Georgian
+German
+Ghanaian
+Gibraltarian
+Greek
+Greenlandic
+Grenadian
+Guamanian
+Guatemalan
+Guinean
+Guyanese
+Haitian
+Honduran
+Hong Konger
+Hungarian
+Icelandic
+Indian
+Indonesian
+Iranian
+Iraqi
+Irish
+Israeli
+Italian
+Ivorian
+Jamaican
+Japanese
+Jordanian
+Kazakh
+Kenyan
+Kittitian
+Kosovan
+Kuwaiti
+Kyrgyz
+Lao
+Latvian
+Lebanese
+Liberian
+Libyan
+Liechtenstein citizen
+Lithuanian
+Luxembourger
+Macanese
+Macedonian
+Malagasy
+Malawian
+Malaysian
+Maldivian
+Malian
+Maltese
+Marshallese
+Martiniquais
+Mauritanian
+Mauritian
+Mexican
+Micronesian
+Moldovan
+Monegasque
+Mongolian
+Montenegrin
+Montserratian
+Moroccan
+Mosotho
+Mozambican
+Namibian
+Nauruan
+Nepalese
+New Zealander
+Nicaraguan
+Nigerian
+Nigerien
+Niuean
+North Korean
+Northern Irish
+Norwegian
+Omani
+Pakistani
+Palauan
+Palestinian
+Panamanian
+Papua New Guinean
+Paraguayan
+Peruvian
+Pitcairn Islander
+Polish
+Portuguese
+Prydeinig
+Puerto Rican
+Qatari
+Romanian
+Russian
+Rwandan
+Salvadorean
+Sammarinese
+Samoan
+Sao Tomean
+Saudi Arabian
+Scottish
+Senegalese
+Serbian
+Sierra Leonean
+Singaporean
+Slovak
+Slovenian
+Solomon Islander
+Somali
+South African
+South Korean
+South Sudanese
+Spanish
+Sri Lankan
+St Helenian
+St Lucian
+Stateless
+Sudanese
+Surinamese
+Swazi
+Swedish
+Swiss
+Syrian
+Taiwanese
+Tajik
+Tanzanian
+Thai
+Togolese
+Tongan
+Trinidadian
+Tristanian
+Tunisian
+Turkish
+Turkmen
+Turks and Caicos Islander
+Tuvaluan
+Ugandan
+Ukrainian
+Uruguayan
+Uzbek
+Vatican citizen
+Venezuelan
+Vietnamese
+Vincentian
+Wallisian
+Welsh
+Yemeni
+Zambian
+Zimbabwean

--- a/suggest/place_of_transmission.txt
+++ b/suggest/place_of_transmission.txt
@@ -1,0 +1,28 @@
+Assisted Living
+Bar / Pub
+Building site
+Conference
+Elderly Care
+Factory
+Food Processing Plant
+Funeral
+Gym
+Hospital
+Hotel
+Household
+Large shared accomodation
+Long Term Acute Care
+Long Term Care Facility
+Nighclub
+Office
+Prison
+Public Space
+Religous place of worship
+Restaurant
+School
+Ship
+Shopping
+Sport event
+Warehouse
+Wedding
+Work


### PR DESCRIPTION
This is based on the sheets in "Line list data model: Standard specification" spreadsheet from Stephen.

I didn't add the professions because they are way too noisy and need cleaning before we check it in.

They will be fetched using https://material-ui.com/components/autocomplete/#asynchronous-requests