### PR TITLE
Remove ID column and display age properly

### DIFF
--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -86,7 +86,7 @@ it('loads and displays cases', async () => {
     expect(items).toBeInTheDocument();
     const admin1 = await findByText(/some admin 1/);
     expect(admin1).toBeInTheDocument();
-    const ageRange = await findByText('[1,3)');
+    const ageRange = await findByText('1-3');
     expect(ageRange).toBeInTheDocument();
     const admin2 = await findByText(/some admin 2/);
     expect(admin2).toBeInTheDocument();

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -32,6 +32,7 @@ it('loads and displays cases', async () => {
             importedCase: {
                 outcome: 'Recovered',
             },
+            demographics: { ageRange: { start: 1, end: 3 } },
             location: {
                 country: 'France',
                 administrativeAreaLevel1: 'some admin 1',
@@ -81,10 +82,12 @@ it('loads and displays cases', async () => {
     expect(mockedAxios.get).toHaveBeenCalledWith(
         '/api/cases/?limit=10&page=1&filter=',
     );
-    const items = await findByText(/abc123/);
+    const items = await findByText(/some notes/);
     expect(items).toBeInTheDocument();
     const admin1 = await findByText(/some admin 1/);
     expect(admin1).toBeInTheDocument();
+    const ageRange = await findByText('[1,3)');
+    expect(ageRange).toBeInTheDocument();
     const admin2 = await findByText(/some admin 2/);
     expect(admin2).toBeInTheDocument();
     const admin3 = await findByText(/some admin 3/);
@@ -166,7 +169,7 @@ it('API errors are displayed', async () => {
         </MemoryRouter>,
     );
 
-    const row = await findByText(/abc123/);
+    const row = await findByText(/some notes/);
     expect(row).toBeInTheDocument();
 
     // Throw error on edit request.
@@ -231,7 +234,7 @@ it('can delete a row', async () => {
     expect(mockedAxios.get).toHaveBeenCalledWith(
         '/api/cases/?limit=10&page=1&filter=',
     );
-    const row = await findByText(/abc123/);
+    const row = await findByText(/some notes/);
     expect(row).toBeInTheDocument();
 
     // Delete case
@@ -451,7 +454,7 @@ it('cannot edit data as a reader only', async () => {
     expect(mockedAxios.get).toHaveBeenCalledWith(
         '/api/cases/?limit=10&page=1&filter=',
     );
-    const row = await findByText(/abc123/);
+    const row = await findByText(/some notes/);
     expect(row).toBeInTheDocument();
 
     const deleteButton = queryByText(/delete_outline/);

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -83,7 +83,7 @@ interface TableRow {
     id: string;
     // demographics
     sex: string;
-    age: number;
+    age: [number, number]; // start, end.
     ethnicity: string;
     // Represents a list as a comma and space separated string e.g. 'Afghan, Albanian'
     nationalities: string;
@@ -141,7 +141,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
             demographics: {
                 sex: rowData.sex,
                 age: {
-                    start: rowData.age,
+                    start: rowData.age[0],
+                    end: rowData.age[1],
                 },
                 ethnicity: rowData.ethnicity,
                 nationalities: rowData.nationalities?.split(', '),
@@ -245,12 +246,6 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                     <MaterialTable
                         columns={[
                             {
-                                title: 'ID',
-                                field: 'id',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
                                 title: 'Sex',
                                 field: 'sex',
                                 filtering: false,
@@ -260,7 +255,11 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 title: 'Age',
                                 field: 'age',
                                 filtering: false,
-                                type: 'numeric',
+                                editable: 'never',
+                                render: (rowData) =>
+                                    rowData.age[0] === rowData.age[1]
+                                        ? rowData.age[0]
+                                        : `[${rowData.age[0]},${rowData.age[1]})`,
                             },
                             {
                                 title: 'Ethnicity',
@@ -389,10 +388,12 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                             flattenedCases.push({
                                                 id: c._id,
                                                 sex: c.demographics?.sex,
-                                                // TODO: show full age range
-                                                age:
+                                                age: [
                                                     c.demographics?.ageRange
                                                         ?.start,
+                                                    c.demographics?.ageRange
+                                                        ?.end,
+                                                ],
                                                 ethnicity:
                                                     c.demographics?.ethnicity,
                                                 nationalities: c.demographics?.nationalities?.join(
@@ -452,6 +453,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             filtering: true,
                             sorting: false, // Would be nice but has to wait on indexes to properly query the DB.
                             padding: 'dense',
+                            draggable: false, // No need to be able to drag and drop headers.
                             pageSize: 10,
                             pageSizeOptions: [5, 10, 20, 50, 100],
                         }}

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -140,12 +140,13 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         return {
             demographics: {
                 sex: rowData.sex,
-                ageRange: rowData.age[1]
-                    ? {
-                          start: rowData.age[0],
-                          end: rowData.age[1],
-                      }
-                    : undefined,
+                ageRange:
+                    rowData.age[0] !== null || rowData.age[1] !== null
+                        ? {
+                              start: rowData.age[0],
+                              end: rowData.age[1],
+                          }
+                        : undefined,
                 ethnicity: rowData.ethnicity,
                 nationalities: rowData.nationalities?.split(', '),
                 profession: rowData.profession,

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -140,13 +140,10 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         return {
             demographics: {
                 sex: rowData.sex,
-                ageRange:
-                    rowData.age[0] !== null || rowData.age[1] !== null
-                        ? {
-                              start: rowData.age[0],
-                              end: rowData.age[1],
-                          }
-                        : undefined,
+                ageRange: {
+                    start: rowData.age[0] ?? undefined,
+                    end: rowData.age[1] ?? undefined,
+                },
                 ethnicity: rowData.ethnicity,
                 nationalities: rowData.nationalities?.split(', '),
                 profession: rowData.profession,
@@ -262,7 +259,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 render: (rowData) =>
                                     rowData.age[0] === rowData.age[1]
                                         ? rowData.age[0]
-                                        : `[${rowData.age[0]},${rowData.age[1]})`,
+                                        : `${rowData.age[0]}-${rowData.age[1]}`,
                             },
                             {
                                 title: 'Ethnicity',

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -140,7 +140,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         return {
             demographics: {
                 sex: rowData.sex,
-                age: {
+                ageRange: {
                     start: rowData.age[0],
                     end: rowData.age[1],
                 },

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -140,10 +140,12 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         return {
             demographics: {
                 sex: rowData.sex,
-                ageRange: {
-                    start: rowData.age[0],
-                    end: rowData.age[1],
-                },
+                ageRange: rowData.age[1]
+                    ? {
+                          start: rowData.age[0],
+                          end: rowData.age[1],
+                      }
+                    : undefined,
                 ethnicity: rowData.ethnicity,
                 nationalities: rowData.nationalities?.split(', '),
                 profession: rowData.profession,
@@ -456,6 +458,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             draggable: false, // No need to be able to drag and drop headers.
                             pageSize: 10,
                             pageSizeOptions: [5, 10, 20, 50, 100],
+                            actionsColumnIndex: -1,
                         }}
                         actions={
                             this.props.user.roles.includes('curator')


### PR DESCRIPTION
A bit more in line with the figma mocks now. Chose the interval display for age `[,...)` instead of  `xx-yy` not sure what's best yet.

![image](https://user-images.githubusercontent.com/1255432/85288441-04fcec80-b496-11ea-8028-593734ec2056.png)

Also disable reordering of columns and put actions at the end as per the mocks (we'll want to switch to a menu instead perhaps)