### PR TITLE
Don't require method of confirmation

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -121,7 +121,7 @@ describe('New case form', function () {
         cy.visit('/cases/new');
         cy.get('button[data-testid="submit"]').click();
 
-        cy.get('p:contains("Required field")').should('have.length', 4);
+        cy.get('p:contains("Required field")').should('have.length', 3);
     });
 
     it('Shows checkbox on field completion', function () {

--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -30,8 +30,6 @@ describe('New case form', function () {
         cy.contains('Country');
         cy.get('li').first().should('contain', 'France').click();
         cy.get('input[name="confirmedDate"]').type('2020-01-01');
-        cy.get('div[data-testid="methodOfConfirmation"]').click();
-        cy.get('li[data-value="PCR test"').click();
         cy.server();
         cy.route('POST', '/api/cases').as('addCase');
         cy.get('button[data-testid="submit"]').click();
@@ -62,8 +60,6 @@ describe('New case form', function () {
         cy.contains('Country');
         cy.get('li').first().should('contain', 'France').click();
         cy.get('input[name="confirmedDate"]').type('2020-01-01');
-        cy.get('div[data-testid="methodOfConfirmation"]').click();
-        cy.get('li[data-value="PCR test"').click();
         // Outcome without a date.
         cy.get('div[data-testid="outcome"]').click();
         cy.get('li[data-value="Recovered"').click();
@@ -105,8 +101,6 @@ describe('New case form', function () {
         cy.contains('Country');
         cy.get('li').first().should('contain', 'France').click();
         cy.get('input[name="confirmedDate"]').type('2020-01-01');
-        cy.get('div[data-testid="methodOfConfirmation"]').click();
-        cy.get('li[data-value="PCR test"').click();
         cy.server();
         // Force server to return error
         cy.route({

--- a/verification/curator-service/ui/src/components/CaseForm.tsx
+++ b/verification/curator-service/ui/src/components/CaseForm.tsx
@@ -227,7 +227,6 @@ const NewCaseValidation = Yup.object().shape(
         ),
         confirmedDate: Yup.string().nullable().required('Required field'),
         location: Yup.object().required('Required field'),
-        methodOfConfirmation: Yup.string().required('Required field'),
     },
     [['maxAge', 'minAge']],
 );

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Events.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Events.tsx
@@ -33,7 +33,6 @@ export default function Events(): JSX.Element {
                     name="methodOfConfirmation"
                     label="Method of confirmation"
                     values={methodsOfConfirmation}
-                    required
                 ></SelectField>
                 <DateField
                     name="onsetSymptomsDate"


### PR DESCRIPTION
It can have value "Unknown" which we are currently saving as undefined in the schema.