### PR TITLE
Another hail mary to try to get the update workflow to work

### DIFF
--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   update-case-data-prod:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install Python dependencies
-        run: python -m pip install -r ./data-serving/scripts/data-pipeline/requirements.txt
+        run: python3 -m pip install -r ./data-serving/scripts/data-pipeline/requirements.txt
 
       - name: Run update script
         run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m "${{ secrets.DB_CONNECTION_URL }}"


### PR DESCRIPTION
Pasting from the bug:

This problem seems to be an issue with the default nameservers on Ubuntu 18.04. It seems like Cloudflare or Google's DNS nameservers would probably work fine, but I can't figure out how to change the default nameserver in this GitHub workflow container.

Some cool background reading:

- https://stackoverflow.com/questions/60541611/mongodb-dump-fails-with-cannot-unmarshal-dns-message
- https://github.com/actions/virtual-environments/issues/798

Unfortunately none of the workarounds have worked yet (locally), including:
`sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf`

(resource in use error)

Since it seems like it could be a problem with ubuntu 18.04 specifically, I might try ubuntu-20.04, even though it's [only in preview](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners) -- it's a hail mary but LET'S TRY IT. Unfortunately can't test this locally because `act` does not support this VM yet

Very option to other suggestions @axmb @attwad @allysonjp715 