### PR TITLE
Better looking place suggest

### DIFF
--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -96,7 +96,7 @@ export default class MapboxGeocoder {
                         'place',
                     ),
                     place: getFeatureTypeFromContext(contexts, 'poi'),
-                    name: feature.text,
+                    name: feature.place_name,
                     geoResolution: getResolution(contexts),
                 };
             });

--- a/verification/curator-service/api/test/geocoding/mapbox.test.ts
+++ b/verification/curator-service/api/test/geocoding/mapbox.test.ts
@@ -51,7 +51,7 @@ describe('geocode', () => {
             country: 'France',
             geometry: { latitude: 45.75889, longitude: 4.84139 },
             place: '',
-            name: 'Lyon',
+            name: 'Lyon, Rhône, France',
             geoResolution: Resolution.Admin3,
         };
         expect(feats[0]).toEqual(wantFeature);

--- a/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
@@ -1,11 +1,12 @@
 import { Field, useFormikContext } from 'formik';
 import Location, { Loc } from './Location';
+import { Typography, makeStyles } from '@material-ui/core';
 
 import { Autocomplete } from '@material-ui/lab';
+import LocationOnIcon from '@material-ui/icons/LocationOn';
 import React from 'react';
 import Scroll from 'react-scroll';
 import { TextField } from 'formik-material-ui';
-import { Typography } from '@material-ui/core';
 import axios from 'axios';
 import throttle from 'lodash/throttle';
 
@@ -27,9 +28,21 @@ function LocationForm(): JSX.Element {
 
 export default LocationForm;
 
+const useStyles = makeStyles((theme) => ({
+    icon: {
+        color: theme.palette.text.secondary,
+        marginRight: theme.spacing(2),
+    },
+    suggestion: {
+        display: 'flex',
+        alignItems: 'center',
+    },
+}));
+
 // Place autocomplete, based on
 // https://material-ui.com/components/autocomplete/#google-maps-place
 function PlacesAutocomplete(): JSX.Element {
+    const classes = useStyles();
     const [value, setValue] = React.useState<Loc | null>(null);
     const [inputValue, setInputValue] = React.useState('');
     const [options, setOptions] = React.useState<Loc[]>([]);
@@ -115,8 +128,12 @@ function PlacesAutocomplete(): JSX.Element {
                 ></Field>
             )}
             renderOption={(option: Loc): React.ReactNode => {
-                // TODO: Provide better looking options.
-                return <Typography variant="body2">{option.name}</Typography>;
+                return (
+                    <span className={classes.suggestion}>
+                        <LocationOnIcon className={classes.icon} />
+                        <Typography variant="body2">{option.name}</Typography>
+                    </span>
+                );
             }}
         />
     );


### PR DESCRIPTION
Use the `place_name` field instead of the `text` which is more suitable for suggest and overall.
Add an icon next to the suggestions.

New suggest UI:
<img width="519" alt="Screen Shot 2020-06-22 at 12 51 31 PM" src="https://user-images.githubusercontent.com/1255432/85280370-4dada900-b488-11ea-878a-c3352cac9850.png">
