### PR TITLE
Add param to limit geocode to a specific resolution

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,15 +26,23 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build stack
         run: docker-compose -f dev/docker-compose.yml -f dev/docker-compose.ci.yml up --build -d -V
+      # Run the tests, if they fail, show docker logs and fail the step.
       - name: Cypress integration tests
         run: |
           npm ci
-          npm run cypress-run
+          npm run cypress-run || docker-compose -f ../../../dev/docker-compose.yml -f ../../../dev/docker-compose.ci.yml logs && false
         working-directory: verification/curator-service/ui
         env:
           CI: true
+      # Screenshots are only available on failures.
       - uses: actions/upload-artifact@v1
         if: failure()
+        with:
+          name: cypress-screenshots
+          path: verification/curator-service/ui/cypress/screenshots
+      # Videos are always available.
+      - uses: actions/upload-artifact@v1
+        if: always()
         with:
           name: cypress-videos
           path: verification/curator-service/ui/cypress/videos/components

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,11 +26,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build stack
         run: docker-compose -f dev/docker-compose.yml -f dev/docker-compose.ci.yml up --build -d -V
-      # Run the tests, if they fail, show docker logs and fail the step.
       - name: Cypress integration tests
         run: |
           npm ci
-          npm run cypress-run || docker-compose -f ../../../dev/docker-compose.yml -f ../../../dev/docker-compose.ci.yml logs && false
+          npm run cypress-run
         working-directory: verification/curator-service/ui
         env:
           CI: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,3 +33,8 @@ jobs:
         working-directory: verification/curator-service/ui
         env:
           CI: true
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-videos
+          path: verification/curator-service/ui/cypress/videos/components

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -1,6 +1,6 @@
+import { GeocodeOptions, Geocoder } from '../geocoding/geocoder';
 import { Request, Response } from 'express';
 
-import { Geocoder } from '../geocoding/geocoder';
 import axios from 'axios';
 
 /**
@@ -110,7 +110,11 @@ export default class CasesController {
         const location = req.body['location'];
         if (!location?.geometry?.latitude || !location.geometry?.longitude) {
             for (const geocoder of this.geocoders) {
-                const features = await geocoder.geocode(location?.query);
+                const opts: GeocodeOptions = {};
+                if (location['limitToResolution']) {
+                    opts.limitToResolution = location['limitToResolution'];
+                }
+                const features = await geocoder.geocode(location?.query, opts);
                 if (features.length === 0) {
                     continue;
                 }
@@ -120,8 +124,9 @@ export default class CasesController {
             }
             return false;
         } else {
-            // Remove any query as we shouldn't store it.
+            // Remove any left over field as the schema doesn't allow unknown fields.
             delete location.query;
+            delete location.limitToResolution;
         }
         return true;
     }

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -3,6 +3,8 @@ import { Request, Response } from 'express';
 
 import axios from 'axios';
 
+class InvalidParamError extends Error {}
+
 /**
  * CasesController forwards requests to the data service.
  * It handles CRUD operations from curators.
@@ -76,6 +78,10 @@ export default class CasesController {
             );
             res.json(response.data);
         } catch (err) {
+            if (err instanceof InvalidParamError) {
+                res.status(422).send(err.message);
+                return;
+            }
             console.log(err);
             res.status(500).send(err.message);
         }
@@ -95,6 +101,10 @@ export default class CasesController {
             );
             res.json(response.data);
         } catch (err) {
+            if (err instanceof InvalidParamError) {
+                res.status(422).send(err.message);
+                return;
+            }
             console.log(err);
             res.status(500).send(err.message);
         }
@@ -118,6 +128,11 @@ export default class CasesController {
                                 'limitToResolution'
                             ] as keyof typeof Resolution
                         ];
+                    if (!opts.limitToResolution) {
+                        throw new InvalidParamError(
+                            `invalid limitToResolution: ${location['limitToResolution']}`,
+                        );
+                    }
                 }
                 const features = await geocoder.geocode(location?.query, opts);
                 if (features.length === 0) {

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -1,4 +1,4 @@
-import { GeocodeOptions, Geocoder } from '../geocoding/geocoder';
+import { GeocodeOptions, Geocoder, Resolution } from '../geocoding/geocoder';
 import { Request, Response } from 'express';
 
 import axios from 'axios';
@@ -112,7 +112,12 @@ export default class CasesController {
             for (const geocoder of this.geocoders) {
                 const opts: GeocodeOptions = {};
                 if (location['limitToResolution']) {
-                    opts.limitToResolution = location['limitToResolution'];
+                    opts.limitToResolution =
+                        Resolution[
+                            location[
+                                'limitToResolution'
+                            ] as keyof typeof Resolution
+                        ];
                 }
                 const features = await geocoder.geocode(location?.query, opts);
                 if (features.length === 0) {

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -121,24 +121,24 @@ export default class CasesController {
         if (location?.geometry?.latitude & location.geometry?.longitude) {
             return true;
         }
-        if (location?.query) {
+        if (!location?.query) {
             throw new InvalidParamError(
                 'location.query must be specified to be able to geocode',
             );
         }
-        for (const geocoder of this.geocoders) {
-            const opts: GeocodeOptions = {};
-            if (location['limitToResolution']) {
-                opts.limitToResolution =
-                    Resolution[
-                        location['limitToResolution'] as keyof typeof Resolution
-                    ];
-                if (!opts.limitToResolution) {
-                    throw new InvalidParamError(
-                        `invalid limitToResolution: ${location['limitToResolution']}`,
-                    );
-                }
+        const opts: GeocodeOptions = {};
+        if (location['limitToResolution']) {
+            opts.limitToResolution =
+                Resolution[
+                    location['limitToResolution'] as keyof typeof Resolution
+                ];
+            if (!opts.limitToResolution) {
+                throw new InvalidParamError(
+                    `invalid limitToResolution: ${location['limitToResolution']}`,
+                );
             }
+        }
+        for (const geocoder of this.geocoders) {
             const features = await geocoder.geocode(location?.query, opts);
             if (features.length === 0) {
                 continue;

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -118,7 +118,7 @@ export default class CasesController {
     private async geocode(req: Request): Promise<boolean> {
         // Geocode query if no lat lng were provided.
         const location = req.body['location'];
-        if (location?.geometry?.latitude & location.geometry?.longitude) {
+        if (location?.geometry?.latitude && location.geometry?.longitude) {
             return true;
         }
         if (!location?.query) {

--- a/verification/curator-service/api/src/geocoding/fake.ts
+++ b/verification/curator-service/api/src/geocoding/fake.ts
@@ -8,6 +8,9 @@ export default class FakeGeocoder {
     constructor() {
         this.entries = new Map<string, GeocodeResult>();
     }
+    // Geocode with fake seeded locations.
+    // It ignores the options that can be passed to the geocoder and
+    // matches locations' name field with the given query.
     async geocode(query: string): Promise<GeocodeResult[]> {
         console.debug('geocoding ', query);
         const entry = this.entries.get(query);

--- a/verification/curator-service/api/src/geocoding/geocoder.ts
+++ b/verification/curator-service/api/src/geocoding/geocoder.ts
@@ -27,7 +27,13 @@ export enum Resolution {
     Country = 'Country',
 }
 
+export interface GeocodeOptions {
+    // If set, will only return features with the given resolution
+    // otherwise all available resolutions can be returned.
+    limitToResolution?: Resolution;
+}
+
 // A geocoder can geocode queries into places.
 export interface Geocoder {
-    geocode(query: string): Promise<GeocodeResult[]>;
+    geocode(query: string, opts?: GeocodeOptions): Promise<GeocodeResult[]>;
 }

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -99,7 +99,6 @@ export default class MapboxGeocoder {
                     req.types = [type];
                 }
             }
-            console.debug('Querying mapbox with', req);
             const resp: MapiResponse = await this.geocodeService
                 .forwardGeocode(req)
                 .send();

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -99,6 +99,7 @@ export default class MapboxGeocoder {
                     req.types = [type];
                 }
             }
+            console.debug('Querying mapbox with', req);
             const resp: MapiResponse = await this.geocodeService
                 .forwardGeocode(req)
                 .send();

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -51,7 +51,7 @@ const resolutionToGeocodeQueryType = new Map<Resolution, GeocodeQueryType>([
     [Resolution.Country, 'country'],
     [Resolution.Admin1, 'region'],
     [Resolution.Admin2, 'district'],
-    [Resolution.Admin3, 'district'],
+    [Resolution.Admin3, 'place'],
     [Resolution.Point, 'poi'],
 ]);
 

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -1,7 +1,9 @@
-import { GeocodeResult, Resolution } from './geocoder';
+import { GeocodeOptions, GeocodeResult, Resolution } from './geocoder';
 import Geocoding, {
     GeocodeFeature,
     GeocodeMode,
+    GeocodeQueryType,
+    GeocodeRequest,
     GeocodeResponse,
     GeocodeService,
 } from '@mapbox/mapbox-sdk/services/geocoding';
@@ -44,6 +46,15 @@ function getResolution(features: GeocodeFeature[]): Resolution {
     return Resolution.Country;
 }
 
+// Get the mapbox types for a given Resolution.
+const resolutionToGeocodeQueryType = new Map<Resolution, GeocodeQueryType>([
+    [Resolution.Country, 'country'],
+    [Resolution.Admin1, 'region'],
+    [Resolution.Admin2, 'district'],
+    [Resolution.Admin3, 'district'],
+    [Resolution.Point, 'poi'],
+]);
+
 export default class MapboxGeocoder {
     private geocodeService: GeocodeService;
     private cache: LRUCache<string, GeocodeResult[]>;
@@ -56,20 +67,40 @@ export default class MapboxGeocoder {
         });
     }
 
-    async geocode(query: string): Promise<GeocodeResult[]> {
+    async geocode(
+        query: string,
+        opts?: GeocodeOptions,
+    ): Promise<GeocodeResult[]> {
         query = query.trim();
-        const cachedResults = this.cache.get(query);
+        const cacheKey = JSON.stringify({
+            query: query.toLowerCase(),
+            opts: opts,
+        });
+        const cachedResults = this.cache.get(cacheKey);
         if (cachedResults) {
             return cachedResults;
         }
         try {
+            const req: GeocodeRequest = {
+                mode: this.endpoint,
+                query: query,
+                language: ['en'],
+                limit: 5,
+            };
+            // Setting req.type allows to filter the top level results
+            // with features of that specific type.
+            // The context of the feature can still has other types
+            // (if you ask for a region, the context will still contain the country).
+            if (opts?.limitToResolution) {
+                const type = resolutionToGeocodeQueryType.get(
+                    opts?.limitToResolution,
+                );
+                if (type) {
+                    req.types = [type];
+                }
+            }
             const resp: MapiResponse = await this.geocodeService
-                .forwardGeocode({
-                    mode: this.endpoint,
-                    query: query,
-                    language: ['en'],
-                    limit: 5,
-                })
+                .forwardGeocode(req)
                 .send();
             const features = (resp.body as GeocodeResponse).features;
             const geocodes = features.map((feature) => {
@@ -100,7 +131,7 @@ export default class MapboxGeocoder {
                     geoResolution: getResolution(contexts),
                 };
             });
-            this.cache.set(query, geocodes);
+            this.cache.set(cacheKey, geocodes);
             return geocodes;
         } catch (e) {
             throw e;

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -164,7 +164,10 @@ describe('Cases', () => {
         mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
             .post('/api/cases')
-            .send({ age: '42', location: { query: 'Lyon' } })
+            .send({
+                age: '42',
+                location: { query: 'Lyon', limitToResolution: 'Admin3' },
+            })
             .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -180,6 +180,19 @@ describe('Cases', () => {
         );
     });
 
+    it('throws on invalid location restrictions', async () => {
+        await curatorRequest
+            .post('/api/cases')
+            .send({
+                age: '42',
+                location: {
+                    query: 'Lyon',
+                    limitToResolution: 'NotAResolution',
+                },
+            })
+            .expect(422);
+    });
+
     it('returns 404 when no geocode could be found on create', async () => {
         mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest

--- a/verification/curator-service/api/test/geocoding/mapbox.test.ts
+++ b/verification/curator-service/api/test/geocoding/mapbox.test.ts
@@ -42,7 +42,9 @@ describe('geocode', () => {
     it('succeeds', async () => {
         features.push(lyon);
         const geocoder = new Geocoder('token', 'mapbox.places');
-        let feats = await geocoder.geocode('some query');
+        let feats = await geocoder.geocode('some query', {
+            limitToResolution: Resolution.Admin3,
+        });
         expect(feats).toHaveLength(1);
         const wantFeature: GeocodeResult = {
             administrativeAreaLevel1: 'Rhône',
@@ -57,7 +59,9 @@ describe('geocode', () => {
         expect(feats[0]).toEqual(wantFeature);
         expect(callCount).toBe(1);
         // Call again, cache should have been hit.
-        feats = await geocoder.geocode('some query');
+        feats = await geocoder.geocode('some query', {
+            limitToResolution: Resolution.Admin3,
+        });
         expect(feats[0]).toEqual(wantFeature);
         expect(callCount).toBe(1);
     });


### PR DESCRIPTION
The /api/cases geocoding requests now accept a `location.limitToResolution` param which allows to filter the geocode results.
This should allow parsers that know they are about a region/district/country to limit geocodes to upper regions and not end up geocoding admin3 when they wanted admin2 for example.

Verified with a modified UI that hardcoded Admin2 as the resolution that geocoding of Puri returns the region instead of the city.

With `Admin2` restriction:
![image](https://user-images.githubusercontent.com/1255432/85525827-bb351300-b609-11ea-878e-2f5510505753.png)

Without:
![image](https://user-images.githubusercontent.com/1255432/85526711-84133180-b60a-11ea-9019-820d9a36a18d.png)


Kind of hard to ensure that properly in unit tests as the fake geocoder ignores options in order to keep it dead simple, happy to make it more complex (accept options and store and expose requests for example via another http handler) if you think it's worth it.