### PR TITLE
Edit in full page instead of inline in linelist

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -23,7 +23,7 @@ describe('Linelist table', function () {
         cy.contains('www.example.com');
     });
 
-    it.only('Can go to the edit page', function () {
+    it('Can go to the edit page', function () {
         cy.addCase({
             country: 'France',
             notes: 'some notes',

--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -23,7 +23,7 @@ describe('Linelist table', function () {
         cy.contains('www.example.com');
     });
 
-    it('Can go to the edit page', function () {
+    it.only('Can go to the edit page', function () {
         cy.addCase({
             country: 'France',
             notes: 'some notes',
@@ -32,7 +32,7 @@ describe('Linelist table', function () {
         cy.visit('/cases');
         cy.contains('some notes');
 
-        cy.get('button[title="Edit"]').click();
+        cy.get('button[title="Edit this case"]').click();
         cy.url().should('contain', '/cases/edit/');
     });
 

--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -23,7 +23,7 @@ describe('Linelist table', function () {
         cy.contains('www.example.com');
     });
 
-    it('Can edit a case', function () {
+    it('Can go to the edit page', function () {
         cy.addCase({
             country: 'France',
             notes: 'some notes',
@@ -33,11 +33,7 @@ describe('Linelist table', function () {
         cy.contains('some notes');
 
         cy.get('button[title="Edit"]').click();
-        cy.get('input[placeholder="Notes"]').clear().type('edited notes');
-        cy.get('button[title="Save"]').click();
-
-        cy.contains('some notes').should('not.exist');
-        cy.contains('edited notes');
+        cy.url().should('contain', '/cases/edit/');
     });
 
     it('Can delete a case', function () {

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -1,18 +1,12 @@
-import { Case, TravelHistory } from './Case';
+import { Case, Travel, TravelHistory } from './Case';
 import MaterialTable, { QueryResult } from 'material-table';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import {
-    Theme,
-    WithStyles,
-    createStyles,
-    withStyles,
-} from '@material-ui/core/styles';
 
+import MuiAlert from '@material-ui/lab/Alert';
 import Paper from '@material-ui/core/Paper';
 import React from 'react';
-import TextField from '@material-ui/core/TextField';
+import User from './User';
 import axios from 'axios';
-import { isUndefined } from 'util';
 
 interface ListResponse {
     cases: Case[];
@@ -44,7 +38,7 @@ interface TableRow {
     latitude: number;
     longitude: number;
     confirmedDate: Date | null;
-    confirmationMethod?: string;
+    confirmationMethod: string;
     // Represents a list as a comma and space separated string e.g. 'fever, cough'
     symptoms: string;
     // Represents a list as a comma and space separated string e.g. 'vertical, iatrogenic'
@@ -59,25 +53,8 @@ interface TableRow {
     notes: string;
 }
 
-interface User {
-    _id: string;
-    name: string;
-    email: string;
-    roles: string[];
-}
-
-// Return type isn't meaningful.
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const styles = (theme: Theme) =>
-    createStyles({
-        error: {
-            color: 'red',
-            marginTop: theme.spacing(2),
-        },
-    });
-
 // Cf. https://material-ui.com/guides/typescript/#augmenting-your-props-using-withstyles
-interface Props extends WithStyles<typeof styles>, RouteComponentProps {
+interface Props extends RouteComponentProps {
     user: User;
 }
 
@@ -87,76 +64,6 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         this.state = {
             url: '/api/cases/',
             error: '',
-        };
-    }
-
-    splitCommaSeparated(value: string | null): string[] {
-        if (!value) return [];
-        return value
-            .split(',')
-            .map((value) => value.trim())
-            .filter((value) => value !== '');
-    }
-
-    // TODO: Consider defining distinct RPC-format and UI-format Case types to
-    // improve type-handling here.
-    createCaseFromRowData(rowData: TableRow): unknown {
-        return {
-            demographics: {
-                sex: rowData.sex,
-                ageRange: {
-                    start: rowData.age[0] ?? undefined,
-                    end: rowData.age[1] ?? undefined,
-                },
-                ethnicity: rowData.ethnicity,
-                nationalities: this.splitCommaSeparated(rowData.nationalities),
-                profession: rowData.profession,
-            },
-            notes: rowData.notes,
-            sources: [
-                {
-                    url: rowData.sourceUrl,
-                },
-            ],
-            location: {
-                country: rowData.country,
-                administrativeAreaLevel1: rowData.adminArea1,
-                administrativeAreaLevel2: rowData.adminArea2,
-                administrativeAreaLevel3: rowData.adminArea3,
-                geometry: {
-                    latitude: rowData.latitude,
-                    longitude: rowData.longitude,
-                },
-                name: rowData.locationName,
-                geoResolution: rowData.geoResolution,
-            },
-            events: [
-                {
-                    name: 'confirmed',
-                    dateRange: {
-                        start: rowData.confirmedDate,
-                    },
-                    value: rowData.confirmationMethod,
-                },
-            ],
-            symptoms: {
-                values: this.splitCommaSeparated(rowData.symptoms),
-            },
-            transmission: {
-                route: this.splitCommaSeparated(rowData.transmissionRoutes),
-                place: this.splitCommaSeparated(rowData.transmissionPlaces),
-                linkedCaseIds: this.splitCommaSeparated(
-                    rowData.transmissionLinkedCaseIds,
-                ),
-            },
-            travelHistory: rowData.travelHistory,
-            revisionMetadata: {
-                revisionNumber: 0,
-                creationMetadata: {
-                    curator: this.props.user.email,
-                    date: new Date().toISOString(),
-                },
-            },
         };
     }
 
@@ -172,306 +79,258 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         });
     }
 
-    editCase(
-        newRowData: TableRow,
-        oldRowData: TableRow | undefined,
-    ): Promise<unknown> {
-        return new Promise((resolve, reject) => {
-            if (isUndefined(oldRowData)) {
-                return reject();
-            }
-            if (!this.validateRequired(newRowData.sourceUrl)) {
-                return reject();
-            }
-            const newCase = this.createCaseFromRowData(newRowData);
-            this.setState({ error: '' });
-            axios
-                .put(this.state.url + oldRowData.id, newCase)
-                .then(resolve)
-                .catch((e) => {
-                    this.setState({ error: e.toString() });
-                    reject(e);
-                });
-        });
-    }
-
-    validateRequired(field: string | null): boolean {
-        return field?.trim() !== '';
-    }
-
     render(): JSX.Element {
-        const { classes, history } = this.props;
+        const { history } = this.props;
         return (
-            <div>
-                <Paper>
-                    <MaterialTable
-                        columns={[
-                            {
-                                title: 'Sex',
-                                field: 'sex',
-                                filtering: false,
-                                lookup: { Female: 'Female', Male: 'Male' },
-                            },
-                            {
-                                title: 'Age',
-                                field: 'age',
-                                filtering: false,
-                                editable: 'never',
-                                render: (rowData) =>
-                                    rowData.age[0] === rowData.age[1]
-                                        ? rowData.age[0]
-                                        : `${rowData.age[0]}-${rowData.age[1]}`,
-                            },
-                            {
-                                title: 'Ethnicity',
-                                field: 'ethnicity',
-                                filtering: false,
-                            },
-                            {
-                                title: 'Nationality',
-                                field: 'nationalities',
-                                filtering: false,
-                            },
-                            {
-                                title: 'Profession',
-                                field: 'profession',
-                                filtering: false,
-                            },
-                            {
-                                title: 'Location',
-                                field: 'locationName',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
-                                title: 'Country',
-                                field: 'country',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
-                                title: 'Confirmed date',
-                                field: 'confirmedDate',
-                                filtering: false,
-                                type: 'date',
-                            },
-                            {
-                                title: 'Confirmation method',
-                                field: 'confirmationMethod',
-                                filtering: false,
-                            },
-                            {
-                                title: 'Symptoms',
-                                field: 'symptoms',
-                                filtering: false,
-                            },
-                            {
-                                title: 'Routes of transmission',
-                                field: 'transmissionRoutes',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
-                                title: 'Places of transmission',
-                                field: 'transmissionPlaces',
-                                filtering: false,
-                                editable: 'never',
-                            },
-                            {
-                                title: 'Contacted case IDs',
-                                field: 'transmissionLinkedCaseIds',
-                                filtering: false,
-                            },
-                            {
-                                title: 'Travel history',
-                                field: 'travelHistory',
-                                filtering: false,
-                                editable: 'never',
-                                render: (rowData) =>
-                                    rowData.travelHistory?.travel
-                                        ?.map((travel) => travel.location.name)
-                                        ?.join(', '),
-                            },
-                            { title: 'Notes', field: 'notes' },
-                            {
-                                title: 'Source URL',
-                                field: 'sourceUrl',
-                                filtering: false,
-                                editComponent: (props): JSX.Element => (
-                                    <TextField
-                                        type="text"
-                                        size="small"
-                                        fullWidth
-                                        placeholder="Source URL"
-                                        error={
-                                            !this.validateRequired(props.value)
-                                        }
-                                        helperText={
-                                            this.validateRequired(props.value)
-                                                ? ''
-                                                : 'Required field'
-                                        }
-                                        onChange={(event): void =>
-                                            props.onChange(event.target.value)
-                                        }
-                                        defaultValue={props.value}
-                                    />
-                                ),
-                            },
-                        ]}
-                        data={(query): Promise<QueryResult<TableRow>> =>
-                            new Promise((resolve, reject) => {
-                                let listUrl = this.state.url;
-                                listUrl += '?limit=' + query.pageSize;
-                                listUrl += '&page=' + (query.page + 1);
-                                listUrl += '&filter=';
-                                listUrl += query.filters
-                                    .map(
-                                        (filter) =>
-                                            `${filter.column.field}:${filter.value}`,
-                                    )
-                                    .join(',');
-                                this.setState({ error: '' });
-                                const response = axios.get<ListResponse>(
-                                    listUrl,
-                                );
-                                response
-                                    .then((result) => {
-                                        const flattenedCases: TableRow[] = [];
-                                        const cases = result.data.cases;
-                                        for (const c of cases) {
-                                            const confirmedEvent = c.events.find(
-                                                (event) =>
-                                                    event.name === 'confirmed',
-                                            );
-                                            flattenedCases.push({
-                                                id: c._id,
-                                                sex: c.demographics?.sex,
-                                                age: [
-                                                    c.demographics?.ageRange
-                                                        ?.start,
-                                                    c.demographics?.ageRange
-                                                        ?.end,
-                                                ],
-                                                ethnicity:
-                                                    c.demographics?.ethnicity,
-                                                nationalities: c.demographics?.nationalities?.join(
-                                                    ', ',
-                                                ),
-                                                profession:
-                                                    c.demographics?.profession,
-                                                country: c.location.country,
-                                                adminArea1:
-                                                    c.location
-                                                        ?.administrativeAreaLevel1,
-                                                adminArea2:
-                                                    c.location
-                                                        ?.administrativeAreaLevel2,
-                                                adminArea3:
-                                                    c.location
-                                                        ?.administrativeAreaLevel3,
-                                                latitude:
-                                                    c.location?.geometry
-                                                        ?.latitude,
-                                                longitude:
-                                                    c.location?.geometry
-                                                        ?.longitude,
-                                                geoResolution:
-                                                    c.location?.geoResolution,
-                                                locationName: c.location?.name,
-                                                confirmedDate: confirmedEvent
-                                                    ?.dateRange?.start
-                                                    ? new Date(
-                                                          confirmedEvent.dateRange.start,
-                                                      )
-                                                    : null,
-                                                confirmationMethod:
-                                                    confirmedEvent?.value,
-                                                symptoms: c.symptoms?.values?.join(
-                                                    ', ',
-                                                ),
-                                                transmissionRoutes: c.transmission?.routes.join(
-                                                    ', ',
-                                                ),
-                                                transmissionPlaces: c.transmission?.places.join(
-                                                    ', ',
-                                                ),
-                                                transmissionLinkedCaseIds: c.transmission?.linkedCaseIds.join(
-                                                    ', ',
-                                                ),
-                                                travelHistory: c.travelHistory,
-                                                notes: c.notes,
-                                                sourceUrl:
-                                                    c.sources &&
-                                                    c.sources.length > 0
-                                                        ? c.sources[0].url
-                                                        : null,
-                                            });
-                                        }
-                                        resolve({
-                                            data: flattenedCases,
-                                            page: query.page,
-                                            totalCount: result.data.total,
-                                        });
-                                    })
-                                    .catch((e) => {
-                                        this.setState({ error: e.toString() });
-                                        reject(e);
-                                    });
-                            })
-                        }
-                        title="COVID-19 cases"
-                        options={{
-                            // TODO: Create text indexes and support search queries.
-                            // https://docs.mongodb.com/manual/text-search/
-                            search: false,
-                            filtering: true,
-                            sorting: false, // Would be nice but has to wait on indexes to properly query the DB.
-                            padding: 'dense',
-                            draggable: false, // No need to be able to drag and drop headers.
-                            pageSize: 10,
-                            pageSizeOptions: [5, 10, 20, 50, 100],
-                            actionsColumnIndex: -1,
-                        }}
-                        actions={
-                            this.props.user.roles.includes('curator')
-                                ? [
-                                      {
-                                          icon: 'add',
-                                          tooltip: 'Submit new case',
-                                          isFreeAction: true,
-                                          onClick: (): void => {
-                                              history.push('/cases/new');
-                                          },
-                                      },
-                                  ]
-                                : undefined
-                        }
-                        editable={
-                            this.props.user.roles.includes('curator')
-                                ? {
-                                      onRowUpdate: (
-                                          newRowData: TableRow,
-                                          oldRowData: TableRow | undefined,
-                                      ): Promise<unknown> =>
-                                          this.editCase(newRowData, oldRowData),
-                                      onRowDelete: (
-                                          rowData: TableRow,
-                                      ): Promise<unknown> =>
-                                          this.deleteCase(rowData),
-                                  }
-                                : undefined
-                        }
-                    />
-                </Paper>
+            <Paper>
                 {this.state.error && (
-                    <div className={classes.error}>{this.state.error}</div>
+                    <MuiAlert elevation={6} variant="filled" severity="error">
+                        {this.state.error}
+                    </MuiAlert>
                 )}
-            </div>
+                <MaterialTable
+                    columns={[
+                        {
+                            title: 'id',
+                            field: 'id',
+                            type: 'string',
+                            hidden: true,
+                        },
+                        {
+                            title: 'Sex',
+                            field: 'sex',
+                            filtering: false,
+                            lookup: { Female: 'Female', Male: 'Male' },
+                        },
+                        {
+                            title: 'Age',
+                            field: 'age',
+                            filtering: false,
+                            render: (rowData) =>
+                                rowData.age[0] === rowData.age[1]
+                                    ? rowData.age[0]
+                                    : `${rowData.age[0]}-${rowData.age[1]}`,
+                        },
+                        {
+                            title: 'Ethnicity',
+                            field: 'ethnicity',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Nationality',
+                            field: 'nationalities',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Profession',
+                            field: 'profession',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Location',
+                            field: 'locationName',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Country',
+                            field: 'country',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Confirmed date',
+                            field: 'confirmedDate',
+                            filtering: false,
+                            type: 'date',
+                        },
+                        {
+                            title: 'Confirmation method',
+                            field: 'confirmationMethod',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Symptoms',
+                            field: 'symptoms',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Routes of transmission',
+                            field: 'transmissionRoutes',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Places of transmission',
+                            field: 'transmissionPlaces',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Contacted case IDs',
+                            field: 'transmissionLinkedCaseIds',
+                            filtering: false,
+                        },
+                        {
+                            title: 'Travel history',
+                            field: 'travelHistory',
+                            filtering: false,
+                            render: (rowData) =>
+                                rowData.travelHistory?.travel
+                                    ?.map(
+                                        (travel: Travel) =>
+                                            travel.location.name,
+                                    )
+                                    ?.join(', '),
+                        },
+                        { title: 'Notes', field: 'notes' },
+                        {
+                            title: 'Source URL',
+                            field: 'sourceUrl',
+                            filtering: false,
+                        },
+                    ]}
+                    data={(query): Promise<QueryResult<TableRow>> =>
+                        new Promise((resolve, reject) => {
+                            let listUrl = this.state.url;
+                            listUrl += '?limit=' + query.pageSize;
+                            listUrl += '&page=' + (query.page + 1);
+                            listUrl += '&filter=';
+                            listUrl += query.filters
+                                .map(
+                                    (filter) =>
+                                        `${filter.column.field}:${filter.value}`,
+                                )
+                                .join(',');
+                            this.setState({ error: '' });
+                            const response = axios.get<ListResponse>(listUrl);
+                            response
+                                .then((result) => {
+                                    const flattenedCases: TableRow[] = [];
+                                    const cases = result.data.cases;
+                                    for (const c of cases) {
+                                        const confirmedEvent = c.events.find(
+                                            (event) =>
+                                                event.name === 'confirmed',
+                                        );
+                                        flattenedCases.push({
+                                            id: c._id,
+                                            sex: c.demographics?.sex,
+                                            age: [
+                                                c.demographics?.ageRange?.start,
+                                                c.demographics?.ageRange?.end,
+                                            ],
+                                            ethnicity:
+                                                c.demographics?.ethnicity,
+                                            nationalities: c.demographics?.nationalities?.join(
+                                                ', ',
+                                            ),
+                                            profession:
+                                                c.demographics?.profession,
+                                            country: c.location.country,
+                                            adminArea1:
+                                                c.location
+                                                    ?.administrativeAreaLevel1,
+                                            adminArea2:
+                                                c.location
+                                                    ?.administrativeAreaLevel2,
+                                            adminArea3:
+                                                c.location
+                                                    ?.administrativeAreaLevel3,
+                                            latitude:
+                                                c.location?.geometry?.latitude,
+                                            longitude:
+                                                c.location?.geometry?.longitude,
+                                            geoResolution:
+                                                c.location?.geoResolution,
+                                            locationName: c.location?.name,
+                                            confirmedDate: confirmedEvent
+                                                ?.dateRange?.start
+                                                ? new Date(
+                                                      confirmedEvent.dateRange.start,
+                                                  )
+                                                : null,
+                                            confirmationMethod:
+                                                confirmedEvent?.value || '',
+                                            symptoms: c.symptoms?.values?.join(
+                                                ', ',
+                                            ),
+                                            transmissionRoutes: c.transmission?.routes.join(
+                                                ', ',
+                                            ),
+                                            transmissionPlaces: c.transmission?.places.join(
+                                                ', ',
+                                            ),
+                                            transmissionLinkedCaseIds: c.transmission?.linkedCaseIds.join(
+                                                ', ',
+                                            ),
+                                            travelHistory: c.travelHistory,
+                                            notes: c.notes,
+                                            sourceUrl:
+                                                c.sources &&
+                                                c.sources.length > 0
+                                                    ? c.sources[0].url
+                                                    : null,
+                                        });
+                                    }
+                                    resolve({
+                                        data: flattenedCases,
+                                        page: query.page,
+                                        totalCount: result.data.total,
+                                    });
+                                })
+                                .catch((e) => {
+                                    this.setState({ error: e.toString() });
+                                    reject(e);
+                                });
+                        })
+                    }
+                    title="COVID-19 cases"
+                    options={{
+                        // TODO: Create text indexes and support search queries.
+                        // https://docs.mongodb.com/manual/text-search/
+                        search: false,
+                        filtering: true,
+                        sorting: false, // Would be nice but has to wait on indexes to properly query the DB.
+                        padding: 'dense',
+                        draggable: false, // No need to be able to drag and drop headers.
+                        pageSize: 10,
+                        pageSizeOptions: [5, 10, 20, 50, 100],
+                        actionsColumnIndex: -1,
+                    }}
+                    actions={
+                        this.props.user.roles.includes('curator')
+                            ? [
+                                  {
+                                      icon: 'add',
+                                      tooltip: 'Submit new case',
+                                      isFreeAction: true,
+                                      onClick: (): void => {
+                                          history.push('/cases/new');
+                                      },
+                                  },
+                                  {
+                                      icon: 'edit',
+                                      tooltip: 'Edit this case',
+                                      onClick: (e, row): void => {
+                                          // Somehow the templating system doesn't think row has an id property but it has.
+                                          const id = (row as TableRow).id;
+                                          history.push(`/cases/edit/${id}`);
+                                      },
+                                  },
+                              ]
+                            : undefined
+                    }
+                    editable={
+                        this.props.user.roles.includes('curator')
+                            ? {
+                                  onRowDelete: (
+                                      rowData: TableRow,
+                                  ): Promise<unknown> =>
+                                      this.deleteCase(rowData),
+                              }
+                            : undefined
+                    }
+                />
+            </Paper>
         );
     }
 }
 
-export default withStyles(styles, { withTheme: true })(
-    withRouter(LinelistTable),
-);
+export default withRouter(LinelistTable);


### PR DESCRIPTION
This simplifies the edit code as it is in one place instead of two and allows full edit of the case.
Also moved the errors in the linelist at the top of the page otherwise one would have to scroll further down the table to see that there was an error.