### PR TITLE
Bring symptoms and preexisting conditions up to spec with addition of status

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -204,19 +204,20 @@
           "_id": {
             "bsonType": "objectId"
           },
-          "provided": {
+          "values": {
             "bsonType": "array",
             "uniqueItems": true,
             "items": {
               "bsonType": "string"
             }
           },
-          "imputed": {
-            "bsonType": "array",
-            "uniqueItems": true,
-            "items": {
-              "bsonType": "string"
-            }
+          "status": {
+            "enum": [
+              "Asymptomatic",
+              "Presymptomatic",
+              "Symptomatic",
+              "Unknown"
+            ]
           }
         }
       },
@@ -227,19 +228,19 @@
           "_id": {
             "bsonType": "objectId"
           },
-          "provided": {
+          "values": {
             "bsonType": "array",
             "uniqueItems": true,
             "items": {
               "bsonType": "string"
             }
           },
-          "imputed": {
-            "bsonType": "array",
-            "uniqueItems": true,
-            "items": {
-              "bsonType": "string"
-            }
+          "status": {
+            "enum": [
+              "Yes",
+              "No",
+              "Unknown"
+            ]
           }
         }
       },

--- a/data-serving/data-service/src/model/dictionary.ts
+++ b/data-serving/data-service/src/model/dictionary.ts
@@ -14,17 +14,14 @@ const uniqueValuesValidator = {
  * and chronic disease fields.
  */
 export const dictionarySchema = new mongoose.Schema({
-    provided: {
+    values: {
         type: [String],
         validate: uniqueValuesValidator,
     },
-    imputed: {
-        type: [String],
-        validate: uniqueValuesValidator,
-    },
+    status: String,
 });
 
 export type DictionaryDocument = mongoose.Document & {
-    provided: [string];
-    imputed: [string];
+    values: [string];
+    status: string;
 };

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -67,35 +67,21 @@
         }
     ],
     "symptoms": {
-        "provided": [
-            "severe pneumonia",
-            "dyspnea",
-            "weakness"
+        "values": [
+            "Severe pneumonia",
+            "Dyspnea",
+            "Weakness"
         ],
-        "imputed": [
-            "severe pneumonia",
-            "pneumonia",
-            "dyspnea",
-            "difficulty breathing",
-            "weakness"
-        ]
+        "status": "Symptomatic"
     },
     "preexistingConditions": {
-        "provided": [
-            "hypertension",
-            "type 2 diabetes",
-            "coronary heart disease",
-            "lung cancer"
+        "values": [
+            "Hypertension",
+            "Type 2 diabetes",
+            "Coronary heart disease",
+            "Lung cancer"
         ],
-        "imputed": [
-            "hypertension",
-            "type 2 diabetes",
-            "diabetes",
-            "coronary heart disease",
-            "heart disease",
-            "lung cancer",
-            "cancer"
-        ]
+        "status": "Yes"
     },
     "travelHistory": {
         "numLocations": 1,

--- a/data-serving/data-service/test/model/data/dictionary.full.json
+++ b/data-serving/data-service/test/model/data/dictionary.full.json
@@ -1,14 +1,7 @@
 {
-    "provided": [
-        "a",
-        "b",
-        "c"
+    "values": [
+        "Cough",
+        "Pneumonia"
     ],
-    "imputed": [
-        "a",
-        "aa",
-        "b",
-        "bb",
-        "c"
-    ]
+    "status": "Symptomatic"
 }

--- a/data-serving/data-service/test/model/dictionary.test.ts
+++ b/data-serving/data-service/test/model/dictionary.test.ts
@@ -14,16 +14,8 @@ const Dictionary = mongoose.model<DictionaryDocument>(
 );
 
 describe('validate', () => {
-    it('a provided field with duplicate values is invalid', async () => {
-        return new Dictionary({ ...fullModel, provided: ['a', 'a'] }).validate(
-            (e) => {
-                expect(e.name).toBe(Error.ValidationError.name);
-            },
-        );
-    });
-
-    it('an imputed field with duplicate values is invalid', async () => {
-        return new Dictionary({ ...fullModel, imputed: ['a', 'a'] }).validate(
+    it('a values field with duplicate values is invalid', async () => {
+        return new Dictionary({ ...fullModel, values: ['a', 'a'] }).validate(
             (e) => {
                 expect(e.name).toBe(Error.ValidationError.name);
             },

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -105,35 +105,21 @@
             }
         ],
         "symptoms": {
-            "provided": [
-                "severe pneumonia",
-                "dyspnea",
-                "weakness"
+            "values": [
+                "Severe pneumonia",
+                "Dyspnea",
+                "Weakness"
             ],
-            "imputed": [
-                "severe pneumonia",
-                "pneumonia",
-                "dyspnea",
-                "difficulty breathing",
-                "weakness"
-            ]
+            "status": "Symptomatic"
         },
         "preexistingConditions": {
-            "provided": [
-                "hypertension",
-                "type 2 diabetes",
-                "coronary heart disease",
-                "lung cancer"
+            "values": [
+                "Hypertension",
+                "Type 2 diabetes",
+                "Coronary heart disease",
+                "Lung cancer"
             ],
-            "imputed": [
-                "hypertension",
-                "type 2 diabetes",
-                "diabetes",
-                "coronary heart disease",
-                "heart disease",
-                "lung cancer",
-                "cancer"
-            ]
+            "status": "Yes"
         },
         "travelHistory": {
             "numLocations": 1,

--- a/data-serving/scripts/convert-data/converters.py
+++ b/data-serving/scripts/convert-data/converters.py
@@ -328,14 +328,14 @@ def convert_dictionary_field(id: str, field_name: str, value: str) -> Dict[
       Dict[str, List[str]]: When the value is present and successfully parsed.
         The dictionary in the format:
         {
-          'provided': List[str]
+          'values': List[str]
         }
     '''
     try:
         string_list = parse_string_list(value)
-        return {'provided': string_list} if string_list else None
+        return {'values': string_list} if string_list else None
     except ValueError as e:
-        log_error(id, field_name, f'{field_name}.provided', value, e)
+        log_error(id, field_name, f'{field_name}.values', value, e)
 
 
 def convert_revision_metadata_field(data_moderator_initials: str) -> Dict[

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -59,7 +59,7 @@ interface Source {
 }
 
 interface Symptoms {
-    provided: string[];
+    values: string[];
 }
 
 interface Transmission {
@@ -199,7 +199,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                 },
             ],
             symptoms: {
-                provided: this.splitCommaSeparated(rowData.symptoms),
+                values: this.splitCommaSeparated(rowData.symptoms),
             },
             transmission: {
                 route: rowData.transmissionRoute,
@@ -448,7 +448,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                     : null,
                                                 confirmationMethod:
                                                     confirmedEvent?.value,
-                                                symptoms: c.symptoms?.provided?.join(
+                                                symptoms: c.symptoms?.values?.join(
                                                     ', ',
                                                 ),
                                                 transmissionRoute:

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -175,7 +175,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                         };
                     }),
                 symptoms: {
-                    provided: values.symptoms,
+                    values: values.symptoms,
                 },
                 transmission: {
                     route: values.transmissionRoute,


### PR DESCRIPTION
- Adds status field (previously missed this in the spec!)
- Renames 'provided' to 'values'
- Removes 'imputed' (we can add later if we ever need it... ontology dreams are looking far away)