### PR TITLE
Display only location name and country in linelist table instead of various geo fields

### DIFF
--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -253,6 +253,7 @@ def convert_location(id: str, location: str, admin3: str, admin2: str,
           'administrativeAreaLevel3': str,
           'place': str,
           'geo_resolution': str,
+          'name': str,
           'geometry': {
             'latitude': float,
             'longitude': float
@@ -294,6 +295,11 @@ def convert_location(id: str, location: str, admin3: str, admin2: str,
 
     if geometry:
         location['geometry'] = geometry
+
+    # Produce a reasonable human readable name based on admin hierarchy.
+    location['name'] = ', '.join([part for part in 
+      [admin1, admin2, admin3]
+    if part])
 
     try:
         parsed_geo_resolution = parse_geo_resolution(geo_resolution)

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -38,6 +38,7 @@ it('loads and displays cases', async () => {
                 administrativeAreaLevel1: 'some admin 1',
                 administrativeAreaLevel2: 'some admin 2',
                 administrativeAreaLevel3: 'some admin 3',
+                name: 'some place name',
                 geometry: {
                     latitude: 42,
                     longitude: 12,
@@ -84,16 +85,10 @@ it('loads and displays cases', async () => {
     );
     const items = await findByText(/some notes/);
     expect(items).toBeInTheDocument();
-    const admin1 = await findByText(/some admin 1/);
-    expect(admin1).toBeInTheDocument();
+    const locationName = await findByText(/some place name/);
+    expect(locationName).toBeInTheDocument();
     const ageRange = await findByText('1-3');
     expect(ageRange).toBeInTheDocument();
-    const admin2 = await findByText(/some admin 2/);
-    expect(admin2).toBeInTheDocument();
-    const admin3 = await findByText(/some admin 3/);
-    expect(admin3).toBeInTheDocument();
-    const geoResolution = await findByText(/Admin3/);
-    expect(geoResolution).toBeInTheDocument();
 });
 
 it('redirects to new case page when + icon is clicked', async () => {

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -45,6 +45,7 @@ interface Location {
     administrativeAreaLevel3: string;
     geoResolution: string;
     geometry: Geometry;
+    name: string;
 }
 
 interface Geometry {
@@ -93,6 +94,7 @@ interface TableRow {
     adminArea2: string;
     adminArea3: string;
     geoResolution: string;
+    locationName: string;
     latitude: number;
     longitude: number;
     confirmedDate: Date | null;
@@ -163,6 +165,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                     latitude: rowData.latitude,
                     longitude: rowData.longitude,
                 },
+                name: rowData.locationName,
                 geoResolution: rowData.geoResolution,
             },
             events: [
@@ -277,50 +280,16 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 filtering: false,
                             },
                             {
+                                title: 'Location',
+                                field: 'locationName',
+                                filtering: false,
+                                editable: 'never',
+                            },
+                            {
                                 title: 'Country',
                                 field: 'country',
                                 filtering: false,
                                 editable: 'never',
-                            },
-                            {
-                                title: 'Admin area 1',
-                                field: 'adminArea1',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
-                                title: 'Admin area 2',
-                                field: 'adminArea2',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
-                                title: 'Admin area 3',
-                                field: 'adminArea3',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
-                                title: 'Geo resolution',
-                                field: 'geoResolution',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
-                                title: 'Latitude',
-                                field: 'latitude',
-                                filtering: false,
-                                editable: 'never',
-                                render: (rowData) =>
-                                    rowData.latitude?.toFixed(4) ?? '',
-                            },
-                            {
-                                title: 'Longitude',
-                                field: 'longitude',
-                                filtering: false,
-                                editable: 'never',
-                                render: (rowData) =>
-                                    rowData.longitude?.toFixed(4) ?? '',
                             },
                             {
                                 title: 'Confirmed date',
@@ -419,6 +388,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                         ?.longitude,
                                                 geoResolution:
                                                     c.location?.geoResolution,
+                                                locationName: c.location?.name,
                                                 confirmedDate: confirmedDate
                                                     ? new Date(confirmedDate)
                                                     : null,


### PR DESCRIPTION
Conforms to mocks.

![image](https://user-images.githubusercontent.com/1255432/85309934-a3e41180-b4b3-11ea-850f-2a5a7d25604e.png)
