### PR TITLE
By default, drop only imported data as part of setup-db script

### DIFF
--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -2816,16 +2816,6 @@
         ],
         "revisionMetadata": {
             "revisionNumber": 0
-        },
-        "importedCase": {
-            "ID": "007-686962",
-            "city": "Moscow",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "13.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
         }
     },
     {

--- a/data-serving/scripts/setup-db/README.md
+++ b/data-serving/scripts/setup-db/README.md
@@ -5,9 +5,13 @@ This directory contains a script to set up a fresh MongoDB collection.
 ## What does it do?
 
 1. Gets or creates the database;
-2. Drops the collection, if it already exists;
-3. (Re-)creates the collection with the schema applied;
-4. TODO: Creates indexes.
+2. If the collection exists, deletes imported docs* from the collection and
+   applies the latest schema; if it doesn't exist yet, creates the collection
+   with the latest schema.
+3. Creates indexes.
+
+*Imported documents are the ones with an `importedCase` property. They come from
+the legacy Google Sheets system, not the new G.H portal.
 
 ## Run it!
 
@@ -16,9 +20,10 @@ the default database (`covid19`) and collection (`cases`), run:
 
 `npm run setup-cases`
 
-To run it with configurable options, e.g. a different connection string, run:
+To run it with configurable options, e.g. a different connection string, or the
+option to delete all documents, run:
 
-`CONN="some_conn_string" DB="some_db" COLL="some_collection" SCHEMA="../some/schema/path.json" INDEX="../some/index/path" npm run setup`
+`CONN="some_conn_string" DB="some_db" COLL="some_collection" SCHEMA="../some/schema/path.json" INDEX="../some/index/path" DELETE_ALL_DOCUMENTS=true|false npm run setup`
 
 For example, the below invocation of `setup` would give you the same result as
 `setup-cases`:

--- a/data-serving/scripts/setup-db/package.json
+++ b/data-serving/scripts/setup-db/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit && eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
-    "setup": "npm install && tsc && mongo $CONN --eval \"let args={connectionString: '$CONN', databaseName: '$DB', collectionName: '$COLL', schemaPath: '$SCHEMA', indexPath: '$INDEX'}\" dist/index.js",
-    "setup-cases": "npm install && tsc && mongo --eval \"let args={databaseName: 'covid19', collectionName: 'cases', schemaPath: './../../data-service/schemas/cases.schema.json', indexPath: './../../data-service/schemas/cases.index.json'}\" dist/index.js"
+    "setup": "npm install && tsc && mongo $CONN --eval \"let args={connectionString: '$CONN', databaseName: '$DB', collectionName: '$COLL', schemaPath: '$SCHEMA', indexPath: '$INDEX', deleteAllDocuments: '$DELETE_ALL_DOCUMENTS'}\" dist/index.js",
+    "setup-cases": "npm install && tsc && mongo --eval \"let args={databaseName: 'covid19', collectionName: 'cases', schemaPath: './../../data-service/schemas/cases.schema.json', indexPath: './../../data-service/schemas/cases.index.json', deleteAllDocuments: '$DELETE_ALL_DOCUMENTS'}\" dist/index.js"
   },
   "repository": {
     "type": "git",

--- a/data-serving/scripts/setup-db/src/index.ts
+++ b/data-serving/scripts/setup-db/src/index.ts
@@ -6,6 +6,8 @@ interface SetupDatabaseParameters {
     collectionName: string;
     schemaPath: string;
     indexPath: string;
+    /** If not specified, deletes only imported documents. Defaults to false. */
+    deleteAllDocuments: boolean;
 }
 
 const setupDatabase = async ({
@@ -14,6 +16,7 @@ const setupDatabase = async ({
     collectionName,
     schemaPath,
     indexPath,
+    deleteAllDocuments = false,
 }: SetupDatabaseParameters): Promise<void> => {
     try {
         const schema = JSON.parse(await cat(schemaPath));
@@ -30,31 +33,47 @@ const setupDatabase = async ({
         const database = await connection.getDB(databaseName);
         print(`Connected to database "${database}"`);
 
-        // If the collection already exists, drop it so we can recreate it
-        // fresh.
+        // If the collection already exists, drop all imported data from it and
+        // apply the latest schema.
+        let collection;
         if (
             (await database.getCollectionNames()).some(
                 (c) => c == collectionName,
             )
         ) {
-            await (await database.getCollection(collectionName)).drop();
-            print('Dropped existing collection');
+            collection = await database.getCollection(collectionName);
+            const query = deleteAllDocuments
+                ? {}
+                : { importedCase: { $exists: true, $ne: null } };
+            const results = await collection.remove(query);
+            print(
+                `Dropped ${
+                    deleteAllDocuments ? 'all' : 'imported'
+                } documents (${results.nRemoved} total) 🗎`,
+            );
+
+            await database.runCommand({
+                collMod: collectionName,
+                validator: schema,
+            });
+            print(
+                `Applied schema to existing collection "${collectionName}" 📑`,
+            );
+        } else {
+            await database.createCollection(collectionName, {
+                validator: schema,
+            });
+            print(`Created collection "${collectionName}" with schema 📑`);
+            collection = await database.getCollection(collectionName);
         }
 
-        await database.createCollection(collectionName, {
-            validator: schema,
-        });
-        print(`Created collection "${collectionName}" with schema`);
-
-        const collection = await database.getCollection(collectionName);
-
-        print('Dropping indexes👇');
+        print('Dropping indexes 👇');
         const indexName = `${collectionName}Idx`;
         await collection.dropIndex(indexName);
 
-        print('Creating indexes👆');
+        print('Creating indexes 👆');
         await collection.createIndex(index, { name: indexName });
-        print('done👍');
+        print('Done 👍');
 
         // Print some stats -- for fun and confirmation!
         const stats = await collection.stats();

--- a/data-serving/scripts/setup-db/src/index.ts
+++ b/data-serving/scripts/setup-db/src/index.ts
@@ -49,7 +49,7 @@ const setupDatabase = async ({
             print(
                 `Dropped ${
                     deleteAllDocuments ? 'all' : 'imported'
-                } documents (${results.nRemoved} total) 🗎`,
+                } documents (${results.nRemoved} total) 🗑️`,
             );
 
             await database.runCommand({

--- a/data-serving/scripts/setup-db/src/types/mongo-cli.d.ts
+++ b/data-serving/scripts/setup-db/src/types/mongo-cli.d.ts
@@ -13,9 +13,9 @@ declare function printjson(message: {}): void;
 declare function quit(): void;
 
 interface Collection {
-    drop: () => Promise<CommandResult>;
+    remove: (query: object) => Promise<CommandResult>;
     stats: () => Promise<CollectionStats>;
-    createIndex: (spec: object, options: {name: string}) => Promise<CommandResult>;
+    createIndex: (spec: object, options: { name: string }) => Promise<CommandResult>;
     dropIndex: (name: string) => Promise<CommandResult>;
 }
 
@@ -47,6 +47,8 @@ interface Database {
     getCollection: (name: string) => Promise<Collection>;
 
     getCollectionNames: () => Promise<[string]>;
+
+    runCommand: (options: { collMod: string, validator: {} }) => Promise<CommandResult>;
 }
 
 /** Options to pass with the command to create a collection. */
@@ -57,4 +59,6 @@ interface CreateCollectionOptions {
 /** The result of a call to `runCommand.` */
 interface CommandResult {
     ok: number;
+
+    nRemoved: number;
 }

--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+DELETE_ALL_DOCUMENTS=true \
 npm --prefix=`dirname "$0"`/../data-serving/scripts/setup-db/ run-script setup-cases
 npm --prefix=`dirname "$0"`/../data-serving/data-service/ run-script import-data


### PR DESCRIPTION
As of this change, `dev/setup_db.sh` will still drop all data from the local db, but other callers of this `setup-db` script (namely our update db workflows) will only drop imported data. This is to protect any data created via the portal, dev or prod (though we can discuss whether we want this for dev).

TESTED=I imported the sample data below, which I've modified to have 1 record that simulates coming from the new curator portal, i.e. it has no `importedCase` record. The script successfully drops the 99 "imported" documents and keeps the 

```
npm run setup-db

Read schema from ./../../data-service/schemas/cases.schema.json
Read index from ./../../data-service/schemas/cases.index.json
Connected to instance at 127.0.0.1:27017
Connected to database "covid19"
Dropped imported documents (99 total) 🗎
Applied schema to existing collection "cases" 📑
Dropping indexes 👇
Creating indexes 👆
Done 👍
{ "collection" : "covid19.cases", "documents" : 1, "indexes" : 2 }
```

Now with `deleteAllDocuments`:
```
DELETE_ALL_DOCUMENTS=true npm run setup-cases

Read schema from ./../../data-service/schemas/cases.schema.json
Read index from ./../../data-service/schemas/cases.index.json
Connected to instance at 127.0.0.1:27017
Connected to database "covid19"
Dropped all documents (1 total) 🗎
Applied schema to existing collection "cases" 📑
Dropping indexes 👇
Creating indexes 👆
Done 👍
{ "collection" : "covid19.cases", "documents" : 0, "indexes" : 2 }
Thank you for joining us 💾
```