### PR TITLE
Bring events schema up to spec

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -126,6 +126,9 @@
             "name": {
               "bsonType": "string"
             },
+            "value": {
+              "bsonType": "string"
+            },
             "dateRange": {
               "bsonType": "object",
               "additionalProperties": false,

--- a/data-serving/data-service/src/model/event.ts
+++ b/data-serving/data-service/src/model/event.ts
@@ -7,10 +7,12 @@ export const eventSchema = new mongoose.Schema({
         type: String,
         required: 'Enter a name for the event',
     },
+    value: String,
     dateRange: dateRangeSchema,
 });
 
 export type EventDocument = mongoose.Document & {
     name: string;
+    value: string;
     dateRange: DateRangeDocument;
 };

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -30,6 +30,7 @@
         },
         {
             "name": "confirmed",
+            "value": "PCR test",
             "dateRange": {
                 "start": 1578891600000,
                 "end": 1578891600000
@@ -43,7 +44,8 @@
             }
         },
         {
-            "name": "discharged",
+            "name": "outcome",
+            "value": "Recovered",
             "dateRange": {
                 "start": "1581483600000",
                 "end": "1581483600000"

--- a/data-serving/data-service/test/model/data/event.full.json
+++ b/data-serving/data-service/test/model/data/event.full.json
@@ -1,5 +1,6 @@
 {
-    "name": "onsetSymptoms",
+    "name": "outcome",
+    "value": "Recovered",
     "dateRange": {
         "start": 1578000000000,
         "end": 1578027600000

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -48,6 +48,7 @@
             },
             {
                 "name": "confirmed",
+                "value": "PCR test",
                 "dateRange": {
                     "start": {
                         "$date": {
@@ -77,7 +78,8 @@
                 }
             },
             {
-                "name": "discharged",
+                "name": "outcome",
+                "value": "Recovered",
                 "dateRange": {
                     "start": {
                         "$date": {


### PR DESCRIPTION
Adding a "value" field to the event schema to capture the content of the event, as well as the date; 

The values we expect include:

- Method of confirmation | String | Multiple choice | - PCR test- Serological test- Clinical diagnosis- 
- Hospital admission | String | Multiple choice | - Yes- No- Unknown
- Admitted to isolation unit in hospital | String | Multiple choice | - Yes- No- Unknown
- Outcome | String | Multiple choice | - Death- Recovered- Unknown

Not going to specify these values in the schema to keep it more open; I think it's probably OK for the UI to be the arbiter here.