### PR TITLE
Add travel history to NewCaseForm

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -18,6 +18,18 @@ describe('New case form', function () {
             name: 'France',
             geoResolution: 'Country',
         });
+        cy.seedLocation({
+            country: 'Germany',
+            geometry: { latitude: 51.0968509, longitude: 5.9688274 },
+            name: 'Germany',
+            geoResolution: 'Country',
+        });
+        cy.seedLocation({
+            country: 'United Kingdom',
+            geometry: { latitude: 54.2316104, longitude: -13.4274035 },
+            name: 'United Kingdom',
+            geoResolution: 'Country',
+        });
 
         cy.visit('/cases/new');
         cy.get('div[data-testid="sex"]').click();
@@ -63,6 +75,12 @@ describe('New case form', function () {
         cy.get('input[placeholder="Contacted case IDs"').type(
             'testcaseid12345678987654\ntestcaseid12345678987655\n',
         );
+        cy.get('button[data-testid="addTravelHistory"').click();
+        cy.get('div[data-testid="travelHistory[0]"]').type('Germany');
+        cy.get('li').first().should('contain', 'Germany').click();
+        cy.get('button[data-testid="addTravelHistory"').click();
+        cy.get('div[data-testid="travelHistory[1]"]').type('United Kingdom');
+        cy.get('li').first().should('contain', 'United Kingdom').click();
         cy.get('input[name="sourceUrl"]').clear().type('www.example.com');
         cy.get('textarea[name="notes"]')
             .clear()
@@ -85,6 +103,7 @@ describe('New case form', function () {
         cy.contains('Direct contact');
         cy.contains('Factory');
         cy.contains('testcaseid12345678987654, testcaseid12345678987655');
+        cy.contains('Germany, United Kingdom');
         cy.contains('www.example.com');
         cy.contains('test notes');
         cy.contains('on new line');

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -68,6 +68,14 @@ interface Transmission {
     linkedCaseIds: string[];
 }
 
+interface TravelHistory {
+    travel: Travel[];
+}
+
+interface Travel {
+    location: Location;
+}
+
 interface Case {
     _id: string;
     importedCase: {
@@ -79,6 +87,7 @@ interface Case {
     symptoms: Symptoms;
     transmission: Transmission;
     sources: Source[];
+    travelHistory: TravelHistory;
     notes: string;
 }
 
@@ -113,6 +122,7 @@ interface TableRow {
     transmissionPlace: string;
     // Represents a list as a comma and space separated string e.g. 'caseId, caseId2'
     transmissionLinkedCaseIds: string;
+    travelHistory: TravelHistory;
     // sources
     sourceUrl: string | null;
     notes: string;
@@ -208,6 +218,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                     rowData.transmissionLinkedCaseIds,
                 ),
             },
+            travelHistory: rowData.travelHistory,
             revisionMetadata: {
                 revisionNumber: 0,
                 creationMetadata: {
@@ -353,6 +364,16 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 field: 'transmissionLinkedCaseIds',
                                 filtering: false,
                             },
+                            {
+                                title: 'Travel history',
+                                field: 'travelHistory',
+                                filtering: false,
+                                editable: 'never',
+                                render: (rowData) =>
+                                    rowData.travelHistory?.travel
+                                        ?.map((travel) => travel.location.name)
+                                        ?.join(', '),
+                            },
                             { title: 'Notes', field: 'notes' },
                             {
                                 title: 'Source URL',
@@ -458,6 +479,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 transmissionLinkedCaseIds: c.transmission?.linkedCaseIds.join(
                                                     ', ',
                                                 ),
+                                                travelHistory: c.travelHistory,
                                                 notes: c.notes,
                                                 sourceUrl:
                                                     c.sources &&

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -117,9 +117,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     nationalities: values.nationalities,
                     profession: values.profession,
                 },
-                location: {
-                    ...values.location,
-                },
+                location: values.location,
                 events: [
                     {
                         name: 'confirmed',
@@ -190,9 +188,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                 travelHistory: {
                     travel: values.travelHistory.map((travelHistory) => {
                         return {
-                            location: {
-                                ...travelHistory,
-                            },
+                            location: travelHistory,
                         };
                     }),
                 },

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -17,6 +17,7 @@ import Scroll from 'react-scroll';
 import Source from './new-case-form-fields/Source';
 import Symptoms from './new-case-form-fields/Symptoms';
 import Transmission from './new-case-form-fields/Transmission';
+import TravelHistory from './new-case-form-fields/TravelHistory';
 import { WithStyles } from '@material-ui/core/styles/withStyles';
 import axios from 'axios';
 import { createStyles } from '@material-ui/core/styles';
@@ -118,7 +119,6 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                 },
                 location: {
                     ...values.location,
-                    ...{ query: values.locationQuery },
                 },
                 events: [
                     {
@@ -187,6 +187,15 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                         url: values.sourceUrl,
                     },
                 ],
+                travelHistory: {
+                    travel: values.travelHistory.map((travelHistory) => {
+                        return {
+                            location: {
+                                ...travelHistory,
+                            },
+                        };
+                    }),
+                },
                 notes: values.notes,
                 revisionMetadata: {
                     revisionNumber: 0,
@@ -258,7 +267,6 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     ethnicity: undefined,
                     nationalities: [],
                     profession: undefined,
-                    locationQuery: '',
                     location: undefined,
                     confirmedDate: null,
                     methodOfConfirmation: undefined,
@@ -274,6 +282,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     transmissionRoute: undefined,
                     transmissionPlace: undefined,
                     transmissionLinkedCaseIds: [],
+                    travelHistory: [],
                     sourceUrl: '',
                     notes: '',
                 }}
@@ -325,8 +334,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                                     isChecked:
                                         values.location !== null &&
                                         values.location !== undefined,
-                                    hasError:
-                                        errors.locationQuery !== undefined,
+                                    hasError: errors.location !== undefined,
                                 })}
                                 Location
                             </div>
@@ -405,6 +413,19 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                             </div>
                             <div
                                 className={classes.tableOfContentsRow}
+                                onClick={(): void =>
+                                    this.scrollTo('travelHistory')
+                                }
+                            >
+                                {this.tableOfContentsIcon({
+                                    isChecked: values.travelHistory.length > 0,
+                                    hasError:
+                                        errors.travelHistory !== undefined,
+                                })}
+                                Travel History
+                            </div>
+                            <div
+                                className={classes.tableOfContentsRow}
                                 onClick={(): void => this.scrollTo('source')}
                             >
                                 {this.tableOfContentsIcon({
@@ -431,6 +452,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                                 <Events></Events>
                                 <Symptoms></Symptoms>
                                 <Transmission></Transmission>
+                                <TravelHistory></TravelHistory>
                                 <Source></Source>
                                 <Notes></Notes>
                                 {isSubmitting && <LinearProgress />}

--- a/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
@@ -19,7 +19,7 @@ function LocationForm(): JSX.Element {
         <Scroll.Element name="location">
             <fieldset>
                 <legend>Location</legend>
-                <PlacesAutocomplete />
+                <PlacesAutocomplete name="location" />
                 <Location location={values.location} />
             </fieldset>
         </Scroll.Element>
@@ -39,9 +39,15 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
+interface PlacesAutocompleteProps {
+    name: string;
+}
+
 // Place autocomplete, based on
 // https://material-ui.com/components/autocomplete/#google-maps-place
-function PlacesAutocomplete(): JSX.Element {
+export function PlacesAutocomplete(
+    props: PlacesAutocompleteProps,
+): JSX.Element {
     const classes = useStyles();
     const [value, setValue] = React.useState<Loc | null>(null);
     const [inputValue, setInputValue] = React.useState('');
@@ -97,8 +103,6 @@ function PlacesAutocomplete(): JSX.Element {
         };
     }, [value, inputValue, fetch]);
 
-    const name = 'location';
-
     return (
         <Autocomplete
             itemType="Loc"
@@ -108,9 +112,9 @@ function PlacesAutocomplete(): JSX.Element {
             onChange={(event: any, newValue: Loc | null): void => {
                 setOptions(newValue ? [newValue, ...options] : options);
                 setValue(newValue);
-                setFieldValue(name, newValue);
+                setFieldValue(props.name, newValue);
             }}
-            onBlur={(): void => setTouched({ [name]: true })}
+            onBlur={(): void => setTouched({ [props.name]: true })}
             onInputChange={(event, newInputValue): void => {
                 setInputValue(newInputValue);
             }}
@@ -121,7 +125,7 @@ function PlacesAutocomplete(): JSX.Element {
                     // to be set in the form values, rather than only selected
                     // dropdown values. Thus we use an unused form value here.
                     name="unused"
-                    data-testid={name}
+                    data-testid={props.name}
                     label="Location"
                     component={TextField}
                     fullWidth

--- a/verification/curator-service/ui/src/components/new-case-form-fields/NewCaseFormValues.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/NewCaseFormValues.tsx
@@ -8,7 +8,6 @@ export default interface NewCaseFormValues {
     ethnicity?: string;
     nationalities: string[];
     profession?: string;
-    locationQuery: string;
     location?: Loc;
     confirmedDate: string | null;
     methodOfConfirmation?: string;
@@ -24,6 +23,8 @@ export default interface NewCaseFormValues {
     transmissionRoute?: string;
     transmissionPlace?: string;
     transmissionLinkedCaseIds: string[];
+    // TODO: add other travel history fields
+    travelHistory: Loc[];
     sourceUrl: string;
     notes: string;
 }

--- a/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
@@ -1,0 +1,66 @@
+import { FieldArray, useFormikContext } from 'formik';
+
+import AddCircleIcon from '@material-ui/icons/AddCircle';
+import Button from '@material-ui/core/Button';
+import Location from './Location';
+import NewCaseFormValues from './NewCaseFormValues';
+import { PlacesAutocomplete } from './LocationForm';
+import React from 'react';
+import Scroll from 'react-scroll';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+    travelHistorySection: {
+        margin: '1em',
+    },
+}));
+
+export default function Events(): JSX.Element {
+    const { values } = useFormikContext<NewCaseFormValues>();
+    const classes = useStyles();
+    return (
+        <Scroll.Element name="travelHistory">
+            <fieldset>
+                <legend>Travel History</legend>
+                <FieldArray name="travelHistory">
+                    {({ push }): JSX.Element => {
+                        return (
+                            <div>
+                                {values.travelHistory &&
+                                    values.travelHistory.map(
+                                        (travelHistoryElement, index) => (
+                                            <fieldset
+                                                key={index}
+                                                className={
+                                                    classes.travelHistorySection
+                                                }
+                                            >
+                                                <PlacesAutocomplete
+                                                    name={`travelHistory[${index}]`}
+                                                ></PlacesAutocomplete>
+                                                <Location
+                                                    location={
+                                                        travelHistoryElement
+                                                    }
+                                                ></Location>
+                                            </fieldset>
+                                        ),
+                                    )}
+
+                                <Button
+                                    data-testid="addTravelHistory"
+                                    startIcon={<AddCircleIcon />}
+                                    onClick={(): void => {
+                                        push({});
+                                    }}
+                                >
+                                    Add travel history
+                                </Button>
+                            </div>
+                        );
+                    }}
+                </FieldArray>
+            </fieldset>
+        </Scroll.Element>
+    );
+}


### PR DESCRIPTION
Removes locationQuery which is no longer used.

This is the beginning of the travel history section to get the framework in place. We still need to add the other travel history fields, and add a way to delete travel history sections once added.