### PR TITLE
Prepare for geo suggestions

### DIFF
--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -64,33 +64,31 @@ export default class MapboxGeocoder {
                 .send();
             const features = (resp.body as GeocodeResponse).features;
             return features.map((feature) => {
+                const contexts: GeocodeFeature[] = [feature];
+                if (feature.context) {
+                    contexts.push(...feature.context);
+                }
                 return {
                     geometry: {
                         longitude: feature.center[0],
                         latitude: feature.center[1],
                     },
-                    country: getFeatureTypeFromContext(
-                        [feature, ...feature.context],
-                        'country',
-                    ),
+                    country: getFeatureTypeFromContext(contexts, 'country'),
                     administrativeAreaLevel1: getFeatureTypeFromContext(
-                        [feature, ...feature.context],
+                        contexts,
                         'region',
                     ),
                     administrativeAreaLevel2: getFeatureTypeFromContext(
-                        [feature, ...feature.context],
+                        contexts,
                         'district',
                     ),
                     administrativeAreaLevel3: getFeatureTypeFromContext(
-                        [feature, ...feature.context],
+                        contexts,
                         'place',
                     ),
-                    place: getFeatureTypeFromContext(
-                        [feature, ...feature.context],
-                        'poi',
-                    ),
+                    place: getFeatureTypeFromContext(contexts, 'poi'),
                     name: feature.text,
-                    geoResolution: getResolution([feature, ...feature.context]),
+                    geoResolution: getResolution(contexts),
                 };
             });
         } catch (e) {

--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -42,7 +42,9 @@ describe('New case form', function () {
         cy.get('div[data-testid="outcome"]').click();
         cy.get('li[data-value="Recovered"').click();
         cy.get('input[name="sourceUrl"]').clear().type('www.example.com');
-        cy.get('input[name="notes"]').clear().type('test notes');
+        cy.get('textarea[name="notes"]')
+            .clear()
+            .type('test notes\non new line');
         cy.server();
         cy.route('POST', '/api/cases').as('addCase');
         cy.get('button[data-testid="submit"]').click();
@@ -58,6 +60,7 @@ describe('New case form', function () {
         cy.contains('1/1/2020');
         cy.contains('www.example.com');
         cy.contains('test notes');
+        cy.contains('on new line');
     });
 
     it('Does not add row on submission error', function () {

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -8,6 +8,7 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import Demographics from './new-case-form-fields/Demographics';
 import ErrorIcon from '@material-ui/icons/Error';
 import Events from './new-case-form-fields/Events';
+import { Loc } from './new-case-form-fields/Location';
 import LocationForm from './new-case-form-fields/LocationForm';
 import Notes from './new-case-form-fields/Notes';
 import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
@@ -60,6 +61,7 @@ interface FormValues {
     ethnicity?: string;
     nationalities: string[];
     locationQuery: string;
+    location?: Loc;
     confirmedDate: string | null;
     methodOfConfirmation?: string;
     onsetSymptomsDate: string | null;
@@ -131,7 +133,8 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     nationalities: values.nationalities,
                 },
                 location: {
-                    query: values.locationQuery,
+                    ...values.location,
+                    ...{ query: values.locationQuery },
                 },
                 events: [
                     {

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.test.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.test.tsx
@@ -7,12 +7,14 @@ test('shows location when passed location information', async () => {
     render(
         <Location
             location={{
-                type: 'place',
+                geoResolution: 'place',
                 country: 'United States',
-                adminArea1: 'Hillsborough County',
-                adminArea3: 'Some city',
-                latitude: 80.45,
-                longitude: 27.9379,
+                administrativeAreaLevel1: 'Hillsborough County',
+                administrativeAreaLevel3: 'Some city',
+                geometry: {
+                    latitude: 80.45,
+                    longitude: 27.9379,
+                },
             }}
         />,
     );

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -15,14 +15,24 @@ const styles = () =>
         },
     });
 
-interface Loc {
-    type: string;
+export interface Loc {
+    geometry: {
+        latitude: number;
+        longitude: number;
+    };
     country: string;
-    adminArea1?: string;
-    adminArea2?: string;
-    adminArea3?: string;
-    latitude: number;
-    longitude: number;
+    // First administrative division (state in the US, Länder in Germany, ...).
+    administrativeAreaLevel1: string | undefined;
+    // Second administrative division (county in the US, departments in France, ...).
+    administrativeAreaLevel2: string | undefined;
+    // Third administrative division (cities usually).
+    administrativeAreaLevel3: string | undefined;
+    // A precise location, such as an establishment or POI.
+    place: string | undefined;
+    // Human readable place name.
+    name: string;
+    // How granular the geocode is.
+    geoResolution: string;
 }
 
 // Cf. https://material-ui.com/guides/typescript/#augmenting-your-props-using-withstyles
@@ -39,7 +49,7 @@ class Location extends React.Component<Props, {}> {
                     <p>
                         <Typography variant="caption">Location Type</Typography>
                     </p>
-                    <p>{this.props.location?.type}</p>
+                    <p>{this.props.location?.geoResolution}</p>
                 </div>
                 <div className={classes.column}>
                     <p>
@@ -51,31 +61,43 @@ class Location extends React.Component<Props, {}> {
                     <p>
                         <Typography variant="caption">Admin area 1</Typography>
                     </p>
-                    <p>{this.props.location?.adminArea1 ?? 'N/A'}</p>
+                    <p>
+                        {this.props.location?.administrativeAreaLevel1 ?? 'N/A'}
+                    </p>
                 </div>
                 <div className={classes.column}>
                     <p>
                         <Typography variant="caption">Admin area 2</Typography>
                     </p>
-                    <p>{this.props.location?.adminArea2 ?? 'N/A'}</p>
+                    <p>
+                        {this.props.location?.administrativeAreaLevel2 ?? 'N/A'}
+                    </p>
                 </div>
                 <div className={classes.column}>
                     <p>
                         <Typography variant="caption">Admin area 3</Typography>
                     </p>
-                    <p>{this.props.location?.adminArea3 ?? 'N/A'}</p>
+                    <p>
+                        {this.props.location?.administrativeAreaLevel3 ?? 'N/A'}
+                    </p>
                 </div>
                 <div className={classes.column}>
                     <p>
                         <Typography variant="caption">Latitude</Typography>
                     </p>
-                    <p>{this.props.location?.latitude?.toFixed(4) ?? '-'}</p>
+                    <p>
+                        {this.props.location?.geometry?.latitude?.toFixed(4) ??
+                            '-'}
+                    </p>
                 </div>
                 <div className={classes.column}>
                     <p>
                         <Typography variant="caption">Longitude</Typography>
                     </p>
-                    <p>{this.props.location?.longitude?.toFixed(4) ?? '-'}</p>
+                    <p>
+                        {this.props.location?.geometry?.longitude?.toFixed(4) ??
+                            '-'}
+                    </p>
                 </div>
             </div>
         );

--- a/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
@@ -15,6 +15,7 @@ class LocationForm extends React.Component<{}, {}> {
                         label="Location"
                         name="locationQuery"
                         type="text"
+                        fullWidth={true}
                         component={TextField}
                     />
                     <Location location={undefined} />

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Notes.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Notes.tsx
@@ -13,6 +13,7 @@ export default class Notes extends React.Component<{}, {}> {
                         label="Notes"
                         name="notes"
                         type="text"
+                        multiline={true}
                         component={TextField}
                     />
                 </fieldset>


### PR DESCRIPTION
A few nit fixes a long the way, making the API consistent between what the UI has and what the curator service expects to avoid a bunch of transformations when sending the request/receiving the geocode results.

Also fix the geocode of top level features (countries) which do not have context attached to them so we couldn't iterate over those.