### PR TITLE
change icons in table

### DIFF
--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
 
 import { MemoryRouter, Router } from 'react-router-dom';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, getByLabelText, render } from '@testing-library/react';
 
 import LinelistTable from './LinelistTable';
 import React from 'react';
@@ -117,7 +117,7 @@ it('redirects to new case page when + icon is clicked', async () => {
     mockedAxios.get.mockResolvedValueOnce(axiosResponse);
 
     const history = createMemoryHistory();
-    const { getByText } = render(
+    const { getByLabelText } = render(
         <Router history={history}>
             <LinelistTable user={curator} />
         </Router>,
@@ -125,7 +125,7 @@ it('redirects to new case page when + icon is clicked', async () => {
 
     expect(mockedAxios.get).toHaveBeenCalledTimes(1);
     expect(mockedAxios.get).toHaveBeenCalledWith('/api/cases/?limit=10&page=1');
-    fireEvent.click(getByText('add'));
+    fireEvent.click(getByLabelText('add'));
     expect(history.location.pathname).toBe('/cases/new');
 });
 
@@ -320,7 +320,7 @@ it('can go to page to edit a row', async () => {
 
     // Load table
     const history = createMemoryHistory();
-    const { getByText, findByText } = render(
+    const { getByLabelText, findByText } = render(
         <Router history={history}>
             <LinelistTable user={curator} />
         </Router>,
@@ -330,7 +330,7 @@ it('can go to page to edit a row', async () => {
     const row = await findByText('some notes');
     expect(row).toBeInTheDocument();
 
-    const editButton = getByText(/edit/);
+    const editButton = getByLabelText(/edit/);
     fireEvent.click(editButton);
     expect(history.location.pathname).toBe('/cases/edit/abc123');
 });
@@ -379,7 +379,7 @@ it('can go to page to view a case', async () => {
 
     // Load table
     const history = createMemoryHistory();
-    const { getByText, findByText } = render(
+    const { findByText, getByLabelText } = render(
         <Router history={history}>
             <LinelistTable user={curator} />
         </Router>,
@@ -389,7 +389,7 @@ it('can go to page to view a case', async () => {
     const row = await findByText('some notes');
     expect(row).toBeInTheDocument();
 
-    const detailsButton = getByText(/details/);
+    const detailsButton = getByLabelText(/details/);
     fireEvent.click(detailsButton);
     expect(history.location.pathname).toBe('/cases/view/abc123');
 });
@@ -437,7 +437,7 @@ it('cannot edit data as a reader only', async () => {
     mockedAxios.get.mockResolvedValueOnce(axiosGetResponse);
 
     // Load table
-    const { findByText, queryByText } = render(
+    const { findByText, queryByText, queryByLabelText } = render(
         <MemoryRouter>
             <LinelistTable
                 user={{
@@ -458,6 +458,6 @@ it('cannot edit data as a reader only', async () => {
     expect(deleteButton).not.toBeInTheDocument();
     const addButton = queryByText(/add_box/);
     expect(addButton).not.toBeInTheDocument();
-    const editButton = queryByText(/edit/);
+    const editButton = queryByLabelText(/edit/);
     expect(editButton).not.toBeInTheDocument();
 });

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -2,10 +2,13 @@ import { Case, Pathogen, Travel, TravelHistory } from './Case';
 import MaterialTable, { QueryResult } from 'material-table';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
+import AddIcon from '@material-ui/icons/AddOutlined';
+import EditIcon from '@material-ui/icons/EditOutlined';
 import MuiAlert from '@material-ui/lab/Alert';
 import Paper from '@material-ui/core/Paper';
 import React from 'react';
 import User from './User';
+import VisibilityIcon from '@material-ui/icons/VisibilityOutlined';
 import axios from 'axios';
 
 interface ListResponse {
@@ -318,7 +321,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                     actions={(this.props.user.roles.includes('curator')
                         ? [
                               {
-                                  icon: 'add',
+                                  icon: () => <AddIcon />,
                                   tooltip: 'Submit new case',
                                   isFreeAction: true,
                                   onClick: (): void => {
@@ -326,7 +329,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                   },
                               },
                               {
-                                  icon: 'edit',
+                                  icon: () => <EditIcon />,
                                   tooltip: 'Edit this case',
                                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
                                   onClick: (_: any, row: any): void => {
@@ -339,7 +342,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                         : []
                     ).concat([
                         {
-                            icon: 'details',
+                            icon: () => <VisibilityIcon />,
                             tooltip: 'View this case details',
                             onClick: (e, row): void => {
                                 // Somehow the templating system doesn't think row has an id property but it has.

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -321,7 +321,11 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                     actions={(this.props.user.roles.includes('curator')
                         ? [
                               {
-                                  icon: () => <AddIcon />,
+                                  icon: () => (
+                                      <span aria-label="add">
+                                          <AddIcon />
+                                      </span>
+                                  ),
                                   tooltip: 'Submit new case',
                                   isFreeAction: true,
                                   onClick: (): void => {
@@ -329,7 +333,11 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                   },
                               },
                               {
-                                  icon: () => <EditIcon />,
+                                  icon: () => (
+                                      <span aria-label="edit">
+                                          <EditIcon />
+                                      </span>
+                                  ),
                                   tooltip: 'Edit this case',
                                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
                                   onClick: (_: any, row: any): void => {
@@ -342,7 +350,11 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                         : []
                     ).concat([
                         {
-                            icon: () => <VisibilityIcon />,
+                            icon: () => (
+                                <span aria-label="details">
+                                    <VisibilityIcon />
+                                </span>
+                            ),
                             tooltip: 'View this case details',
                             onClick: (e, row): void => {
                                 // Somehow the templating system doesn't think row has an id property but it has.


### PR DESCRIPTION
While material team fixes its issues with the details icon, use our own:

![image](https://user-images.githubusercontent.com/1255432/86376475-53c13800-bc87-11ea-917d-d50185912e9c.png)

fyi @axmb 