### PR TITLE
Use undefined rather than null where possible

### DIFF
--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -61,7 +61,7 @@ interface FormValues {
     age?: number;
     ethnicity?: string;
     nationalities: string[];
-    profession: string | null;
+    profession?: string;
     locationQuery: string;
     location?: Loc;
     confirmedDate: string | null;
@@ -134,7 +134,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     ageRange: ageRange,
                     ethnicity: values.ethnicity,
                     nationalities: values.nationalities,
-                    profession: values.profession || undefined,
+                    profession: values.profession,
                 },
                 location: {
                     ...values.location,
@@ -266,7 +266,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     age: undefined,
                     ethnicity: undefined,
                     nationalities: [],
-                    profession: null,
+                    profession: undefined,
                     locationQuery: '',
                     location: undefined,
                     confirmedDate: null,
@@ -310,7 +310,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                                             values.maxAge !== '') ||
                                         values.ethnicity !== undefined ||
                                         values.nationalities.length > 0 ||
-                                        values.profession !== null,
+                                        values.profession !== undefined,
                                     hasError:
                                         errors.sex !== undefined ||
                                         errors.minAge !== undefined ||

--- a/verification/curator-service/ui/src/components/new-case-form-fields/FormikAutocomplete.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/FormikAutocomplete.tsx
@@ -64,7 +64,7 @@ export default function FormikAutocomplete(
             options={options}
             loading={loading}
             onChange={(_, values): void => {
-                setFieldValue(props.name, values);
+                setFieldValue(props.name, values ?? undefined);
             }}
             onBlur={(): void => setTouched({ [props.name]: true })}
             renderInput={(params): JSX.Element => (


### PR DESCRIPTION
undefined can't be set as a default value for dates. When it is set the date picker UI element shows today's date rather than a blank picker (as it does for null).