### PR TITLE
Remove "New" from NewCaseForm(Values) and send curator edits

### DIFF
--- a/data-serving/data-service/src/model/revision-metadata.ts
+++ b/data-serving/data-service/src/model/revision-metadata.ts
@@ -26,7 +26,7 @@ export const revisionMetadataSchema = new mongoose.Schema({
     updateMetadata: {
         type: editMetadataSchema,
         required: function (this: RevisionMetadataDocument): boolean {
-            return this.revisionNumber > 0;
+            return this?.revisionNumber > 0;
         },
     },
 });
@@ -40,5 +40,5 @@ type EditMetadataDocument = mongoose.Document & {
 export type RevisionMetadataDocument = mongoose.Document & {
     revisionNumber: number;
     creationMetadata: EditMetadataDocument;
-    updateMetadata: EditMetadataDocument;
+    updateMetadata?: EditMetadataDocument;
 };

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -10,6 +10,7 @@ import { Link, Route, Switch } from 'react-router-dom';
 
 import Add from '@material-ui/icons/Add';
 import BulkCaseForm from './BulkCaseForm';
+import CaseForm from './CaseForm';
 import Charts from './Charts';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
@@ -26,7 +27,6 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import MenuIcon from '@material-ui/icons/Menu';
-import NewCaseForm from './NewCaseForm';
 import PeopleIcon from '@material-ui/icons/People';
 import PersonIcon from '@material-ui/icons/Person';
 import Profile from './Profile';
@@ -377,7 +377,7 @@ class App extends React.Component<Props, State> {
                             )}
                             {this.hasAnyRole(['curator']) && (
                                 <Route path="/cases/new">
-                                    <NewCaseForm user={this.state.user} />
+                                    <CaseForm user={this.state.user} />
                                 </Route>
                             )}
                             {this.hasAnyRole(['curator']) && (

--- a/verification/curator-service/ui/src/components/Case.tsx
+++ b/verification/curator-service/ui/src/components/Case.tsx
@@ -96,7 +96,9 @@ interface Revision {
 }
 
 interface RevisionMetadata {
+    revisionNumber: number;
     creationMetadata: Revision;
+    updateMetadata?: Revision;
 }
 
 export interface Case {

--- a/verification/curator-service/ui/src/components/CaseForm.test.tsx
+++ b/verification/curator-service/ui/src/components/CaseForm.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, wait } from '@testing-library/react';
 
-import NewCaseForm from './NewCaseForm';
+import CaseForm from './CaseForm';
 import React from 'react';
 
 const user = {
@@ -11,7 +11,7 @@ const user = {
 };
 
 it('renders form', () => {
-    const { getByText, getAllByText } = render(<NewCaseForm user={user} />);
+    const { getByText, getAllByText } = render(<CaseForm user={user} />);
     expect(getByText(/Submit case/i)).toBeInTheDocument();
     expect(getAllByText(/Demographics/i)).toHaveLength(2);
     expect(getAllByText(/Location/i)).toHaveLength(4);
@@ -21,7 +21,7 @@ it('renders form', () => {
 });
 
 it('can add and remove genome sequencing sections', async () => {
-    const { queryByTestId, getByText } = render(<NewCaseForm user={user} />);
+    const { queryByTestId, getByText } = render(<CaseForm user={user} />);
 
     expect(queryByTestId('genome-sequence-section')).not.toBeInTheDocument();
     await wait(() => {

--- a/verification/curator-service/ui/src/components/CaseForm.tsx
+++ b/verification/curator-service/ui/src/components/CaseForm.tsx
@@ -2,13 +2,11 @@ import * as Yup from 'yup';
 
 import { Button, LinearProgress } from '@material-ui/core';
 import { Form, Formik } from 'formik';
-import {
-    GenomeSequence,
-    Travel,
-} from './new-case-form-fields/NewCaseFormValues';
+import { GenomeSequence, Travel } from './new-case-form-fields/CaseFormValues';
 import { green, grey, red } from '@material-ui/core/colors';
 
 import { Case } from './Case';
+import CaseFormValues from './new-case-form-fields/CaseFormValues';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import Demographics from './new-case-form-fields/Demographics';
 import ErrorIcon from '@material-ui/icons/Error';
@@ -16,7 +14,6 @@ import Events from './new-case-form-fields/Events';
 import GenomeSequences from './new-case-form-fields/GenomeSequences';
 import LocationForm from './new-case-form-fields/LocationForm';
 import MuiAlert from '@material-ui/lab/Alert';
-import NewCaseFormValues from './new-case-form-fields/NewCaseFormValues';
 import Notes from './new-case-form-fields/Notes';
 import Pathogens from './new-case-form-fields/Pathogens';
 import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
@@ -56,7 +53,7 @@ const styles = () =>
         },
     });
 
-function initialValuesFromCase(c?: Case): NewCaseFormValues {
+function initialValuesFromCase(c?: Case): CaseFormValues {
     if (!c) {
         return {
             sex: undefined,
@@ -162,7 +159,7 @@ interface Props extends WithStyles<typeof styles> {
     initialCase?: Case;
 }
 
-interface NewCaseFormState {
+interface CaseFormState {
     errorMessage: string;
 }
 
@@ -229,7 +226,7 @@ function hasErrors(fields: string[], errors: any, touched: any): boolean {
     return false;
 }
 
-class NewCaseForm extends React.Component<Props, NewCaseFormState> {
+class CaseForm extends React.Component<Props, CaseFormState> {
     constructor(props: Props) {
         super(props);
         this.state = {
@@ -265,7 +262,7 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
         return filteredGenomeSequences;
     }
 
-    async submitCase(values: NewCaseFormValues): Promise<void> {
+    async submitCase(values: CaseFormValues): Promise<void> {
         const ageRange = values.age
             ? { start: values.age, end: values.age }
             : { start: values.minAge, end: values.maxAge };
@@ -360,13 +357,25 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
             genomeSequences: this.filterGenomeSequences(values.genomeSequences),
             pathogens: values.pathogens,
             notes: values.notes,
-            revisionMetadata: {
-                revisionNumber: 0,
-                creationMetadata: {
-                    curator: this.props.user.email,
-                    date: new Date().toISOString(),
-                },
-            },
+            revisionMetadata: this.props.initialCase
+                ? {
+                      revisionNumber:
+                          this.props.initialCase.revisionMetadata
+                              .revisionNumber + 1,
+                      creationMetadata: this.props.initialCase.revisionMetadata
+                          .creationMetadata,
+                      updateMetadata: {
+                          curator: this.props.user.email,
+                          date: new Date().toISOString(),
+                      },
+                  }
+                : {
+                      revisionNumber: 0,
+                      creationMetadata: {
+                          curator: this.props.user.email,
+                          date: new Date().toISOString(),
+                      },
+                  },
         };
         try {
             // Update or create depending on the presence of the initial case ID.
@@ -710,4 +719,4 @@ class NewCaseForm extends React.Component<Props, NewCaseFormState> {
     }
 }
 
-export default withStyles(styles)(NewCaseForm);
+export default withStyles(styles)(CaseForm);

--- a/verification/curator-service/ui/src/components/EditCase.tsx
+++ b/verification/curator-service/ui/src/components/EditCase.tsx
@@ -1,7 +1,7 @@
 import { Case } from './Case';
+import CaseForm from './CaseForm';
 import { LinearProgress } from '@material-ui/core';
 import MuiAlert from '@material-ui/lab/Alert';
-import NewCaseForm from './NewCaseForm';
 import React from 'react';
 import User from './User';
 import axios from 'axios';
@@ -45,7 +45,7 @@ class EditCase extends React.Component<Props, State> {
                     </MuiAlert>
                 )}
                 {this.state.case && (
-                    <NewCaseForm
+                    <CaseForm
                         user={this.props.user}
                         initialCase={this.state.case}
                     />

--- a/verification/curator-service/ui/src/components/ViewCase.test.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.test.tsx
@@ -37,6 +37,8 @@ it('loads and displays case', async () => {
     expect(getByText('news.org/an-article')).toBeInTheDocument();
     expect(getByText('abc123')).toBeInTheDocument();
     expect(getByText('2020-01-20')).toBeInTheDocument();
+    expect(getByText('xyz789')).toBeInTheDocument();
+    expect(getByText('2020-04-13')).toBeInTheDocument();
     expect(
         getByText('Contact of a confirmed case at work.'),
     ).toBeInTheDocument();

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -148,6 +148,26 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
                         }
                     />
 
+                    {props.c.revisionMetadata?.updateMetadata && (
+                        <>
+                            <RowHeader title="Date of edit" />
+                            <RowContent
+                                content={
+                                    props.c.revisionMetadata?.updateMetadata
+                                        ?.date || ''
+                                }
+                            />
+
+                            <RowHeader title="Edited by" />
+                            <RowContent
+                                content={
+                                    props.c.revisionMetadata?.updateMetadata
+                                        ?.curator || ''
+                                }
+                            />
+                        </>
+                    )}
+
                     <RowHeader title="Notes" />
                     <RowContent content={props.c.notes} />
                 </Grid>

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -362,7 +362,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
                             .join(', ')}
                     />
 
-                    {props.c.genomeSequences.map((e) => (
+                    {props.c.genomeSequences?.map((e) => (
                         <GenomeSequenceRows
                             key={shortId.generate()}
                             sequence={e}

--- a/verification/curator-service/ui/src/components/common-form-fields/FormikFields.tsx
+++ b/verification/curator-service/ui/src/components/common-form-fields/FormikFields.tsx
@@ -1,6 +1,7 @@
 import { FastField, Field, useFormikContext } from 'formik';
 
 import { Autocomplete } from '@material-ui/lab';
+import CaseFormValues from '../new-case-form-fields/CaseFormValues';
 import DateFnsUtils from '@date-io/date-fns';
 import FormControl from '@material-ui/core/FormControl';
 import { FormHelperText } from '@material-ui/core';
@@ -8,7 +9,6 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { KeyboardDatePicker } from 'formik-material-ui-pickers';
 import MenuItem from '@material-ui/core/MenuItem';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
-import NewCaseFormValues from '../new-case-form-fields/NewCaseFormValues';
 import React from 'react';
 import { Select } from 'formik-material-ui';
 import { TextField } from 'formik-material-ui';
@@ -44,7 +44,7 @@ export function FormikAutocomplete(
     const [options, setOptions] = React.useState<string[]>([]);
     const loading = open && options.length === 0;
     const { setFieldValue, setTouched, initialValues } = useFormikContext<
-        NewCaseFormValues
+        CaseFormValues
     >();
 
     React.useEffect(() => {
@@ -189,7 +189,7 @@ interface RequiredHelperTextProps {
 export function RequiredHelperText(
     props: RequiredHelperTextProps,
 ): JSX.Element {
-    const { values, touched } = useFormikContext<NewCaseFormValues>();
+    const { values, touched } = useFormikContext<CaseFormValues>();
     return (
         <div>
             {hasKey(touched, props.name) &&

--- a/verification/curator-service/ui/src/components/fixtures/fullCase.json
+++ b/verification/curator-service/ui/src/components/fixtures/fullCase.json
@@ -145,7 +145,7 @@
         },
         "updateMetadata": {
             "curator": "xyz789",
-            "date": "2020-01-13",
+            "date": "2020-04-13",
             "notes": "fix source error"
         }
     },

--- a/verification/curator-service/ui/src/components/new-case-form-fields/CaseFormValues.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/CaseFormValues.tsx
@@ -1,6 +1,6 @@
 import { Location as Loc } from '../Case';
 
-export default interface NewCaseFormValues {
+export default interface CaseFormValues {
     sex?: string;
     minAge?: number;
     maxAge?: number;

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Demographics.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Demographics.tsx
@@ -1,11 +1,11 @@
 import { FastField, useFormikContext } from 'formik';
 import { Select, TextField } from 'formik-material-ui';
 
+import CaseFormValues from './CaseFormValues';
 import FormControl from '@material-ui/core/FormControl';
 import { FormikAutocomplete } from '../common-form-fields/FormikFields';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
-import NewCaseFormValues from './NewCaseFormValues';
 import React from 'react';
 import Scroll from 'react-scroll';
 import { WithStyles } from '@material-ui/core/styles/withStyles';
@@ -49,7 +49,7 @@ const ethnicityValues = [
 
 function Demographics(props: DemographicsProps): JSX.Element {
     const { classes } = props;
-    const { initialValues } = useFormikContext<NewCaseFormValues>();
+    const { initialValues } = useFormikContext<CaseFormValues>();
     return (
         <Scroll.Element name="demographics">
             <fieldset>

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Events.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Events.tsx
@@ -1,6 +1,6 @@
 import { DateField, SelectField } from '../common-form-fields/FormikFields';
 
-import NewCaseFormValues from './NewCaseFormValues';
+import CaseFormValues from './CaseFormValues';
 import React from 'react';
 import Scroll from 'react-scroll';
 import { useFormikContext } from 'formik';
@@ -19,7 +19,7 @@ const methodsOfConfirmation = [
 const outcomes = [undefined, 'Death', 'Recovered'];
 
 export default function Events(): JSX.Element {
-    const { values } = useFormikContext<NewCaseFormValues>();
+    const { values } = useFormikContext<CaseFormValues>();
     return (
         <Scroll.Element name="events">
             <fieldset>

--- a/verification/curator-service/ui/src/components/new-case-form-fields/GenomeSequences.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/GenomeSequences.tsx
@@ -3,8 +3,8 @@ import { FastField, FieldArray, useFormikContext } from 'formik';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import Button from '@material-ui/core/Button';
 import CancelIcon from '@material-ui/icons/Cancel';
+import CaseFormValues from './CaseFormValues';
 import { DateField } from '../common-form-fields/FormikFields';
-import NewCaseFormValues from './NewCaseFormValues';
 import React from 'react';
 import Scroll from 'react-scroll';
 import { TextField } from 'formik-material-ui';
@@ -25,7 +25,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 export default function GenomeSequences(): JSX.Element {
-    const { values } = useFormikContext<NewCaseFormValues>();
+    const { values } = useFormikContext<CaseFormValues>();
     const classes = useStyles();
     return (
         <Scroll.Element name="genomeSequences">

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Pathogens.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Pathogens.tsx
@@ -1,7 +1,7 @@
 import { Field, useFormikContext } from 'formik';
 
 import { Autocomplete } from '@material-ui/lab';
-import NewCaseFormValues from './NewCaseFormValues';
+import CaseFormValues from './CaseFormValues';
 import React from 'react';
 import Scroll from 'react-scroll';
 import { TextField } from 'formik-material-ui';
@@ -26,7 +26,7 @@ export function PathogensAutocomplete(): JSX.Element {
     );
     const loading = open && options.keys.length === 0;
     const { setFieldValue, setTouched, initialValues } = useFormikContext<
-        NewCaseFormValues
+        CaseFormValues
     >();
 
     React.useEffect(() => {

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Symptoms.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Symptoms.tsx
@@ -1,11 +1,11 @@
+import CaseFormValues from './CaseFormValues';
 import { FormikAutocomplete } from '../common-form-fields/FormikFields';
-import NewCaseFormValues from './NewCaseFormValues';
 import React from 'react';
 import Scroll from 'react-scroll';
 import { useFormikContext } from 'formik';
 
 export default function Symptoms(): JSX.Element {
-    const { initialValues } = useFormikContext<NewCaseFormValues>();
+    const { initialValues } = useFormikContext<CaseFormValues>();
     return (
         <Scroll.Element name="symptoms">
             <fieldset>

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Transmission.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Transmission.tsx
@@ -1,6 +1,6 @@
+import CaseFormValues from './CaseFormValues';
 import ChipInput from 'material-ui-chip-input';
 import { FormikAutocomplete } from '../common-form-fields/FormikFields';
-import NewCaseFormValues from './NewCaseFormValues';
 import React from 'react';
 import Scroll from 'react-scroll';
 import { makeStyles } from '@material-ui/core';
@@ -21,7 +21,7 @@ interface SelectFieldProps {
 
 export default function Transmission(): JSX.Element {
     const { setFieldValue, setTouched, initialValues } = useFormikContext<
-        NewCaseFormValues
+        CaseFormValues
     >();
     const classes = useStyles();
     return (

--- a/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
@@ -4,8 +4,8 @@ import { FieldArray, useFormikContext } from 'formik';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import Button from '@material-ui/core/Button';
 import CancelIcon from '@material-ui/icons/Cancel';
+import CaseFormValues from './CaseFormValues';
 import Location from './Location';
-import NewCaseFormValues from './NewCaseFormValues';
 import { PlacesAutocomplete } from './LocationForm';
 import React from 'react';
 import Scroll from 'react-scroll';
@@ -39,7 +39,7 @@ const travelMethods = [
 ];
 
 export default function Events(): JSX.Element {
-    const { values } = useFormikContext<NewCaseFormValues>();
+    const { values } = useFormikContext<CaseFormValues>();
     const classes = useStyles();
     return (
         <Scroll.Element name="travelHistory">


### PR DESCRIPTION
Sorry got git-snipped here where I got two PRs in one somehow :(

- one does s/NewCaseForm/CaseForm everywhere
- one sets the udpateMetadata upon edits, waiting for #394 to be properly implemented to show the last editor in the details page.