### PR TITLE
pass down initial location nameto autocomplete field when editing a case

### DIFF
--- a/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
@@ -103,6 +103,13 @@ export default function Events(): JSX.Element {
                                                             </Button>
                                                         </div>
                                                         <PlacesAutocomplete
+                                                            initialValue={
+                                                                initialValues
+                                                                    .travelHistory[
+                                                                    index
+                                                                ]?.location
+                                                                    ?.name
+                                                            }
                                                             name={`travelHistory[${index}].location`}
                                                         ></PlacesAutocomplete>
                                                         <Location


### PR DESCRIPTION
When something exists:

![image](https://user-images.githubusercontent.com/1255432/86334917-168c8400-bc4e-11ea-82a1-c60b1c406765.png)

When you click on the field:
![image](https://user-images.githubusercontent.com/1255432/86334946-1f7d5580-bc4e-11ea-9494-733795fa88c7.png)


When you change:
![image](https://user-images.githubusercontent.com/1255432/86334966-26a46380-bc4e-11ea-8900-27e237b2c0ef.png)

Fixes #416 