### PR TITLE
Find existing sources when creating/updating/upserting case and fill them in properly

### DIFF
--- a/data-serving/data-service/src/model/case.ts
+++ b/data-serving/data-service/src/model/case.ts
@@ -27,7 +27,7 @@ const caseSchema = new mongoose.Schema(
             type: [eventSchema],
             required: true,
             validate: {
-                validator: (events: [EventDocument]) =>
+                validator: (events: [EventDocument]): boolean =>
                     events.some((e) => e.name == 'confirmed'),
                 message: 'Must include an event with name "confirmed"',
             },

--- a/data-serving/data-service/src/model/source.ts
+++ b/data-serving/data-service/src/model/source.ts
@@ -1,22 +1,13 @@
 import mongoose from 'mongoose';
 
 const fieldRequiredValidator = [
-    function (this: SourceDocument) {
-        return (
-            this != null &&
-            this.id == null &&
-            this.url == null &&
-            this.other == null
-        );
+    function (this: SourceDocument): boolean {
+        return this != null && this.url == null && this.other == null;
     },
     'Source must specify id, url, or other',
 ];
 
 export const sourceSchema = new mongoose.Schema({
-    id: {
-        type: String,
-        required: fieldRequiredValidator,
-    },
     url: {
         type: String,
         required: fieldRequiredValidator,
@@ -28,7 +19,8 @@ export const sourceSchema = new mongoose.Schema({
 });
 
 export type SourceDocument = mongoose.Document & {
-    id: string;
     url: string;
     other: string;
 };
+
+export const Source = mongoose.model<SourceDocument>('Source', sourceSchema);

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -215,8 +215,9 @@ describe('Sources', () => {
         expect(c.sources).toHaveLength(1);
     });
     it('are reused if existing on create', async () => {
-        const source = await new Source({ url: 'cdc.gov' }).save();
-        console.log('created source with id', source.id);
+        const source = await new Source({
+            url: minimalCase.sources[0].url,
+        }).save();
         return request(app)
             .post('/api/cases')
             .send(minimalCase)
@@ -225,7 +226,6 @@ describe('Sources', () => {
     });
     it('are reused if existing on update', async () => {
         const source = await new Source({ url: 'nope.gov' }).save();
-        console.log('created source with id', source.id);
         const resp = await request(app)
             .post('/api/cases')
             .send(minimalCase)
@@ -240,8 +240,9 @@ describe('Sources', () => {
             .expect(200, new RegExp(source.id));
     });
     it('are reused if existing on upsert', async () => {
-        const source = await new Source({ url: 'cdc.gov' }).save();
-        console.log('created source with id', source.id);
+        const source = await new Source({
+            url: minimalCase.sources[0].url,
+        }).save();
         return request(app)
             .put('/api/cases/')
             .send(minimalCase)

--- a/data-serving/data-service/test/model/data/source.full.json
+++ b/data-serving/data-service/test/model/data/source.full.json
@@ -1,5 +1,4 @@
 {
-    "id": "abc",
     "url": "http://abc.def",
     "other": "ghi"
 }

--- a/data-serving/data-service/test/model/source.test.ts
+++ b/data-serving/data-service/test/model/source.test.ts
@@ -1,20 +1,14 @@
-import { SourceDocument, sourceSchema } from '../../src/model/source';
+import { Source, sourceSchema } from '../../src/model/source';
 
 import { Error } from 'mongoose';
 import fullModel from './data/source.full.json';
 import mongoose from 'mongoose';
-
-const Source = mongoose.model<SourceDocument>('Source', sourceSchema);
 
 describe('validate', () => {
     it('empty source is invalid', async () => {
         return new Source({}).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });
-    });
-
-    it('a source with only an id is valid', async () => {
-        return new Source({ id: 'abc' }).validate();
     });
 
     it('a source with only url is valid', async () => {


### PR DESCRIPTION
I'm curious what you all think we should do here. This is going to cost us a bit as we do a round trip to fetch any existing source by URL before touching a case but this way we get consistent sub documents which was not the case before.

https://mongoosejs.com/docs/subdocs.html

I've tried to use mongoose pre save hooks (https://mongoosejs.com/docs/middleware.html#order) as it felt cleaner at first but there are a few issues with that approach:
- There is a circular dependency between the schema and its model when before saving a source we're trying to fetch existing sources. This is doable by using the globally accessible mongoose.schemas['Source'] but feels ugly and brittle.
- Subdocuments save hooks are called before top level documents save hooks so when a case is saved the sub sources are already saved so there's no easy way to know if the sub sources were just created or already existed before.