### PR TITLE
Make transmission.places, transmission.routes, and travel.methods arrays

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -346,17 +346,21 @@
                     "Unknown"
                   ]
                 },
-                "method": {
-                  "enum": [
-                    "Bus",
-                    "Car",
-                    "Coach",
-                    "Ferry",
-                    "Plane",
-                    "Train",
-                    "Other",
-                    "Unknown"
-                  ]
+                "methods": {
+                  "bsonType": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "enum": [
+                      "Bus",
+                      "Car",
+                      "Coach",
+                      "Ferry",
+                      "Plane",
+                      "Train",
+                      "Other",
+                      "Unknown"
+                    ]
+                  }
                 }
               }
             }
@@ -411,29 +415,44 @@
         }
       },
       "transmission": {
-        "route": {
-          "enum": [
-            "Airborne infection",
-            "Droplet infection",
-            "Fecal–oral",
-            "Sexual",
-            "Oral",
-            "Direct contact",
-            "Vertical",
-            "Iatrogenic",
-            "Vector borne",
-            "Other",
-            "Unknown"
-          ]
-        },
-        "place": {
-          "bsonType": "string"
-        },
-        "linkedCaseIds": {
-          "bsonType": "array",
-          "uniqueItems": true,
-          "items": {
-            "bsonType": "string"
+        "bsonType": "object",
+        "additionalProperties": false,
+        "properties": {
+          "_id": {
+            "bsonType": "objectId"
+          },
+          "routes": {
+            "bsonType": "array",
+            "uniqueItems": true,
+            "items": {
+              "enum": [
+                "Airborne infection",
+                "Droplet infection",
+                "Fecal–oral",
+                "Sexual",
+                "Oral",
+                "Direct contact",
+                "Vertical",
+                "Iatrogenic",
+                "Vector borne",
+                "Other",
+                "Unknown"
+              ]
+            }
+          },
+          "places": {
+            "bsonType": "array",
+            "uniqueItems": true,
+            "items": {
+              "bsonType": "string"
+            }
+          },
+          "linkedCaseIds": {
+            "bsonType": "array",
+            "uniqueItems": true,
+            "items": {
+              "bsonType": "string"
+            }
           }
         }
       },

--- a/data-serving/data-service/src/model/transmission.ts
+++ b/data-serving/data-service/src/model/transmission.ts
@@ -15,18 +15,20 @@ export enum Route {
 }
 
 export const transmissionSchema = new mongoose.Schema({
-    route: {
-        type: String,
-        enum: Object.values(Route),
-    },
-    // Data dictionary.
-    place: String,
     // Ids of other cases of people with whom this person had contact.
     linkedCaseIds: [String],
+    // Data dictionary.
+    places: [String],
+    routes: [
+        {
+            type: String,
+            enum: Object.values(Route),
+        },
+    ],
 });
 
 export type TransmissionDocument = mongoose.Document & {
-    route: Route;
-    places: string;
     linkedCaseIds: [string];
+    places: [string];
+    routes: [Route];
 };

--- a/data-serving/data-service/src/model/travel.ts
+++ b/data-serving/data-service/src/model/travel.ts
@@ -23,21 +23,23 @@ export enum TravelMethod {
 }
 
 export const travelSchema = new mongoose.Schema({
-    location: locationSchema,
     dateRange: dateRangeSchema,
+    location: locationSchema,
+    methods: [
+        {
+            type: String,
+            enum: Object.values(TravelMethod),
+        },
+    ],
     purpose: {
         type: String,
         enum: Object.values(TravelPurpose),
-    },
-    method: {
-        type: String,
-        enum: Object.values(TravelMethod),
     },
 });
 
 export type TravelDocument = mongoose.Document & {
     dateRange: DateRangeDocument;
     location: LocationDocument;
-    method: TravelMethod;
+    methods: [TravelMethod];
     purpose: TravelPurpose;
 };

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -118,7 +118,7 @@
                         "longitude": -73.9740028
                     }
                 },
-                "method": "Plane",
+                "methods": [ "Plane" ],
                 "purpose": "Family"
             }
         ],
@@ -155,8 +155,8 @@
         }
     },
     "transmission": {
-        "route": "Vector borne",
-        "place": "Gym",
+        "routes": [ "Vector borne" ],
+        "places": [ "Gym" ],
         "linkedCaseIds": [ "abc", "def" ]
     },
     "importedCase": {

--- a/data-serving/data-service/test/model/data/transmission.full.json
+++ b/data-serving/data-service/test/model/data/transmission.full.json
@@ -1,5 +1,5 @@
 {
-    "route": "Vector borne",
-    "place": "Gym",
+    "routes": [ "Vector borne" ],
+    "places": [ "Gym" ],
     "linkedCaseIds": [ "abc", "def" ]
 }

--- a/data-serving/data-service/test/model/data/travel-history.full.json
+++ b/data-serving/data-service/test/model/data/travel-history.full.json
@@ -19,7 +19,7 @@
                     "longitude": -73.9740028
                 }
             },
-            "method": "Plane",
+            "methods": [ "Plane" ],
             "purpose": "Family"
         }
     ],

--- a/data-serving/data-service/test/model/transmission.test.ts
+++ b/data-serving/data-service/test/model/transmission.test.ts
@@ -17,7 +17,7 @@ describe('validate', () => {
     it('an unknown route is invalid', async () => {
         return new Transmission({
             ...minimalModel,
-            ...{ route: 'Zombie bite' },
+            ...{ routes: ['Zombie bite'] },
         }).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });

--- a/data-serving/data-service/test/model/travel.test.ts
+++ b/data-serving/data-service/test/model/travel.test.ts
@@ -20,7 +20,7 @@ describe('validate', () => {
     it('an unknown travel method is invalid', async () => {
         return new Travel({
             ...fullModel,
-            ...{ method: 'Unicycle' },
+            ...{ methods: ['Unicycle'] },
         }).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -164,7 +164,7 @@
                         }
                     }
                 },
-                "method": "Plane",
+                "methods": [ "Plane" ],
                 "purpose": "Family"
             }],
             "traveledPrior30Days": true
@@ -208,8 +208,8 @@
             }
         },
         "transmission": {
-            "route": "Vector borne",
-            "place": "Gym",
+            "routes": [ "Vector borne" ],
+            "places": [ "Gym" ],
             "linkedCaseIds": [ "abc", "def" ]
         },
         "importedCase": {

--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -56,10 +56,10 @@ describe('New case form', function () {
         cy.get('li').first().should('contain', 'dry cough').click();
         cy.get('div[data-testid="symptoms"]').type('mild fever');
         cy.get('li').first().should('contain', 'mild fever').click();
-        cy.get('div[data-testid="transmissionRoute"]').click();
-        cy.get('li[data-value="Direct contact"').click();
-        cy.get('div[data-testid="transmissionPlace"]').click();
-        cy.get('li[data-value="Factory"').click();
+        cy.get('div[data-testid="transmissionRoutes"]').click();
+        cy.get('li').first().should('contain', 'Airborne infection').click();
+        cy.get('div[data-testid="transmissionPlaces"]').click();
+        cy.get('li').first().should('contain', 'Assisted Living').click();
         cy.get('input[placeholder="Contacted case IDs"').type(
             'testcaseid12345678987654\ntestcaseid12345678987655\n',
         );
@@ -82,8 +82,8 @@ describe('New case form', function () {
         cy.contains('France');
         cy.contains('1/1/2020');
         cy.contains('dry cough, mild fever');
-        cy.contains('Direct contact');
-        cy.contains('Factory');
+        cy.contains('Airborne infection');
+        cy.contains('Assisted Living');
         cy.contains('testcaseid12345678987654, testcaseid12345678987655');
         cy.contains('www.example.com');
         cy.contains('test notes');

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -63,8 +63,8 @@ interface Symptoms {
 }
 
 interface Transmission {
-    route: string;
-    place: string;
+    routes: string[];
+    places: string[];
     linkedCaseIds: string[];
 }
 
@@ -109,8 +109,10 @@ interface TableRow {
     confirmationMethod?: string;
     // Represents a list as a comma and space separated string e.g. 'fever, cough'
     symptoms: string;
-    transmissionRoute: string;
-    transmissionPlace: string;
+    // Represents a list as a comma and space separated string e.g. 'vertical, iatrogenic'
+    transmissionRoutes: string;
+    // Represents a list as a comma and space separated string e.g. 'gym, hospital'
+    transmissionPlaces: string;
     // Represents a list as a comma and space separated string e.g. 'caseId, caseId2'
     transmissionLinkedCaseIds: string;
     // sources
@@ -202,8 +204,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                 provided: this.splitCommaSeparated(rowData.symptoms),
             },
             transmission: {
-                route: rowData.transmissionRoute,
-                place: rowData.transmissionPlace,
+                route: this.splitCommaSeparated(rowData.transmissionRoutes),
+                place: this.splitCommaSeparated(rowData.transmissionPlaces),
                 linkedCaseIds: this.splitCommaSeparated(
                     rowData.transmissionLinkedCaseIds,
                 ),
@@ -337,14 +339,14 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 filtering: false,
                             },
                             {
-                                title: 'Route of transmission',
-                                field: 'transmissionRoute',
+                                title: 'Routes of transmission',
+                                field: 'transmissionRoutes',
                                 filtering: false,
                                 editable: 'never',
                             },
                             {
-                                title: 'Place of transmission',
-                                field: 'transmissionPlace',
+                                title: 'Places of transmission',
+                                field: 'transmissionPlaces',
                                 filtering: false,
                                 editable: 'never',
                             },
@@ -451,10 +453,12 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 symptoms: c.symptoms?.provided?.join(
                                                     ', ',
                                                 ),
-                                                transmissionRoute:
-                                                    c.transmission?.route,
-                                                transmissionPlace:
-                                                    c.transmission?.place,
+                                                transmissionRoutes: c.transmission?.routes.join(
+                                                    ', ',
+                                                ),
+                                                transmissionPlaces: c.transmission?.places.join(
+                                                    ', ',
+                                                ),
                                                 transmissionLinkedCaseIds: c.transmission?.linkedCaseIds.join(
                                                     ', ',
                                                 ),

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -178,8 +178,8 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     provided: values.symptoms,
                 },
                 transmission: {
-                    route: values.transmissionRoute,
-                    place: values.transmissionPlace,
+                    routes: values.transmissionRoutes,
+                    places: values.transmissionPlaces,
                     linkedCaseIds: values.transmissionLinkedCaseIds,
                 },
                 sources: [
@@ -271,8 +271,8 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     outcomeDate: null,
                     outcome: undefined,
                     symptoms: [],
-                    transmissionRoute: undefined,
-                    transmissionPlace: undefined,
+                    transmissionRoutes: [],
+                    transmissionPlaces: [],
                     transmissionLinkedCaseIds: [],
                     sourceUrl: '',
                     notes: '',
@@ -387,16 +387,14 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                             >
                                 {this.tableOfContentsIcon({
                                     isChecked:
-                                        values.transmissionRoute !==
-                                            undefined ||
-                                        values.transmissionPlace !==
-                                            undefined ||
+                                        values.transmissionRoutes.length > 0 ||
+                                        values.transmissionPlaces.length > 0 ||
                                         values.transmissionLinkedCaseIds
                                             .length > 0,
                                     hasError:
-                                        errors.transmissionRoute !==
+                                        errors.transmissionRoutes !==
                                             undefined ||
-                                        errors.transmissionPlace !==
+                                        errors.transmissionPlaces !==
                                             undefined ||
                                         errors.transmissionLinkedCaseIds !==
                                             undefined,

--- a/verification/curator-service/ui/src/components/new-case-form-fields/NewCaseFormValues.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/NewCaseFormValues.tsx
@@ -21,8 +21,8 @@ export default interface NewCaseFormValues {
     outcomeDate: string | null;
     outcome?: string;
     symptoms: string[];
-    transmissionRoute?: string;
-    transmissionPlace?: string;
+    transmissionRoutes: string[];
+    transmissionPlaces: string[];
     transmissionLinkedCaseIds: string[];
     sourceUrl: string;
     notes: string;

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Transmission.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Transmission.tsx
@@ -1,13 +1,9 @@
-import { Field, useFormikContext } from 'formik';
-
 import ChipInput from 'material-ui-chip-input';
-import FormControl from '@material-ui/core/FormControl';
-import InputLabel from '@material-ui/core/InputLabel';
-import MenuItem from '@material-ui/core/MenuItem';
+import FormikAutocomplete from './FormikAutocomplete';
 import React from 'react';
 import Scroll from 'react-scroll';
-import { Select } from 'formik-material-ui';
 import { makeStyles } from '@material-ui/core';
+import { useFormikContext } from 'formik';
 
 const useStyles = makeStyles(() => ({
     fieldRow: {
@@ -22,92 +18,29 @@ interface SelectFieldProps {
     values: (string | undefined)[];
 }
 
-function SelectField(props: SelectFieldProps): JSX.Element {
-    const classes = useStyles();
-    return (
-        <FormControl className={classes.fieldRow}>
-            <InputLabel htmlFor={props.name}>{props.label}</InputLabel>
-            <Field
-                as="select"
-                name={props.name}
-                type="text"
-                data-testid={props.name}
-                component={Select}
-            >
-                {props.values.map((value) => (
-                    <MenuItem key={value ?? 'undefined'} value={value}>
-                        {value}
-                    </MenuItem>
-                ))}
-            </Field>
-        </FormControl>
-    );
-}
-
-// TODO: get values from DB.
-const transmissionRoutes = [
-    undefined,
-    'Airborne infection',
-    'Droplet infection',
-    'Fecal–oral',
-    'Sexual',
-    'Oral',
-    'Direct contact',
-    'Vertical',
-    'Iatrogenic',
-    'Vector borne',
-    'Other',
-];
-
-const transmissionPlaces = [
-    undefined,
-    'Assisted Living',
-    'Bar / Pub',
-    'Building site',
-    'Conference',
-    'Elderly Care',
-    'Factory',
-    'Food Processing Plant',
-    'Funeral',
-    'Gym',
-    'Hospital',
-    'Hotel',
-    'Household',
-    'Large shared accomodation',
-    'Long Term Acute Care',
-    'Long Term Care Facility',
-    'Nighclub',
-    'Office',
-    'Prison',
-    'Public Space',
-    'Restaurant',
-    'Religous place of worship',
-    'School',
-    'Ship',
-    'Shopping',
-    'Sport event',
-    'Warehouse',
-    'Wedding',
-    'Work',
-    'Other',
-];
-
 export default function Transmission(): JSX.Element {
     const { setFieldValue, setTouched } = useFormikContext();
+    const classes = useStyles();
     return (
         <Scroll.Element name="transmission">
             <fieldset>
                 <legend>Transmission</legend>
-                <SelectField
-                    name="transmissionRoute"
-                    label="Route of transmission"
-                    values={transmissionRoutes}
-                ></SelectField>
-                <SelectField
-                    name="transmissionPlace"
-                    label="Place of transmission"
-                    values={transmissionPlaces}
-                ></SelectField>
+                <div className={classes.fieldRow}>
+                    <FormikAutocomplete
+                        name="transmissionRoutes"
+                        label="Route of transmission"
+                        multiple={true}
+                        optionsLocation="https://raw.githubusercontent.com/open-covid-data/healthmap-gdo-temp/master/suggest/route_of_transmission.txt"
+                    />
+                </div>
+                <div className={classes.fieldRow}>
+                    <FormikAutocomplete
+                        name="transmissionPlaces"
+                        label="Places of transmission"
+                        multiple={true}
+                        optionsLocation="https://raw.githubusercontent.com/open-covid-data/healthmap-gdo-temp/master/suggest/place_of_transmission.txt"
+                    />
+                </div>
                 <ChipInput
                     fullWidth
                     alwaysShowPlaceholder


### PR DESCRIPTION
Per comments & updates to spec, updating 3 fields to be lists instead of singletons:

- transmission.places
- transmission.routes
- travel.methods

(I asked for clarity on the spec on which things were lists; this should bring it in alignment with the doc)

I copied the UI for other multi-selects but have no idea what I'm doing so LMK if that needs work!