### PR TITLE
Geocode new cases

### DIFF
--- a/data-serving/scripts/setup-db/README.md
+++ b/data-serving/scripts/setup-db/README.md
@@ -14,13 +14,13 @@ This directory contains a script to set up a fresh MongoDB collection.
 To run it with the defaults -- i.e. against localhost, no authentication, using
 the default database (`covid19`) and collection (`cases`), run:
 
-`npm run setup_cases`
+`npm run setup-cases`
 
 To run it with configurable options, e.g. a different connection string, run:
 
 `CONN="some_conn_string" DB="some_db" COLL="some_collection" SCHEMA="../some/schema/path.json" npm run setup`
 
 For example, the below invocation of `setup` would give you the same result as
-`setup_cases`:
+`setup-cases`:
 
 `CONN="mongodb://127.0.0.1:27017" DB="covid19" COLL="cases" SCHEMA="./../../data-service/schemas/cases.schema.json" npm run setup`

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -10,7 +10,7 @@ import axios from 'axios';
 export default class CasesController {
     constructor(
         private readonly dataServerURL: string,
-        private readonly geocoder: Geocoder,
+        private readonly geocoders: Geocoder[],
     ) {}
 
     list = async (req: Request, res: Response): Promise<void> => {
@@ -65,16 +65,24 @@ export default class CasesController {
     create = async (req: Request, res: Response): Promise<void> => {
         // Geocode query if no lat lng were provided.
         const location = req.body['location'];
-        if (!location?.lat || !location.lng) {
-            const features = await this.geocoder.geocode(location?.query);
-            if (features.length === 0) {
+        if (!location?.geometry?.lat || !location.geometry?.lng) {
+            let geocodeSuccess = false;
+            for (const geocoder of this.geocoders) {
+                const features = await geocoder.geocode(location?.query);
+                if (features.length === 0) {
+                    continue;
+                }
+                // Currently a 1:1 match between the GeocodeResult and the data service API.
+                req.body['location'] = features[0];
+                geocodeSuccess = true;
+                break;
+            }
+            if (!geocodeSuccess) {
                 res.status(404).send(
                     `no geolocation found for ${location?.query}`,
                 );
                 return;
             }
-            // Currently a 1:1 match between the GeocodeResult and the data service API.
-            req.body['location'] = features[0];
         }
         try {
             const response = await axios.post(

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -63,7 +63,19 @@ export default class CasesController {
     };
 
     create = async (req: Request, res: Response): Promise<void> => {
-        // TODO: Geocode if no lat/lng provided.
+        // Geocode query if no lat lng were provided.
+        const location = req.body['location'];
+        if (!location?.lat || !location.lng) {
+            const features = await this.geocoder.geocode(location?.query);
+            if (features.length === 0) {
+                res.status(404).send(
+                    `no geolocation found for ${location?.query}`,
+                );
+                return;
+            }
+            // Currently a 1:1 match between the GeocodeResult and the data service API.
+            req.body['location'] = features[0];
+        }
         try {
             const response = await axios.post(
                 this.dataServerURL + '/api' + req.url,

--- a/verification/curator-service/api/src/geocoding/fake.ts
+++ b/verification/curator-service/api/src/geocoding/fake.ts
@@ -9,6 +9,7 @@ export default class FakeGeocoder {
         this.entries = new Map<string, GeocodeResult>();
     }
     async geocode(query: string): Promise<GeocodeResult[]> {
+        console.debug('geocoding ', query);
         const entry = this.entries.get(query);
         return entry ? [entry] : [];
     }
@@ -16,10 +17,12 @@ export default class FakeGeocoder {
     seed = (req: Request, res: Response): void => {
         const body = req.body as GeocodeResult;
         this.entries.set(body.name, body);
+        console.debug('after seed:', this.entries);
         res.sendStatus(200);
     };
 
     clear = (req: Request, res: Response): void => {
+        console.debug('clearing fake geocodes');
         this.entries.clear();
         res.sendStatus(200);
     };

--- a/verification/curator-service/api/src/geocoding/geocoder.ts
+++ b/verification/curator-service/api/src/geocoding/geocoder.ts
@@ -15,6 +15,16 @@ export interface GeocodeResult {
     place: string | undefined;
     // Human readable place name.
     name: string;
+    // How granular the geocode is.
+    geoResolution: Resolution;
+}
+
+export enum Resolution {
+    Point = 'Point',
+    Admin3 = 'Admin3',
+    Admin2 = 'Admin2',
+    Admin1 = 'Admin1',
+    Country = 'Country',
 }
 
 // A geocoder can geocode queries into places.

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -1,3 +1,4 @@
+import { GeocodeResult, Resolution } from './geocoder';
 import Geocoding, {
     GeocodeFeature,
     GeocodeMode,
@@ -5,7 +6,6 @@ import Geocoding, {
     GeocodeService,
 } from '@mapbox/mapbox-sdk/services/geocoding';
 
-import { GeocodeResult } from './geocoder';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
 
 // getFeatureTypeFromContext will return the feature 'text' field if it is of the provided type.
@@ -20,6 +20,27 @@ function getFeatureTypeFromContext(
         }
     }
     return '';
+}
+
+// Gets the finest resolution contained in the features.
+function getResolution(features: GeocodeFeature[]): Resolution {
+    // IDs contain the type of features in "place.someid" format.
+    const types = new Set(
+        features.map((f: GeocodeFeature): string =>
+            f.id.substring(0, f.id.indexOf('.')),
+        ),
+    );
+    // Go through each type from finest to largest and return the first match.
+    if (types.has('poi')) {
+        return Resolution.Point;
+    } else if (types.has('place')) {
+        return Resolution.Admin3;
+    } else if (types.has('district')) {
+        return Resolution.Admin2;
+    } else if (types.has('region')) {
+        return Resolution.Admin1;
+    }
+    return Resolution.Country;
 }
 
 export default class MapboxGeocoder {
@@ -69,6 +90,7 @@ export default class MapboxGeocoder {
                         'poi',
                     ),
                     name: feature.text,
+                    geoResolution: getResolution([feature, ...feature.context]),
                 };
             });
         } catch (e) {

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -32,6 +32,7 @@ export default class MapboxGeocoder {
 
     async geocode(query: string): Promise<GeocodeResult[]> {
         try {
+            // TODO: Add LRU cache.
             const resp: MapiResponse = await this.geocodeService
                 .forwardGeocode({
                     mode: this.endpoint,

--- a/verification/curator-service/api/src/util/validate-env.ts
+++ b/verification/curator-service/api/src/util/validate-env.ts
@@ -16,6 +16,7 @@ export default function validateEnv(): Readonly<{
     ENABLE_LOCAL_AUTH: boolean;
     MAPBOX_TOKEN: string;
     MAPBOX_PERMANENT_GEOCODE: boolean;
+    ENABLE_FAKE_GEOCODER: boolean;
 }> &
     CleanEnv & {
         readonly [varName: string]: string | undefined;
@@ -85,6 +86,11 @@ export default function validateEnv(): Readonly<{
             desc: 'Whether to use the permanent geocode endpoint',
             devDefault: false,
             default: true,
+        }),
+        ENABLE_FAKE_GEOCODER: bool({
+            desc: 'Whether to enable the fake seedable geocoder',
+            devDefault: true,
+            default: false,
         }),
     });
 }

--- a/verification/curator-service/api/test/auth.test.ts
+++ b/verification/curator-service/api/test/auth.test.ts
@@ -16,8 +16,6 @@ import supertest from 'supertest';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-jest.mock('../src/geocoding/mapbox');
-
 beforeAll(() => {
     return mongoose.connect(
         // This is provided by jest-mongodb.

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -1,8 +1,8 @@
 import * as baseUser from './users/base.json';
 
+import { GeocodeResult, Resolution } from '../src/geocoding/geocoder';
 import { Session, User } from '../src/model/user';
 
-import { GeocodeResult } from '../src/geocoding/geocoder';
 import app from '../src/index';
 import axios from 'axios';
 import mongoose from 'mongoose';
@@ -130,6 +130,7 @@ describe('Cases', () => {
             geometry: { latitude: 45.75889, longitude: 4.84139 },
             place: '',
             name: 'Lyon',
+            geoResolution: Resolution.Admin3,
         };
         await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
         mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -2,6 +2,7 @@ import * as baseUser from './users/base.json';
 
 import { Session, User } from '../src/model/user';
 
+import { GeocodeResult } from '../src/geocoding/geocoder';
 import app from '../src/index';
 import axios from 'axios';
 import mongoose from 'mongoose';
@@ -9,7 +10,6 @@ import supertest from 'supertest';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
-jest.mock('../src/geocoding/mapbox');
 
 afterEach(() => {
     jest.clearAllMocks();
@@ -58,6 +58,9 @@ describe('Cases', () => {
             .post('/auth/register')
             .send({ ...baseUser, ...{ roles: ['reader', 'curator'] } })
             .expect(200);
+    });
+    afterEach(async () => {
+        await curatorRequest.post('/api/geocode/clear').expect(200);
     });
     it('denies access to non readers', async () => {
         await supertest
@@ -118,11 +121,21 @@ describe('Cases', () => {
         );
     });
 
-    it('proxies create calls', async () => {
+    it('proxies create calls and geocode', async () => {
+        const lyon: GeocodeResult = {
+            administrativeAreaLevel1: 'Rhône',
+            administrativeAreaLevel2: '',
+            administrativeAreaLevel3: 'Lyon',
+            country: 'France',
+            geometry: { latitude: 45.75889, longitude: 4.84139 },
+            place: '',
+            name: 'Lyon',
+        };
+        await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
         mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
             .post('/api/cases')
-            .send({ age: '42' })
+            .send({ age: '42', location: { query: 'Lyon' } })
             .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
@@ -130,7 +143,16 @@ describe('Cases', () => {
             'http://localhost:3000/api/cases',
             {
                 age: '42',
+                location: lyon,
             },
         );
+    });
+
+    it('returns 404 when no geocode could be found on create', async () => {
+        mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);
+        await curatorRequest
+            .post('/api/cases')
+            .send({ age: '42', location: { query: 'Lyon' } })
+            .expect(404);
     });
 });

--- a/verification/curator-service/api/test/geocoding/mapbox.test.ts
+++ b/verification/curator-service/api/test/geocoding/mapbox.test.ts
@@ -48,6 +48,7 @@ describe('geocode', () => {
             geometry: { latitude: 45.75889, longitude: 4.84139 },
             place: '',
             name: 'Lyon',
+            geoResolution: 'Admin3',
         });
     });
     it('can return no results', async () => {

--- a/verification/curator-service/api/test/index.test.ts
+++ b/verification/curator-service/api/test/index.test.ts
@@ -1,7 +1,6 @@
 import app from '../src/index';
 import mongoose from 'mongoose';
 import request from 'supertest';
-jest.mock('../src/geocoding/mapbox');
 
 beforeAll(() => {
     return mongoose.connect(

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -19,7 +19,6 @@ jest.mock('../src/clients/aws-events-client', () => {
         return { deleteRule: mockDeleteRule, putRule: mockPutRule };
     });
 });
-jest.mock('../src/geocoding/mapbox');
 
 beforeAll(() => {
     return mongoose.connect(

--- a/verification/curator-service/api/test/users.test.ts
+++ b/verification/curator-service/api/test/users.test.ts
@@ -6,8 +6,6 @@ import app from '../src/index';
 import mongoose from 'mongoose';
 import supertest from 'supertest';
 
-jest.mock('../src/geocoding/mapbox');
-
 beforeAll(() => {
     return mongoose.connect(
         // This is provided by jest-mongodb.

--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -11,6 +11,8 @@ describe('Linelist table', function () {
 
         cy.get('button[title="Add"]').click();
         cy.get('input[placeholder="Country"]').clear().type('France');
+        cy.get('input[placeholder="Lat"]').clear().type('42');
+        cy.get('input[placeholder="Lng"]').clear().type('12');
         cy.get('input[placeholder="Admin area 1"]').clear().type('Rhône');
         cy.get('input[placeholder="Admin area 2"]')
             .clear()

--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -8,6 +8,12 @@ describe('New case form', function () {
     it('Can add row to linelist', function () {
         cy.visit('/cases');
         cy.contains('No records to display');
+        cy.seedLocation({
+            country: 'France',
+            geometry: { latitude: 45.75889, longitude: 4.84139 },
+            name: 'France',
+            geoResolution: 'Country',
+        });
 
         cy.visit('/cases/new');
         cy.get('div[data-testid="sex"]').click();
@@ -15,7 +21,7 @@ describe('New case form', function () {
         cy.get('input[name="age"]').clear().type('21');
         cy.get('div[data-testid="ethnicity"]').click();
         cy.get('li[data-value="Asian"').click();
-        cy.get('input[name="country"]').clear().type('France');
+        cy.get('input[name="locationQuery"]').clear().type('France');
         cy.get('input[name="confirmedDate"]').clear().type('2020-01-01');
         cy.get('input[name="sourceUrl"]').clear().type('www.example.com');
         cy.get('input[name="notes"]').clear().type('test notes');
@@ -36,6 +42,8 @@ describe('New case form', function () {
     });
 
     it('Does not add row on submission error', function () {
+        // Avoid geolocation fail, the failure should happen at the data service level.
+        cy.seedLocation({ name: '' });
         cy.visit('/cases');
         cy.contains('No records to display');
 
@@ -53,7 +61,7 @@ describe('New case form', function () {
     it('Shows checkbox on field completion', function () {
         cy.visit('/cases/new');
         cy.get('svg[data-testid="check-icon"]').should('not.exist');
-        cy.get('input[name="country"]').clear().type('France');
+        cy.get('input[name="locationQuery"]').clear().type('France');
         cy.get('svg[data-testid="check-icon"]').should('exist');
     });
 

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -8,6 +8,8 @@ declare global {
             ) => void;
             login: () => void;
             addSource: (name: string, url: string) => void;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            seedLocation: (loc: any) => void;
         }
     }
 }
@@ -24,6 +26,10 @@ export function addCase(
             location: {
                 country: country,
                 geoResolution: 'Country',
+                geometry: {
+                    lat: 42,
+                    lng: 12,
+                },
             },
             events: [
                 {
@@ -66,6 +72,15 @@ export function login(opts: {
     });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function seedLocation(loc: any): void {
+    cy.request({
+        method: 'POST',
+        url: '/api/geocode/seed',
+        body: loc,
+    });
+}
+
 export function addSource(name: string, url: string): void {
     cy.request({
         method: 'POST',
@@ -82,3 +97,4 @@ export function addSource(name: string, url: string): void {
 Cypress.Commands.add('addCase', addCase);
 Cypress.Commands.add('login', login);
 Cypress.Commands.add('addSource', addSource);
+Cypress.Commands.add('seedLocation', seedLocation);

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -34,6 +34,10 @@ it('loads and displays cases', async () => {
                 country: 'France',
                 administrativeAreaLevel1: 'some admin 1',
                 administrativeAreaLevel2: 'some admin 2',
+                geometry: {
+                    lat: 42,
+                    lng: 12,
+                },
                 // TODO: Infer the geo resolution from the location.
                 geoResolution: 'Admin2',
             },
@@ -251,6 +255,10 @@ it('can add a row', async () => {
         location: {
             country: 'France',
             geoResolution: 'Country',
+            geometry: {
+                lat: 42,
+                lng: 12,
+            },
         },
         events: [
             {
@@ -311,6 +319,10 @@ it('can edit a row', async () => {
             location: {
                 country: 'France',
                 geoResolution: 'Country',
+                geometry: {
+                    lat: 42,
+                    lng: 12,
+                },
             },
             events: [
                 {
@@ -424,6 +436,10 @@ it('cannot edit data as a reader only', async () => {
             location: {
                 country: 'France',
                 geoResolution: 'Country',
+                geometry: {
+                    lat: 42,
+                    lng: 12,
+                },
             },
             events: [
                 {

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -39,6 +39,12 @@ interface Location {
     country: string;
     administrativeAreaLevel1: string;
     administrativeAreaLevel2: string;
+    geometry: Geometry;
+}
+
+interface Geometry {
+    lat: number;
+    lng: number;
 }
 
 interface Source {
@@ -72,6 +78,8 @@ interface TableRow {
     country: string;
     adminArea1: string;
     adminArea2: string;
+    lat: number;
+    lng: number;
     confirmedDate: Date | null;
     // sources
     sourceUrl: string | null;
@@ -130,6 +138,10 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                 country: rowData.country,
                 administrativeAreaLevel1: rowData.adminArea1,
                 administrativeAreaLevel2: rowData.adminArea2,
+                geometry: {
+                    lat: rowData.lat,
+                    lng: rowData.lng,
+                },
                 // TODO: Infer the geo resolution from the location.
                 geoResolution: 'Admin2',
             },
@@ -249,6 +261,16 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 filtering: false,
                             },
                             {
+                                title: 'Lat',
+                                field: 'lat',
+                                filtering: false,
+                            },
+                            {
+                                title: 'Lng',
+                                field: 'lng',
+                                filtering: false,
+                            },
+                            {
                                 title: 'Confirmed date',
                                 field: 'confirmedDate',
                                 filtering: false,
@@ -322,6 +344,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 adminArea2:
                                                     c.location
                                                         ?.administrativeAreaLevel2,
+                                                lat: c.location.geometry?.lat,
+                                                lng: c.location.geometry?.lng,
                                                 confirmedDate: confirmedDate
                                                     ? new Date(confirmedDate)
                                                     : null,

--- a/verification/curator-service/ui/src/components/NewCaseForm.test.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.test.tsx
@@ -22,7 +22,7 @@ it('renders form', () => {
     const { getByText, getAllByText } = render(<NewCaseForm user={user} />);
     expect(getByText(/Submit case/i)).toBeInTheDocument();
     expect(getAllByText(/Demographics/i)).toHaveLength(2);
-    expect(getAllByText(/Location/i)).toHaveLength(2);
+    expect(getAllByText(/Location/i)).toHaveLength(3);
     expect(getAllByText(/Events/i)).toHaveLength(2);
     expect(getByText(/Source URL/i)).toBeInTheDocument();
 });
@@ -60,8 +60,7 @@ it('submits case ok', async () => {
             },
         },
         location: {
-            country: '',
-            geoResolution: 'Country',
+            query: '',
         },
         revisionMetadata: {
             revisionNumber: 0,

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -58,7 +58,7 @@ interface FormValues {
     maxAge?: number;
     age?: number;
     ethnicity?: string;
-    country: string;
+    locationQuery: string;
     confirmedDate: string | null;
     sourceUrl: string;
     notes: string;
@@ -121,9 +121,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     ethnicity: values.ethnicity,
                 },
                 location: {
-                    country: values.country,
-                    // TODO: Infer the geo resolution from the location.
-                    geoResolution: 'Country',
+                    query: values.locationQuery,
                 },
                 events: {
                     name: 'confirmed',
@@ -205,7 +203,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     maxAge: undefined,
                     age: undefined,
                     ethnicity: undefined,
-                    country: '',
+                    locationQuery: '',
                     confirmedDate: null,
                     sourceUrl: '',
                     notes: '',
@@ -251,8 +249,10 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                                 onClick={(): void => this.scrollTo('location')}
                             >
                                 {this.tableOfContentsIcon({
-                                    isChecked: values.country.trim() !== '',
-                                    hasError: errors.country !== undefined,
+                                    isChecked:
+                                        values.locationQuery.trim() !== '',
+                                    hasError:
+                                        errors.locationQuery !== undefined,
                                 })}
                                 Location
                             </div>
@@ -295,8 +295,8 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                                     <fieldset>
                                         <legend>Location</legend>
                                         <Field
-                                            label="Country"
-                                            name="country"
+                                            label="Location"
+                                            name="locationQuery"
                                             type="text"
                                             component={TextField}
                                         />


### PR DESCRIPTION
If a new case doesn't have lat/lng it will trigger geocoding based on the request's `location.query` string.

I replaced `country` in the new form with this `query` field. It will be an autocomplete field once we have it working (ETA 4-5 years based on early assessment).

In order to be able to run the dev stack connected to map box and the integration tests as well I made the cases controller accept an array of geocoders that are called in sequence. This way we can fake locations in integration tests and play with real geocodes on our local stack.

We also should probably retire the edit/new functionality of the linelist table soon, fixing the tests is not super fun now that the new form and the table have drifted a bit.