### PR TITLE
Add a case data update script for dev

### DIFF
--- a/.github/workflows/case-data-update-dev.yml
+++ b/.github/workflows/case-data-update-dev.yml
@@ -7,7 +7,7 @@ on:
     paths: ["data-serving/data-service/schemas/**"]
 
 jobs:
-  # NOTE: This job should bee kept in sync with the prod version.
+  # NOTE: This job should be kept in sync with the prod version.
   update-case-data-dev:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/case-data-update-dev.yml
+++ b/.github/workflows/case-data-update-dev.yml
@@ -1,0 +1,40 @@
+name: Update case data in dev
+
+on:
+  push:
+    # Update the data when the schema changes.
+    branches: [master]
+    paths: ["data-serving/data-service/schemas/**"]
+
+jobs:
+  # NOTE: This job should bee kept in sync with the prod version.
+  update-case-data-dev:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install MongoDB CLIs
+        run: |
+          wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
+          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5DC22404A6F9F1CA 656408E390CFB1F5
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install Python dependencies
+        run: python3 -m pip install -r ./data-serving/scripts/data-pipeline/requirements.txt
+
+      - name: Run update script on dev db (1% of data)
+        run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m "${{ secrets.DB_CONNECTION_URL_DEV }}" -r .01

--- a/.github/workflows/case-data-update-prod.yml
+++ b/.github/workflows/case-data-update-prod.yml
@@ -14,7 +14,7 @@ on:
     - cron: "0 5 * * *"
 
 jobs:
-  # NOTE: This job should bee kept in sync with the dev version.
+  # NOTE: This job should be kept in sync with the dev version.
   update-case-data-prod:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/case-data-update-prod.yml
+++ b/.github/workflows/case-data-update-prod.yml
@@ -1,10 +1,10 @@
-name: Update case data
+name: Update case data in prod
 
 on:
   push:
     # Update the data when the conversion script changes.
     branches: [master]
-    paths: ["/data-serving/scripts/convert-data/**"]
+    paths: ["data-serving/scripts/convert-data/**"]
   repository_dispatch:
     # Update the data on a signal that the input data has changed.
     types: [latest-data-push]
@@ -14,6 +14,7 @@ on:
     - cron: "0 5 * * *"
 
 jobs:
+  # NOTE: This job should bee kept in sync with the dev version.
   update-case-data-prod:
     runs-on: ubuntu-latest
 
@@ -42,5 +43,5 @@ jobs:
       - name: Install Python dependencies
         run: python3 -m pip install -r ./data-serving/scripts/data-pipeline/requirements.txt
 
-      - name: Run update script
-        run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m "${{ secrets.DB_CONNECTION_URL }}"
+      - name: Run update script on prod db
+        run: ./data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh -m "${{ secrets.DB_CONNECTION_URL_PROD }}"


### PR DESCRIPTION
Apparently there's no way to do workflow composition or inheritance so I've duplicated the logic to keep a clean dev/prod separation -- and because they need to be triggered on different things.

Right now, *prod* mainly updates when the *data* should change: nightly after the expected CSV upload, and whenever the conversion script changes.

Now *dev* will mainly update when the *schema* should change, because we don't care about the data in dev being fresh -- but we don't want our dev instance to go down because the schema doesn't match the dataserver.

Ideally, we'd really trigger these things when we trigger the binary pushes, but I believe that's blocked ATM.

TESTED=Ran it locally with `act`