### PR TITLE
Preserve proxied error status/data in curator case API.

### DIFF
--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -23,6 +23,10 @@ export default class CasesController {
             res.json(response.data);
         } catch (err) {
             console.log(err);
+            if (err.response?.status && err.response?.data) {
+                res.status(err.response.status).send(err.response.data);
+                return;
+            }
             res.status(500).send(err);
         }
     };
@@ -35,6 +39,10 @@ export default class CasesController {
             res.json(response.data);
         } catch (err) {
             console.log(err);
+            if (err.response?.status && err.response?.data) {
+                res.status(err.response.status).send(err.response.data);
+                return;
+            }
             res.status(500).send(err);
         }
     };
@@ -47,6 +55,10 @@ export default class CasesController {
             res.json(response.data);
         } catch (err) {
             console.log(err);
+            if (err.response?.status && err.response?.data) {
+                res.status(err.response.status).send(err.response.data);
+                return;
+            }
             res.status(500).send(err);
         }
     };
@@ -60,6 +72,10 @@ export default class CasesController {
             res.json(response.data);
         } catch (err) {
             console.log(err);
+            if (err.response?.status && err.response?.data) {
+                res.status(err.response.status).send(err.response.data);
+                return;
+            }
             res.status(500).send(err);
         }
     };
@@ -83,6 +99,10 @@ export default class CasesController {
                 return;
             }
             console.log(err);
+            if (err.response?.status && err.response?.data) {
+                res.status(err.response.status).send(err.response.data);
+                return;
+            }
             res.status(500).send(err.message);
         }
     };
@@ -106,6 +126,10 @@ export default class CasesController {
                 return;
             }
             console.log(err);
+            if (err.response?.status && err.response?.data) {
+                res.status(err.response.status).send(err.response.data);
+                return;
+            }
             res.status(500).send(err.message);
         }
     };

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -261,11 +261,11 @@ describe('Cases', () => {
 
         const code = 404;
         const message = 'Not found';
-        mockedAxios.put.mockRejectedValueOnce({
+        mockedAxios.post.mockRejectedValueOnce({
             response: { status: code, data: message },
         });
         const res = await curatorRequest
-            .put('/api/cases')
+            .post('/api/cases')
             .send({
                 age: '42',
                 location: { query: 'Lyon', limitToResolution: 'Admin3' },

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -73,6 +73,18 @@ describe('Cases', () => {
         );
     });
 
+    it('list maintains error data from proxied call if available', async () => {
+        const code = 404;
+        const message = 'Not found';
+        mockedAxios.get.mockRejectedValueOnce({
+            response: { status: code, data: message },
+        });
+        const res = await curatorRequest
+            .get('/api/cases?limit=10&page=1&filter=')
+            .expect(code);
+        expect(res.text).toEqual(message);
+    });
+
     it('proxies get calls', async () => {
         mockedAxios.get.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
@@ -83,6 +95,18 @@ describe('Cases', () => {
         expect(mockedAxios.get).toHaveBeenCalledWith(
             'http://localhost:3000/api/cases/5e99f21a1c9d440000ceb088',
         );
+    });
+
+    it('get maintains error data from proxied call if available', async () => {
+        const code = 404;
+        const message = 'Not found';
+        mockedAxios.get.mockRejectedValueOnce({
+            response: { status: code, data: message },
+        });
+        const res = await curatorRequest
+            .get('/api/cases/5e99f21a1c9d440000ceb088')
+            .expect(code);
+        expect(res.text).toEqual(message);
     });
 
     it('proxies update calls', async () => {
@@ -101,6 +125,19 @@ describe('Cases', () => {
         );
     });
 
+    it('update maintains error data from proxied call if available', async () => {
+        const code = 404;
+        const message = 'Not found';
+        mockedAxios.put.mockRejectedValueOnce({
+            response: { status: code, data: message },
+        });
+        const res = await curatorRequest
+            .put('/api/cases/5e99f21a1c9d440000ceb088')
+            .send({ age: '42' })
+            .expect(code);
+        expect(res.text).toEqual(message);
+    });
+
     it('proxies delete calls', async () => {
         mockedAxios.delete.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
@@ -111,6 +148,18 @@ describe('Cases', () => {
         expect(mockedAxios.delete).toHaveBeenCalledWith(
             'http://localhost:3000/api/cases/5e99f21a1c9d440000ceb088',
         );
+    });
+
+    it('delete maintains error data from proxied call if available', async () => {
+        const code = 404;
+        const message = 'Not found';
+        mockedAxios.delete.mockRejectedValueOnce({
+            response: { status: code, data: message },
+        });
+        const res = await curatorRequest
+            .delete('/api/cases/5e99f21a1c9d440000ceb088')
+            .expect(code);
+        expect(res.text).toEqual(message);
     });
 
     it('proxies upsert calls and geocodes', async () => {
@@ -139,6 +188,31 @@ describe('Cases', () => {
                 location: lyon,
             },
         );
+    });
+
+    it('upsert maintains error data from proxied call if available', async () => {
+        const lyon: GeocodeResult = {
+            administrativeAreaLevel1: 'Rhône',
+            administrativeAreaLevel2: '',
+            administrativeAreaLevel3: 'Lyon',
+            country: 'France',
+            geometry: { latitude: 45.75889, longitude: 4.84139 },
+            place: '',
+            name: 'Lyon',
+            geoResolution: Resolution.Admin3,
+        };
+        await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
+
+        const code = 404;
+        const message = 'Not found';
+        mockedAxios.put.mockRejectedValueOnce({
+            response: { status: code, data: message },
+        });
+        const res = await curatorRequest
+            .put('/api/cases')
+            .send({ age: '42', location: { query: 'Lyon' } })
+            .expect(code);
+        expect(res.text).toEqual(message);
     });
 
     it('proxies create calls and geocode', async () => {
@@ -170,6 +244,34 @@ describe('Cases', () => {
                 location: lyon,
             },
         );
+    });
+
+    it('create maintains error data from proxied call if available', async () => {
+        const lyon: GeocodeResult = {
+            administrativeAreaLevel1: 'Rhône',
+            administrativeAreaLevel2: '',
+            administrativeAreaLevel3: 'Lyon',
+            country: 'France',
+            geometry: { latitude: 45.75889, longitude: 4.84139 },
+            place: '',
+            name: 'Lyon',
+            geoResolution: Resolution.Admin3,
+        };
+        await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
+
+        const code = 404;
+        const message = 'Not found';
+        mockedAxios.put.mockRejectedValueOnce({
+            response: { status: code, data: message },
+        });
+        const res = await curatorRequest
+            .put('/api/cases')
+            .send({
+                age: '42',
+                location: { query: 'Lyon', limitToResolution: 'Admin3' },
+            })
+            .expect(code);
+        expect(res.text).toEqual(message);
     });
 
     it('throws on invalid location restrictions', async () => {


### PR DESCRIPTION
Ran into this while implementing bulk upload errors.

Previously, the curator service would completely swallow the nature of the error. E.g., for validation issues it'd return something along the lines of:

```
{
  code: 500
  message: 'Request failed with code 422.'
}
```

Which has the downside of (1) removing helpful information as to the nature of the error (say, a specific validation issue), and (2) casts all errors (except geocoding 422s) to 500. What I've added isn't totally perfect, and assumes (probably safely) that we're satisfied with just catching errors made using axios and which received a response from the case server. But, that seems fair enough for now.