### PR TITLE
Add more travel history fields

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -34,7 +34,7 @@ describe('New case form', function () {
         cy.visit('/cases/new');
         cy.get('div[data-testid="sex"]').click();
         cy.get('li[data-value="Female"').click();
-        cy.get('input[name="age"]').clear().type('21');
+        cy.get('input[name="age"]').type('21');
         cy.get('div[data-testid="ethnicity"]').click();
         cy.get('li[data-value="Asian"').click();
         cy.get('div[data-testid="nationalities"]').type('Afghan');
@@ -47,23 +47,21 @@ describe('New case form', function () {
         cy.contains('France');
         cy.contains('Country');
         cy.get('li').first().should('contain', 'France').click();
-        cy.get('input[name="confirmedDate"]').clear().type('2020-01-01');
+        cy.get('input[name="confirmedDate"]').type('2020-01-01');
         cy.get('div[data-testid="methodOfConfirmation"]').click();
         cy.get('li[data-value="PCR test"').click();
-        cy.get('input[name="onsetSymptomsDate"]').clear().type('2020-01-02');
-        cy.get('input[name="firstClinicalConsultationDate"]')
-            .clear()
-            .type('2020-01-03');
-        cy.get('input[name="selfIsolationDate"]').clear().type('2020-01-04');
+        cy.get('input[name="onsetSymptomsDate"]').type('2020-01-02');
+        cy.get('input[name="firstClinicalConsultationDate"]').type(
+            '2020-01-03',
+        );
+        cy.get('input[name="selfIsolationDate"]').type('2020-01-04');
         cy.get('div[data-testid="admittedToHospital"]').click();
         cy.get('li[data-value="Yes"').click();
-        cy.get('input[name="hospitalAdmissionDate"]')
-            .clear()
-            .type('2020-01-05');
-        cy.get('input[name="icuAdmissionDate"]').clear().type('2020-01-06');
+        cy.get('input[name="hospitalAdmissionDate"]').type('2020-01-05');
+        cy.get('input[name="icuAdmissionDate"]').type('2020-01-06');
         cy.get('div[data-testid="outcome"]').click();
         cy.get('li[data-value="Recovered"').click();
-        cy.get('input[name="outcomeDate"]').clear().type('2020-01-07');
+        cy.get('input[name="outcomeDate"]').type('2020-01-07');
         cy.get('div[data-testid="symptoms"]').type('dry cough');
         cy.get('li').first().should('contain', 'dry cough').click();
         cy.get('div[data-testid="symptoms"]').type('mild fever');
@@ -76,15 +74,35 @@ describe('New case form', function () {
             'testcaseid12345678987654\ntestcaseid12345678987655\n',
         );
         cy.get('button[data-testid="addTravelHistory"').click();
-        cy.get('div[data-testid="travelHistory[0]"]').type('Germany');
+        cy.get('div[data-testid="travelHistory[0].location"]').type('Germany');
         cy.get('li').first().should('contain', 'Germany').click();
+        cy.get('input[name="travelHistory[0].dateRange.start"]').type(
+            '2020-01-06',
+        );
+        cy.get('input[name="travelHistory[0].dateRange.end"]').type(
+            '2020-01-07',
+        );
+        cy.get('div[data-testid="travelHistory[0].purpose"]').click();
+        cy.get('li[data-value="Business"').click();
+        cy.get('div[data-testid="travelHistory[0].method"]').click();
+        cy.get('li[data-value="Car"').click();
         cy.get('button[data-testid="addTravelHistory"').click();
-        cy.get('div[data-testid="travelHistory[1]"]').type('United Kingdom');
+        cy.get('div[data-testid="travelHistory[1].location"]').type(
+            'United Kingdom',
+        );
         cy.get('li').first().should('contain', 'United Kingdom').click();
-        cy.get('input[name="sourceUrl"]').clear().type('www.example.com');
-        cy.get('textarea[name="notes"]')
-            .clear()
-            .type('test notes\non new line');
+        cy.get('input[name="travelHistory[1].dateRange.start"]').type(
+            '2020-01-01',
+        );
+        cy.get('input[name="travelHistory[1].dateRange.end"]').type(
+            '2020-01-05',
+        );
+        cy.get('div[data-testid="travelHistory[1].purpose"]').click();
+        cy.get('li[data-value="Business"').click();
+        cy.get('div[data-testid="travelHistory[1].method"]').click();
+        cy.get('li[data-value="Car"').click();
+        cy.get('input[name="sourceUrl"]').type('www.example.com');
+        cy.get('textarea[name="notes"]').type('test notes\non new line');
         cy.server();
         cy.route('POST', '/api/cases').as('addCase');
         cy.get('button[data-testid="submit"]').click();
@@ -124,8 +142,8 @@ describe('New case form', function () {
         cy.contains('France');
         cy.contains('Country');
         cy.get('li').first().should('contain', 'France').click();
-        cy.get('input[name="confirmedDate"]').clear().type('2020-01-01');
-        cy.get('input[name="sourceUrl"]').clear().type('www.example.com');
+        cy.get('input[name="confirmedDate"]').type('2020-01-01');
+        cy.get('input[name="sourceUrl"]').type('www.example.com');
         cy.server();
         cy.route('POST', '/api/cases').as('addCase');
         cy.get('button[data-testid="submit"]').click();
@@ -176,7 +194,7 @@ describe('New case form', function () {
         cy.visit('/cases/new');
         cy.get('svg[data-testid="error-icon"]').should('not.exist');
         cy.get('svg[data-testid="check-icon"]').should('not.exist');
-        cy.get('input[name="confirmedDate"]').clear().type('2020/02/31');
+        cy.get('input[name="confirmedDate"]').type('2020/02/31');
         cy.get('svg[data-testid="error-icon"]').should('exist');
         cy.get('svg[data-testid="check-icon"]').should('not.exist');
     });

--- a/verification/curator-service/ui/src/components/NewCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/NewCaseForm.tsx
@@ -185,11 +185,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
                     },
                 ],
                 travelHistory: {
-                    travel: values.travelHistory.map((travelHistory) => {
-                        return {
-                            location: travelHistory,
-                        };
-                    }),
+                    travel: values.travelHistory,
                 },
                 notes: values.notes,
                 revisionMetadata: {

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Demographics.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Demographics.tsx
@@ -2,7 +2,7 @@ import { Select, TextField } from 'formik-material-ui';
 
 import { Field } from 'formik';
 import FormControl from '@material-ui/core/FormControl';
-import FormikAutocomplete from './FormikAutocomplete';
+import { FormikAutocomplete } from './FormikFields';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import React from 'react';

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Events.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Events.tsx
@@ -1,79 +1,9 @@
-import { Field, useFormikContext } from 'formik';
+import { DateField, SelectField } from './FormikFields';
 
-import DateFnsUtils from '@date-io/date-fns';
-import FormControl from '@material-ui/core/FormControl';
-import InputLabel from '@material-ui/core/InputLabel';
-import { KeyboardDatePicker } from 'formik-material-ui-pickers';
-import MenuItem from '@material-ui/core/MenuItem';
-import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import NewCaseFormValues from './NewCaseFormValues';
 import React from 'react';
 import Scroll from 'react-scroll';
-import { Select } from 'formik-material-ui';
-import { makeStyles } from '@material-ui/core';
-
-const useStyles = makeStyles(() => ({
-    fieldRow: {
-        marginBottom: '2em',
-        width: '100%',
-    },
-    field: {
-        width: '50%',
-    },
-}));
-
-interface DateFieldProps {
-    name: string;
-    label: string;
-}
-
-function DateField(props: DateFieldProps): JSX.Element {
-    const classes = useStyles();
-    return (
-        <div className={classes.fieldRow}>
-            <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                <Field
-                    className={classes.field}
-                    name={props.name}
-                    label={props.label}
-                    format="yyyy/MM/dd"
-                    maxDate={new Date()}
-                    minDate={new Date('2019/12/01')}
-                    component={KeyboardDatePicker}
-                />
-            </MuiPickersUtilsProvider>
-        </div>
-    );
-}
-
-interface SelectFieldProps {
-    name: string;
-    label: string;
-    values: (string | undefined)[];
-}
-
-function SelectField(props: SelectFieldProps): JSX.Element {
-    const classes = useStyles();
-    return (
-        <FormControl className={classes.fieldRow}>
-            <InputLabel htmlFor={props.name}>{props.label}</InputLabel>
-            <Field
-                as="select"
-                name={props.name}
-                type="text"
-                data-testid={props.name}
-                className={classes.field}
-                component={Select}
-            >
-                {props.values.map((value) => (
-                    <MenuItem key={value ?? 'undefined'} value={value}>
-                        {value}
-                    </MenuItem>
-                ))}
-            </Field>
-        </FormControl>
-    );
-}
+import { useFormikContext } from 'formik';
 
 const yesNoUndefined = [undefined, 'Yes', 'No'];
 

--- a/verification/curator-service/ui/src/components/new-case-form-fields/FormikFields.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/FormikFields.tsx
@@ -1,9 +1,27 @@
+import { Field, useFormikContext } from 'formik';
+
 import { Autocomplete } from '@material-ui/lab';
-import { Field } from 'formik';
+import DateFnsUtils from '@date-io/date-fns';
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import { KeyboardDatePicker } from 'formik-material-ui-pickers';
+import MenuItem from '@material-ui/core/MenuItem';
+import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import React from 'react';
+import { Select } from 'formik-material-ui';
 import { TextField } from 'formik-material-ui';
 import axios from 'axios';
-import { useFormikContext } from 'formik';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+    fieldRow: {
+        marginBottom: '2em',
+        width: '100%',
+    },
+    field: {
+        width: '50%',
+    },
+}));
 
 interface FormikAutocompleteProps {
     name: string;
@@ -14,7 +32,7 @@ interface FormikAutocompleteProps {
 
 // Autocomplete for use in a Formik form.
 // Based on https://material-ui.com/components/autocomplete/#asynchronous-requests.
-export default function FormikAutocomplete(
+export function FormikAutocomplete(
     props: FormikAutocompleteProps,
 ): JSX.Element {
     const [open, setOpen] = React.useState(false);
@@ -80,5 +98,58 @@ export default function FormikAutocomplete(
                 ></Field>
             )}
         />
+    );
+}
+
+interface SelectFieldProps {
+    name: string;
+    label: string;
+    values: (string | undefined)[];
+}
+
+export function SelectField(props: SelectFieldProps): JSX.Element {
+    const classes = useStyles();
+    return (
+        <FormControl className={classes.fieldRow}>
+            <InputLabel htmlFor={props.name}>{props.label}</InputLabel>
+            <Field
+                as="select"
+                name={props.name}
+                type="text"
+                data-testid={props.name}
+                className={classes.field}
+                component={Select}
+            >
+                {props.values.map((value) => (
+                    <MenuItem key={value ?? 'undefined'} value={value}>
+                        {value}
+                    </MenuItem>
+                ))}
+            </Field>
+        </FormControl>
+    );
+}
+
+interface DateFieldProps {
+    name: string;
+    label: string;
+}
+
+export function DateField(props: DateFieldProps): JSX.Element {
+    const classes = useStyles();
+    return (
+        <div className={classes.fieldRow}>
+            <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                <Field
+                    className={classes.field}
+                    name={props.name}
+                    label={props.label}
+                    format="yyyy/MM/dd"
+                    maxDate={new Date()}
+                    minDate={new Date('2019/12/01')}
+                    component={KeyboardDatePicker}
+                />
+            </MuiPickersUtilsProvider>
+        </div>
     );
 }

--- a/verification/curator-service/ui/src/components/new-case-form-fields/NewCaseFormValues.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/NewCaseFormValues.tsx
@@ -23,8 +23,17 @@ export default interface NewCaseFormValues {
     transmissionRoutes: string[];
     transmissionPlaces: string[];
     transmissionLinkedCaseIds: string[];
-    // TODO: add other travel history fields
-    travelHistory: Loc[];
+    travelHistory: Travel[];
     sourceUrl: string;
     notes: string;
+}
+
+interface Travel {
+    location: Loc;
+    dateRange: {
+        start: string | null;
+        end: string | null;
+    };
+    purpose?: string;
+    method?: string;
 }

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Symptoms.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Symptoms.tsx
@@ -1,4 +1,4 @@
-import FormikAutocomplete from './FormikAutocomplete';
+import { FormikAutocomplete } from './FormikFields';
 import React from 'react';
 import Scroll from 'react-scroll';
 

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Transmission.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Transmission.tsx
@@ -1,5 +1,5 @@
 import ChipInput from 'material-ui-chip-input';
-import FormikAutocomplete from './FormikAutocomplete';
+import { FormikAutocomplete } from './FormikFields';
 import React from 'react';
 import Scroll from 'react-scroll';
 import { makeStyles } from '@material-ui/core';

--- a/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
@@ -1,3 +1,4 @@
+import { DateField, SelectField } from './FormikFields';
 import { FieldArray, useFormikContext } from 'formik';
 
 import AddCircleIcon from '@material-ui/icons/AddCircle';
@@ -14,6 +15,20 @@ const useStyles = makeStyles(() => ({
         margin: '1em',
     },
 }));
+
+// TODO: get values from DB.
+const travelPurposes = [undefined, 'Business', 'Leisure', 'Family', 'Other'];
+
+const travelMethods = [
+    undefined,
+    'Bus',
+    'Car',
+    'Coach',
+    'Ferry',
+    'Plane',
+    'Train',
+    'Other',
+];
 
 export default function Events(): JSX.Element {
     const { values } = useFormikContext<NewCaseFormValues>();
@@ -36,13 +51,31 @@ export default function Events(): JSX.Element {
                                                 }
                                             >
                                                 <PlacesAutocomplete
-                                                    name={`travelHistory[${index}]`}
+                                                    name={`travelHistory[${index}].location`}
                                                 ></PlacesAutocomplete>
                                                 <Location
                                                     location={
-                                                        travelHistoryElement
+                                                        travelHistoryElement.location
                                                     }
                                                 ></Location>
+                                                <DateField
+                                                    name={`travelHistory[${index}].dateRange.start`}
+                                                    label="Start date"
+                                                ></DateField>
+                                                <DateField
+                                                    name={`travelHistory[${index}].dateRange.end`}
+                                                    label="End date"
+                                                ></DateField>
+                                                <SelectField
+                                                    name={`travelHistory[${index}].purpose`}
+                                                    label="Primary reason for travel"
+                                                    values={travelPurposes}
+                                                ></SelectField>
+                                                <SelectField
+                                                    name={`travelHistory[${index}].method`}
+                                                    label="Method of travel"
+                                                    values={travelMethods}
+                                                ></SelectField>
                                             </fieldset>
                                         ),
                                     )}
@@ -51,7 +84,12 @@ export default function Events(): JSX.Element {
                                     data-testid="addTravelHistory"
                                     startIcon={<AddCircleIcon />}
                                     onClick={(): void => {
-                                        push({});
+                                        push({
+                                            dateRange: {
+                                                start: null,
+                                                end: null,
+                                            },
+                                        });
                                     }}
                                 >
                                     Add travel history


### PR DESCRIPTION
- Removes unnecessary ".clear()" calls in cypress test
- Consolidates formik fields into it's own file
- Unfortunately couldn't use a material date *range* picker since it is not stable yet: https://dev.material-ui-pickers.dev/demo/daterangepicker So I went with two date pickers

<img width="692" alt="Screen Shot 2020-06-25 at 5 40 29 PM" src="https://user-images.githubusercontent.com/30459667/85761766-ff5c0c80-b70a-11ea-8c4c-d5740e330e71.png">
