### PR TITLE
Maybe try to fix daily case update workflow?

### DIFF
--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -43,4 +43,4 @@ jobs:
         run: python -m pip install -r ./data-serving/scripts/data-pipeline/requirements.txt
 
       - name: Run update script
-        run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m ${{ secrets.DB_CONNECTION_URL }}
+        run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m "${{ secrets.DB_CONNECTION_URL }}"

--- a/data-serving/scripts/setup-db/package.json
+++ b/data-serving/scripts/setup-db/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit && eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
-    "setup": "npm install && tsc && mongo --eval \"let args={connectionString: '$CONN', databaseName: '$DB', collectionName: '$COLL', schemaPath: '$SCHEMA'}\" dist/index.js",
+    "setup": "npm install && tsc && mongo $CONN --eval \"let args={connectionString: '$CONN', databaseName: '$DB', collectionName: '$COLL', schemaPath: '$SCHEMA'}\" dist/index.js",
     "setup-cases": "npm install && tsc && mongo --eval \"let args={databaseName: 'covid19', collectionName: 'cases', schemaPath: './../../data-service/schemas/cases.schema.json'}\" dist/index.js"
   },
   "repository": {


### PR DESCRIPTION
There are two errors in the logs from the workflow:

```
MongoDB shell version v4.2.6
connecting to: mongodb://127.0.0.1:27017/?compressors=disabled&gssapiServiceName=mongodb
2020-06-23T05:15:20.984+0000 E  QUERY    [js] Error: couldn't connect to server 127.0.0.1:27017, connection attempt failed: SocketException: Error connecting to 127.0.0.1:27017 :: caused by :: Connection refused :
connect@src/mongo/shell/mongo.js:341:17
@(connect):2:6
2020-06-23T05:15:20.986+0000 F  -        [main] exception: connect failed
2020-06-23T05:15:20.986+0000 E  -        [main] exiting with code 1
```

The change in the package.json is meant to address this, by having the `mongo` command connect to the proper connection string (even though the subsequent js that it evals will re-connect to it)

```
2020-06-23T05:15:21.141+0000	error parsing command line options: error parsing uri: lookup covid19-map-cluster01-sc7u9.mongodb.net on 127.0.0.53:53: cannot unmarshal DNS message
2020-06-23T05:15:21.141+0000	try 'mongoimport --help' for more information
```

The change in the yml file is meant to address this by putting quotes around the connection string

I have 0 idea if these will work -- it works running it locally with `act` but it always has *shrug*