### PR TITLE
Last-last hail mary to get the update workflow to work

### DIFF
--- a/.github/workflows/case-data-update.yml
+++ b/.github/workflows/case-data-update.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   update-case-data-prod:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
+++ b/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
@@ -73,7 +73,7 @@ function import_data() {
         --collection $collection \
         --file $CONVERTED_DATA_PATH \
         --jsonArray \
-        --uri=$mongodb_connection_string/$db
+        --uri="$mongodb_connection_string"
 }
 
 function cleanup() {


### PR DESCRIPTION
The real magic of this PR is in the different connection string, which is a github secret. It follows the < 3.4 connection string format here: https://www.mongodb.com/blog/post/mongodb-3-6-here-to-SRV-you-with-easier-replica-set-connections

PERHAPS without the +srv URL, it won't do a DNS lookup, and magic will happen.

Note that this format of URL requires the database name in the conn string, hence the change in the data-pipeline script.

TESTED=It works locally... but so did so many other things.