### PR TITLE
add unknown check for genome sequence details

### DIFF
--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -362,7 +362,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
                             .join(', ')}
                     />
 
-                    {props.c.genomeSequences.map((e) => (
+                    {props.c.genomeSequences?.map((e) => (
                         <GenomeSequenceRows
                             key={shortId.generate()}
                             sequence={e}


### PR DESCRIPTION
Otherwise we'd get
```
TypeError: Cannot read property 'map' of undefined
    at (ViewCase.tsx:365)
...
```