### PR TITLE
Add a validate_only param to the case creation API

### DIFF
--- a/data-serving/data-service/.eslintrc.js
+++ b/data-serving/data-service/.eslintrc.js
@@ -24,10 +24,6 @@ module.exports = {
         "no-bitwise": [
             "error"
         ],
-        "indent": [
-            "error",
-            4
-        ],
         "linebreak-style": [
             "error",
             "unix"

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -83,7 +83,7 @@ export const create = async (req: Request, res: Response): Promise<void> => {
         // storage.
         const c = new Case(req.body);
         let result;
-        if (req.query.validate_only) {
+        if (req.query.validate_only === 'true') {
             await c.validate();
             result = c;
         } else {

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -36,7 +36,7 @@ export const list = async (req: Request, res: Response): Promise<void> => {
     const searchQuery = String(req.query.q || '').trim();
     const query = searchQuery
         ? {
-            $text: { $search: searchQuery },
+              $text: { $search: searchQuery },
           }
         : {};
 
@@ -82,7 +82,13 @@ export const create = async (req: Request, res: Response): Promise<void> => {
         // TODO: Don't consume req.body directly; add layer between API and
         // storage.
         const c = new Case(req.body);
-        const result = await c.save();
+        let result;
+        if (req.query.validate_only) {
+            await c.validate();
+            result = c;
+        } else {
+            result = await c.save();
+        }
         res.status(201).json(result);
     } catch (err) {
         if (err.name === 'ValidationError') {

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -138,6 +138,22 @@ describe('POST', () => {
             .expect('Content-Type', /json/)
             .expect(201);
     });
+    it('create with invalid input and validate_only should return 422', async () => {
+        return request(app)
+            .post('/api/cases?validate_only=true')
+            .send({})
+            .expect(422);
+    });
+    it('create with valid input and validate_only should not save case', async () => {
+        const res = await request(app)
+            .post('/api/cases?validate_only=true')
+            .send(minimalCase)
+            .expect('Content-Type', /json/)
+            .expect(201);
+
+        expect(await Case.collection.countDocuments()).toEqual(0);
+        expect(res.body._id).not.toHaveLength(0);
+    });
 });
 
 describe('PUT', () => {

--- a/data-serving/scripts/setup-db/.eslintrc.js
+++ b/data-serving/scripts/setup-db/.eslintrc.js
@@ -21,10 +21,6 @@ module.exports = {
         "@typescript-eslint"
     ],
     "rules": {
-        "indent": [
-            "error",
-            4
-        ],
         "linebreak-style": [
             "error",
             "unix"

--- a/verification/curator-service/api/.eslintrc.js
+++ b/verification/curator-service/api/.eslintrc.js
@@ -24,10 +24,6 @@ module.exports = {
         "no-bitwise": [
             "error"
         ],
-        "indent": [
-            "error",
-            4
-        ],
         "linebreak-style": [
             "error",
             "unix"

--- a/verification/curator-service/ui/.eslintrc.js
+++ b/verification/curator-service/ui/.eslintrc.js
@@ -23,10 +23,6 @@ module.exports = {
         "no-bitwise": [
             "error"
         ],
-        "indent": [
-            "error",
-            4
-        ],
         "linebreak-style": [
             "error",
             "unix"


### PR DESCRIPTION
This allows bulk ingestion to check all cases prior to saving them to the DB, to avoid partial uploads.

I'm using a query param in the existing creation API, which is a [relatively canonical technique](https://google.aip.dev/163).

Spotted a conflict between our eslint config and prettier in the controller file. So including a tiny fix to our eslint configs that properly delegates indentation formatting to prettier.