### PR TITLE
Add CaseReference object, per spec, to our case schema/model

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -16,10 +16,10 @@
           "_id": {
             "bsonType": "objectId"
           },
-          "dataSourceId": {
+          "sourceId": {
             "bsonType": "string"
           },
-          "dataEntryId": {
+          "sourceEntryId": {
             "bsonType": "string"
           }
         }

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -9,6 +9,21 @@
       "__v": {
         "bsonType": "int"
       },
+      "caseReference": {
+        "bsonType": "object",
+        "additionalProperties": false,
+        "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
+          "dataSourceId": {
+            "bsonType": "string"
+          },
+          "dataEntryId": {
+            "bsonType": "string"
+          }
+        }
+      },
       "demographics": {
         "bsonType": "object",
         "additionalProperties": false,

--- a/data-serving/data-service/src/model/case-reference.ts
+++ b/data-serving/data-service/src/model/case-reference.ts
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+export const caseReferenceSchema = new mongoose.Schema({
+    dataSourceId: {
+        type: String,
+        required: true,
+    },
+    dataEntryId: String,
+});
+
+export type CaseReferenceDocument = mongoose.Document & {
+    dataSourceId: string;
+    dataEntryId: string;
+};

--- a/data-serving/data-service/src/model/case-reference.ts
+++ b/data-serving/data-service/src/model/case-reference.ts
@@ -1,14 +1,14 @@
 import mongoose from 'mongoose';
 
 export const caseReferenceSchema = new mongoose.Schema({
-    dataSourceId: {
+    sourceId: {
         type: String,
         required: true,
     },
-    dataEntryId: String,
+    sourceEntryId: String,
 });
 
 export type CaseReferenceDocument = mongoose.Document & {
-    dataSourceId: string;
-    dataEntryId: string;
+    sourceId: string;
+    sourceEntryId: string;
 };

--- a/data-serving/data-service/src/model/case.ts
+++ b/data-serving/data-service/src/model/case.ts
@@ -1,3 +1,4 @@
+import { CaseReferenceDocument, caseReferenceSchema } from './case-reference';
 import { DemographicsDocument, demographicsSchema } from './demographics';
 import { DictionaryDocument, dictionarySchema } from './dictionary';
 import { EventDocument, eventSchema } from './event';
@@ -15,7 +16,7 @@ import mongoose from 'mongoose';
 
 const caseSchema = new mongoose.Schema(
     {
-        preexistingConditions: dictionarySchema,
+        caseReference: caseReferenceSchema,
         demographics: demographicsSchema,
         events: {
             type: [eventSchema],
@@ -34,6 +35,7 @@ const caseSchema = new mongoose.Schema(
         },
         notes: String,
         pathogens: [pathogenSchema],
+        preexistingConditions: dictionarySchema,
         sources: {
             type: [sourceSchema],
             required: true,
@@ -63,7 +65,7 @@ const caseSchema = new mongoose.Schema(
 
 type CaseDocument = mongoose.Document & {
     _id: ObjectId;
-    preexistingConditions: DictionaryDocument;
+    caseReference: CaseReferenceDocument;
     demographics: DemographicsDocument;
     events: [EventDocument];
     importedCase: {};
@@ -71,6 +73,7 @@ type CaseDocument = mongoose.Document & {
     revisionMetadata: RevisionMetadataDocument;
     notes: string;
     pathogens: [PathogenDocument];
+    preexistingConditions: DictionaryDocument;
     sources: [SourceDocument];
     symptoms: DictionaryDocument;
     travelHistory: [TravelDocument];

--- a/data-serving/data-service/test/model/case-reference.test.ts
+++ b/data-serving/data-service/test/model/case-reference.test.ts
@@ -14,9 +14,9 @@ const CaseReference = mongoose.model<CaseReferenceDocument>(
 );
 
 describe('validate', () => {
-    it('a caseReference document without dataSourceId is invalid', async () => {
+    it('a caseReference document without sourceId is invalid', async () => {
         const missingSourceId = { ...minimalModel };
-        delete missingSourceId.dataSourceId;
+        delete missingSourceId.sourceId;
 
         return new CaseReference(missingSourceId).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);

--- a/data-serving/data-service/test/model/case-reference.test.ts
+++ b/data-serving/data-service/test/model/case-reference.test.ts
@@ -1,0 +1,32 @@
+import {
+    CaseReferenceDocument,
+    caseReferenceSchema,
+} from '../../src/model/case-reference';
+
+import { Error } from 'mongoose';
+import fullModel from './data/case-reference.full.json';
+import minimalModel from './data/case-reference.minimal.json';
+import mongoose from 'mongoose';
+
+const CaseReference = mongoose.model<CaseReferenceDocument>(
+    'CaseReference',
+    caseReferenceSchema,
+);
+
+describe('validate', () => {
+    it('a caseReference document without dataSourceId is invalid', async () => {
+        const missingSourceId = { ...minimalModel };
+        delete missingSourceId.dataSourceId;
+
+        return new CaseReference(missingSourceId).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+    it('a minimal caseReference document is valid', async () => {
+        return new CaseReference(minimalModel).validate();
+    });
+
+    it('a fully specified caseReference document is valid', async () => {
+        return new CaseReference(fullModel).validate();
+    });
+});

--- a/data-serving/data-service/test/model/data/case-reference.full.json
+++ b/data-serving/data-service/test/model/data/case-reference.full.json
@@ -1,0 +1,4 @@
+{
+    "dataSourceId": "sourceId",
+    "dataEntryId": "entryId"
+}

--- a/data-serving/data-service/test/model/data/case-reference.full.json
+++ b/data-serving/data-service/test/model/data/case-reference.full.json
@@ -1,4 +1,4 @@
 {
-    "dataSourceId": "sourceId",
-    "dataEntryId": "entryId"
+    "sourceId": "sourceId",
+    "sourceEntryId": "entryId"
 }

--- a/data-serving/data-service/test/model/data/case-reference.minimal.json
+++ b/data-serving/data-service/test/model/data/case-reference.minimal.json
@@ -1,0 +1,3 @@
+{
+    "dataSourceId": "sourceId"
+}

--- a/data-serving/data-service/test/model/data/case-reference.minimal.json
+++ b/data-serving/data-service/test/model/data/case-reference.minimal.json
@@ -1,3 +1,3 @@
 {
-    "dataSourceId": "sourceId"
+    "sourceId": "sourceId"
 }

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -1,4 +1,8 @@
 {
+    "caseReference": {
+        "dataSourceId": "sourceId",
+        "dataEntryId": "entryId"
+    },
     "demographics": {
         "ageRange": {
             "start": 50.0,

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -1,7 +1,7 @@
 {
     "caseReference": {
-        "dataSourceId": "sourceId",
-        "dataEntryId": "entryId"
+        "sourceId": "sourceId",
+        "sourceEntryId": "entryId"
     },
     "demographics": {
         "ageRange": {


### PR DESCRIPTION
I'll chat with Kelly next week, but for the time being, this adds the `CaseReference` object defined in the official line list spec to our data service schema/model. This is necessary to perform upsert for the purpose of deduplication, which I'll send subsequently.

I suspect we'll want to somewhat merge this with the `Sources` field; something for me to pick Kelly/Stephen's brain on next week.