### PR TITLE
Add the case upsert API to the data service

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -124,7 +124,13 @@ export const update = async (req: Request, res: Response): Promise<void> => {
 };
 
 /**
- * Upserts a case based on a compound index of { sourceId, entryId }.
+ * Upserts a case based on a compound index of
+ * caseReference.{dataSourceId, dataEntryId}.
+ *
+ * On success, the returned status code indicates whether than item was created
+ * (201) or updated (200).
+ *
+ * Handles HTTP PUT /api/cases.
  */
 export const upsert = async (req: Request, res: Response): Promise<void> => {
     try {
@@ -143,7 +149,6 @@ export const upsert = async (req: Request, res: Response): Promise<void> => {
                 upsert: true,
             },
         );
-        console.log(result);
         let status;
         if (result.lastErrorObject.updatedExisting) {
             status = 200;
@@ -152,7 +157,6 @@ export const upsert = async (req: Request, res: Response): Promise<void> => {
         }
         res.status(status).json(result.value);
     } catch (err) {
-        console.log(err);
         if (err.name === 'ValidationError') {
             res.status(422).json(err.message);
             return;

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -135,8 +135,9 @@ export const update = async (req: Request, res: Response): Promise<void> => {
 export const upsert = async (req: Request, res: Response): Promise<void> => {
     try {
         const c = await Case.findOne({
-            'caseReference.dataSourceId': req.body.caseReference?.dataSourceId,
-            'caseReference.dataEntryId': req.body.caseReference?.dataEntryId,
+            'caseReference.sourceId': req.body.caseReference?.sourceId,
+            'caseReference.sourceEntryId':
+                req.body.caseReference?.sourceEntryId,
         });
         if (c) {
             c.set(req.body);

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -134,28 +134,21 @@ export const update = async (req: Request, res: Response): Promise<void> => {
  */
 export const upsert = async (req: Request, res: Response): Promise<void> => {
     try {
-        const result = await Case.findOneAndUpdate(
-            {
-                'caseReference.dataSourceId':
-                    req.body.caseReference?.dataSourceId,
-                'caseReference.dataEntryId':
-                    req.body.caseReference?.dataEntryId,
-            },
-            req.body,
-            {
-                new: true,
-                rawResult: true,
-                runValidators: true,
-                upsert: true,
-            },
-        );
-        let status;
-        if (result.lastErrorObject.updatedExisting) {
-            status = 200;
+        const c = await Case.findOne({
+            'caseReference.dataSourceId': req.body.caseReference?.dataSourceId,
+            'caseReference.dataEntryId': req.body.caseReference?.dataEntryId,
+        });
+        if (c) {
+            c.set(req.body);
+            const result = await c.save();
+            res.status(200).json(result);
+            return;
         } else {
-            status = 201;
+            const c = new Case(req.body);
+            const result = await c.save();
+            res.status(201).json(result);
+            return;
         }
-        res.status(status).json(result.value);
     } catch (err) {
         if (err.name === 'ValidationError') {
             res.status(422).json(err.message);

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -28,6 +28,7 @@ const apiRouter = express.Router();
 apiRouter.get('/cases/:id([a-z0-9]{24})', caseController.get);
 apiRouter.get('/cases', caseController.list);
 apiRouter.post('/cases', caseController.create);
+apiRouter.put('/cases', caseController.upsert);
 apiRouter.put('/cases/:id([a-z0-9]{24})', caseController.update);
 apiRouter.delete('/cases/:id([a-z0-9]{24})', caseController.del);
 app.use('/api', apiRouter);

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -151,15 +151,15 @@ describe('PUT', () => {
         const c = new Case(minimalCase);
         const sourceId = 'abc123';
         const entryId = 'def456';
-        c.set('caseReference.dataSourceId', sourceId);
-        c.set('caseReference.dataEntryId', entryId);
+        c.set('caseReference.sourceId', sourceId);
+        c.set('caseReference.sourceEntryId', entryId);
         await c.save();
 
         const newNotes = 'abc';
         const res = await request(app)
             .put('/api/cases')
             .send({
-                caseReference: { dataSourceId: sourceId, dataEntryId: entryId },
+                caseReference: { sourceId: sourceId, sourceEntryId: entryId },
                 notes: newNotes,
             })
             .expect('Content-Type', /json/)
@@ -182,14 +182,14 @@ describe('PUT', () => {
         const c = new Case(minimalCase);
         const sourceId = 'abc123';
         const entryId = 'def456';
-        c.set('caseReference.dataSourceId', sourceId);
-        c.set('caseReference.dataEntryId', entryId);
+        c.set('caseReference.sourceId', sourceId);
+        c.set('caseReference.sourceEntryId', entryId);
         await c.save();
 
         return request(app)
             .put('/api/cases')
             .send({
-                caseReference: { dataSourceId: sourceId, dataEntryId: entryId },
+                caseReference: { sourceId: sourceId, sourceEntryId: entryId },
                 location: {},
             })
             .expect(422);

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -147,6 +147,34 @@ describe('PUT', () => {
             .put('/api/cases/53cb6b9b4f4ddef1ad47f943')
             .expect(404);
     });
+    it('upsert present item should return 200 OK', async () => {
+        const c = new Case(minimalCase);
+        const sourceId = 'abc123';
+        const entryId = 'def456';
+        c.set('caseReference.dataSourceId', sourceId);
+        c.set('caseReference.dataEntryId', entryId);
+        await c.save();
+
+        const newNotes = 'abc';
+        const res = await request(app)
+            .put('/api/cases')
+            .send({
+                caseReference: { dataSourceId: sourceId, dataEntryId: entryId },
+                notes: newNotes,
+            })
+            .expect('Content-Type', /json/)
+            .expect(200);
+
+        expect(res.body.notes).toEqual(newNotes);
+        expect(await c.collection.countDocuments()).toEqual(1);
+    });
+    it('upsert new item should return 201 CREATED', async () => {
+        return request(app)
+            .put('/api/cases')
+            .send(minimalCase)
+            .expect('Content-Type', /json/)
+            .expect(201);
+    });
 });
 
 describe('DELETE', () => {

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -175,6 +175,25 @@ describe('PUT', () => {
             .expect('Content-Type', /json/)
             .expect(201);
     });
+    it('upsert new item with invalid input should return 422', () => {
+        return request(app).put('/api/cases').send({}).expect(422);
+    });
+    it('invalid upsert present item should return 422', async () => {
+        const c = new Case(minimalCase);
+        const sourceId = 'abc123';
+        const entryId = 'def456';
+        c.set('caseReference.dataSourceId', sourceId);
+        c.set('caseReference.dataEntryId', entryId);
+        await c.save();
+
+        return request(app)
+            .put('/api/cases')
+            .send({
+                caseReference: { dataSourceId: sourceId, dataEntryId: entryId },
+                location: {},
+            })
+            .expect(422);
+    });
 });
 
 describe('DELETE', () => {

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -62,27 +62,31 @@ export default class CasesController {
         }
     };
 
+    upsert = async (req: Request, res: Response): Promise<void> => {
+        if (!(await this.geocode(req))) {
+            res.status(404).send(
+                `no geolocation found for ${req.body['location']?.query}`,
+            );
+            return;
+        }
+        try {
+            const response = await axios.put(
+                this.dataServerURL + '/api' + req.url,
+                req.body,
+            );
+            res.json(response.data);
+        } catch (err) {
+            console.log(err);
+            res.status(500).send(err);
+        }
+    };
+
     create = async (req: Request, res: Response): Promise<void> => {
-        // Geocode query if no lat lng were provided.
-        const location = req.body['location'];
-        if (!location?.geometry?.lat || !location.geometry?.lng) {
-            let geocodeSuccess = false;
-            for (const geocoder of this.geocoders) {
-                const features = await geocoder.geocode(location?.query);
-                if (features.length === 0) {
-                    continue;
-                }
-                // Currently a 1:1 match between the GeocodeResult and the data service API.
-                req.body['location'] = features[0];
-                geocodeSuccess = true;
-                break;
-            }
-            if (!geocodeSuccess) {
-                res.status(404).send(
-                    `no geolocation found for ${location?.query}`,
-                );
-                return;
-            }
+        if (!(await this.geocode(req))) {
+            res.status(404).send(
+                `no geolocation found for ${req.body['location']?.query}`,
+            );
+            return;
         }
         try {
             const response = await axios.post(
@@ -95,4 +99,26 @@ export default class CasesController {
             res.status(500).send(err);
         }
     };
+
+    /**
+     * Geocodes request content if no lat lng were provided.
+     *
+     * @returns {boolean} Whether lat lng were either provided or geocoded
+     */
+    private async geocode(req: Request): Promise<boolean> {
+        const location = req.body['location'];
+        if (!location?.geometry?.lat || !location.geometry?.lng) {
+            for (const geocoder of this.geocoders) {
+                const features = await geocoder.geocode(location?.query);
+                if (features.length === 0) {
+                    continue;
+                }
+                // Currently a 1:1 match between the GeocodeResult and the data service API.
+                req.body['location'] = features[0];
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
 }

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -167,6 +167,7 @@ apiRouter.get(
     casesController.get,
 );
 apiRouter.post('/cases', mustHaveAnyRole(['curator']), casesController.create);
+apiRouter.put('/cases', mustHaveAnyRole(['curator']), casesController.upsert);
 apiRouter.put(
     '/cases/:id([a-z0-9]{24})',
     mustHaveAnyRole(['curator']),

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -121,6 +121,34 @@ describe('Cases', () => {
         );
     });
 
+    it('proxies upsert calls and geocodes', async () => {
+        const lyon: GeocodeResult = {
+            administrativeAreaLevel1: 'Rhône',
+            administrativeAreaLevel2: '',
+            administrativeAreaLevel3: 'Lyon',
+            country: 'France',
+            geometry: { latitude: 45.75889, longitude: 4.84139 },
+            place: '',
+            name: 'Lyon',
+            geoResolution: Resolution.Admin3,
+        };
+        await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
+        mockedAxios.put.mockResolvedValueOnce(emptyAxiosResponse);
+        await curatorRequest
+            .put('/api/cases')
+            .send({ age: '42', location: { query: 'Lyon' } })
+            .expect(200)
+            .expect('Content-Type', /json/);
+        expect(mockedAxios.put).toHaveBeenCalledTimes(1);
+        expect(mockedAxios.put).toHaveBeenCalledWith(
+            'http://localhost:3000/api/cases',
+            {
+                age: '42',
+                location: lyon,
+            },
+        );
+    });
+
     it('proxies create calls and geocode', async () => {
         const lyon: GeocodeResult = {
             administrativeAreaLevel1: 'Rhône',


### PR DESCRIPTION
I'd originally envisioned implementing this with `Mongoose.Model.findOneAndUpdate([...], {upsert=true})`, but it turns out that behavior's pretty thorny. I've used some straight-forward base calls instead, which seems to be the simplest solution here.

One thing I'm lukewarm on is the fact that we're allowing partial updates here. But, best to leave that consistent with the PUT update API until we introduce a PATCH endpoint.