### PR TITLE
Don't validate on change

### DIFF
--- a/verification/curator-service/ui/src/components/CaseForm.tsx
+++ b/verification/curator-service/ui/src/components/CaseForm.tsx
@@ -470,6 +470,9 @@ class CaseForm extends React.Component<Props, CaseFormState> {
             <Formik
                 initialValues={initialValuesFromCase(initialCase)}
                 validationSchema={NewCaseValidation}
+                // Validating on change slows down the form too much. It will
+                // validate on blur and form submission.
+                validateOnChange={false}
                 onSubmit={(values) => this.submitCase(values)}
             >
                 {({


### PR DESCRIPTION
Validating the entire form on every change was making the form very laggy. Now it will validate on blur and form submission, and the form is responsive again.