### PR TITLE
Add a proxy upsert API to the curator service

### DIFF
--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -62,27 +62,31 @@ export default class CasesController {
         }
     };
 
+    upsert = async (req: Request, res: Response): Promise<void> => {
+        if (!(await this.geocode(req))) {
+            res.status(404).send(
+                `no geolocation found for ${req.body['location']?.query}`,
+            );
+            return;
+        }
+        try {
+            const response = await axios.put(
+                this.dataServerURL + '/api' + req.url,
+                req.body,
+            );
+            res.json(response.data);
+        } catch (err) {
+            console.log(err);
+            res.status(500).send(err);
+        }
+    };
+
     create = async (req: Request, res: Response): Promise<void> => {
-        // Geocode query if no lat lng were provided.
-        const location = req.body['location'];
-        if (!location?.geometry?.lat || !location.geometry?.lng) {
-            let geocodeSuccess = false;
-            for (const geocoder of this.geocoders) {
-                const features = await geocoder.geocode(location?.query);
-                if (features.length === 0) {
-                    continue;
-                }
-                // Currently a 1:1 match between the GeocodeResult and the data service API.
-                req.body['location'] = features[0];
-                geocodeSuccess = true;
-                break;
-            }
-            if (!geocodeSuccess) {
-                res.status(404).send(
-                    `no geolocation found for ${location?.query}`,
-                );
-                return;
-            }
+        if (!(await this.geocode(req))) {
+            res.status(404).send(
+                `no geolocation found for ${req.body['location']?.query}`,
+            );
+            return;
         }
         try {
             const response = await axios.post(
@@ -95,4 +99,26 @@ export default class CasesController {
             res.status(500).send(err);
         }
     };
+
+    /**
+     * Geocodes request content if no lat lng were provided.
+     *
+     * @returns {boolean} Whether lat lng were either provided or geocoded
+     */
+    private async geocode(req: Request): Promise<boolean> {
+        const location = req.body['location'];
+        if (!location?.geometry?.lat || !location.geometry?.lng) {
+            for (const geocoder of this.geocoders) {
+                const features = await geocoder.geocode(location?.query);
+                if (features.length === 0) {
+                    continue;
+                }
+                // Currently a 1:1 match between the GeocodeResult and the data service API.
+                req.body['location'] = features[0];
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
 }

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -167,6 +167,7 @@ apiRouter.get(
     casesController.get,
 );
 apiRouter.post('/cases', mustHaveAnyRole(['curator']), casesController.create);
+apiRouter.put('/cases', mustHaveAnyRole(['curator']), casesController.upsert);
 apiRouter.put(
     '/cases/:id([a-z0-9]{24})',
     mustHaveAnyRole(['curator']),

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -121,6 +121,34 @@ describe('Cases', () => {
         );
     });
 
+    it('proxies upsert calls and geocodes', async () => {
+        const lyon: GeocodeResult = {
+            administrativeAreaLevel1: 'Rhône',
+            administrativeAreaLevel2: '',
+            administrativeAreaLevel3: 'Lyon',
+            country: 'France',
+            geometry: { latitude: 45.75889, longitude: 4.84139 },
+            place: '',
+            name: 'Lyon',
+            geoResolution: Resolution.Admin3,
+        };
+        await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
+        mockedAxios.put.mockResolvedValueOnce(emptyAxiosResponse);
+        await curatorRequest
+            .put('/api/cases')
+            .send({ age: '42', location: { query: 'Lyon' } })
+            .expect(200)
+            .expect('Content-Type', /json/);
+        expect(mockedAxios.put).toHaveBeenCalledTimes(1);
+        expect(mockedAxios.put).toHaveBeenCalledWith(
+            'http://localhost:3000/api/cases',
+            {
+                age: '42',
+                location: lyon,
+            },
+        );
+    });
+
     it('proxies create calls and geocode', async () => {
         const lyon: GeocodeResult = {
             administrativeAreaLevel1: 'Rhône',


### PR DESCRIPTION
Only non-triviality here is geocoding. I've just extracted the biz logic to be shared by create and upsert mechanisms.