### PR TITLE
3 schema removals per various conversations

### DIFF
--- a/data-serving/data-service/package-lock.json
+++ b/data-serving/data-service/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-      "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.1.tgz",
+      "integrity": "sha512-Qsdz0W0dyK84BuBh5KZATWXOtVDXIF2EeNRzpyWblPUeAmnIokwWcwrpAm5pTPMjuWoIQt9C67X3Af1OlL6oSw==",
       "requires": {
-        "@jsdevtools/ono": "^7.1.0",
+        "@jsdevtools/ono": "^7.1.2",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^3.13.1"
       }
@@ -3247,15 +3247,15 @@
       }
     },
     "express-openapi-validator": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-3.16.2.tgz",
-      "integrity": "sha512-LZRiVH79PGae4+uB0EkvcUGv6R7syc0d4s6lUHgPVkjsX1/9qtUT440BSB1S/MvaMNg3RzTOcIjENhnqUj2WYw==",
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-3.16.4.tgz",
+      "integrity": "sha512-69lLYPRvZ97ods94dccqj0Bn3HCcyW1YX4Wb3HbmFqizDHd1L+Mnwx3R2RyXunm1w2OocDj2MyiDyV4R2ViOnQ==",
       "requires": {
         "ajv": "^6.12.2",
         "content-type": "^1.0.4",
-        "deasync": "^0.1.19",
+        "deasync": "^0.1.20",
         "js-yaml": "^3.14.0",
-        "json-schema-ref-parser": "^8.0.0",
+        "json-schema-ref-parser": "^9.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0",
         "lodash.zipobject": "^4.1.3",
@@ -5852,11 +5852,11 @@
       "dev": true
     },
     "json-schema-ref-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-      "integrity": "sha512-2P4icmNkZLrBr6oa5gSZaDSol/oaBHYkoP/8dsw63E54NnHGRhhiFuy9yFoxPuSm+uHKmeGxAAWMDF16SCHhcQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.1.tgz",
+      "integrity": "sha512-KLrCjRjW5hMXxsX4osVBWpwixXL9NtICfpyNNS0eHguN5mP/I4UatI7i7PFS8jU94b1NHF4EbirACdCn0RFPBA==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "8.0.0"
+        "@apidevtools/json-schema-ref-parser": "9.0.1"
       }
     },
     "json-schema-traverse": {

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -54,8 +54,7 @@
             "enum": [
               "Male",
               "Female",
-              "Other",
-              "Unknown"
+              "Other"
             ]
           },
           "profession": {
@@ -215,8 +214,7 @@
             "enum": [
               "Asymptomatic",
               "Presymptomatic",
-              "Symptomatic",
-              "Unknown"
+              "Symptomatic"
             ]
           }
         }
@@ -238,8 +236,7 @@
           "status": {
             "enum": [
               "Yes",
-              "No",
-              "Unknown"
+              "No"
             ]
           }
         }
@@ -343,8 +340,7 @@
                     "Business",
                     "Leisure",
                     "Family",
-                    "Other",
-                    "Unknown"
+                    "Other"
                   ]
                 },
                 "methods": {
@@ -358,8 +354,7 @@
                       "Ferry",
                       "Plane",
                       "Train",
-                      "Other",
-                      "Unknown"
+                      "Other"
                     ]
                   }
                 }
@@ -436,8 +431,7 @@
                 "Vertical",
                 "Iatrogenic",
                 "Vector borne",
-                "Other",
-                "Unknown"
+                "Other"
               ]
             }
           },

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -248,9 +248,6 @@
           "_id": {
             "bsonType": "objectId"
           },
-          "numLocations": {
-            "bsonType": "int"
-          },
           "travel": {
             "bsonType": "array",
             "uniqueItems": true,

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -96,9 +96,6 @@
             },
             "sequenceLength": {
               "bsonType": "int"
-            },
-            "notes": {
-              "bsonType": "string"
             }
           }
         }

--- a/data-serving/data-service/src/model/genome-sequence.ts
+++ b/data-serving/data-service/src/model/genome-sequence.ts
@@ -8,7 +8,6 @@ export const genomeSequenceSchema = new mongoose.Schema({
     sequenceId: String,
     sequenceName: String,
     sequenceLength: positiveIntFieldInfo,
-    notes: String,
 });
 
 export type GenomeSequenceDocument = mongoose.Document & {
@@ -17,5 +16,4 @@ export type GenomeSequenceDocument = mongoose.Document & {
     sequenceId: string;
     sequenceName: string;
     sequenceLength: number;
-    notes: string;
 };

--- a/data-serving/data-service/src/model/transmission.ts
+++ b/data-serving/data-service/src/model/transmission.ts
@@ -11,7 +11,6 @@ export enum Route {
     Iatrogenic = 'Iatrogenic',
     VectorBorne = 'Vector borne',
     Other = 'Other',
-    Unknown = 'Unknown',
 }
 
 export const transmissionSchema = new mongoose.Schema({

--- a/data-serving/data-service/src/model/travel-history.ts
+++ b/data-serving/data-service/src/model/travel-history.ts
@@ -1,16 +1,13 @@
 import { TravelDocument, travelSchema } from './travel';
 
 import mongoose from 'mongoose';
-import { positiveIntFieldInfo } from './positive-int';
 
 export const travelHistorySchema = new mongoose.Schema({
-    numLocations: positiveIntFieldInfo,
     travel: [travelSchema],
     traveledPrior30Days: Boolean,
 });
 
 export type TravelHistoryDocument = mongoose.Document & {
-    numLocations: number;
     travel: [TravelDocument];
     traveledPrior30Days: boolean;
 };

--- a/data-serving/data-service/src/model/travel.ts
+++ b/data-serving/data-service/src/model/travel.ts
@@ -8,7 +8,6 @@ export enum TravelPurpose {
     Leisure = 'Leisure',
     Family = 'Family',
     Other = 'Other',
-    Unknown = 'Unknown',
 }
 
 export enum TravelMethod {
@@ -19,7 +18,6 @@ export enum TravelMethod {
     Plane = 'Plane',
     Train = 'Train',
     Other = 'Other',
-    Unknown = 'Unknown',
 }
 
 export const travelSchema = new mongoose.Schema({

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -19,8 +19,7 @@
             "repositoryUrl": "https://www.ncbi.nlm.nih.gov/nuccore/NC_045512",
             "sequenceId": "NC_045512.2",
             "sequenceName": "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
-            "sequenceLength": 33000,
-            "notes": "The reference sequence is identical to MN908947."
+            "sequenceLength": 33000
         }
     ],
     "location": {

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -84,7 +84,6 @@
         "status": "Yes"
     },
     "travelHistory": {
-        "numLocations": 1,
         "travel": [
             {
                 "dateRange": {

--- a/data-serving/data-service/test/model/data/genome-sequence.full.json
+++ b/data-serving/data-service/test/model/data/genome-sequence.full.json
@@ -3,6 +3,5 @@
         "repositoryUrl": "https://www.ncbi.nlm.nih.gov/nuccore/NC_045512",
         "sequenceId": "NC_045512.2",
         "sequenceName": "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
-        "sequenceLength": 33000,
-        "notes": "The reference sequence is identical to MN908947."
+        "sequenceLength": 33000
 }

--- a/data-serving/data-service/test/model/data/travel-history.full.json
+++ b/data-serving/data-service/test/model/data/travel-history.full.json
@@ -1,5 +1,4 @@
 {
-    "numLocations": 1,
     "travel": [
         {
             "dateRange": {

--- a/data-serving/data-service/test/model/travel-history.test.ts
+++ b/data-serving/data-service/test/model/travel-history.test.ts
@@ -3,7 +3,6 @@ import {
     travelHistorySchema,
 } from '../../src/model/travel-history';
 
-import { Error } from 'mongoose';
 import fullModel from './data/travel-history.full.json';
 import minimalModel from './data/travel-history.minimal.json';
 import mongoose from 'mongoose';
@@ -14,15 +13,6 @@ const TravelHistory = mongoose.model<TravelHistoryDocument>(
 );
 
 describe('validate', () => {
-    it('a non-integer numLocations is invalid', async () => {
-        return new TravelHistory({
-            ...minimalModel,
-            numLocations: 1.1,
-        }).validate((e) => {
-            expect(e.name).toBe(Error.ValidationError.name);
-        });
-    });
-
     it('a minimal travelHistory is valid', async () => {
         return new TravelHistory(minimalModel).validate();
     });

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -122,7 +122,6 @@
             "status": "Yes"
         },
         "travelHistory": {
-            "numLocations": 1,
             "travel": [{
                 "dateRange": {
                     "start": {

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -20,8 +20,7 @@
                 "repositoryUrl": "https://www.ncbi.nlm.nih.gov/nuccore/NC_045512",
                 "sequenceId": "NC_045512.2",
                 "sequenceName": "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
-                "sequenceLength": 33000,
-                "notes": "The reference sequence is identical to MN908947."
+                "sequenceLength": 33000
             }
         ],
         "location": {


### PR DESCRIPTION
Each commit represents a different small schema  removal:

- 'Unknown' options from enums (decided on another PR that an empty field implies this, and we can export or display absence of data as 'Unknown' as necessary)
- travelHistory.numLocations (decided Friday during design review)
- genomeSequence.notes: Consolidating into the top-level notes field (already exists)