### PR TITLE
Display validation errors in the bulk upload form.

### DIFF
--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -119,7 +119,7 @@ const BulkFormSchema = Yup.object().shape({
 class BulkCaseForm extends React.Component<
     BulkCaseFormProps,
     BulkCaseFormState
-    > {
+> {
     constructor(props: BulkCaseFormProps) {
         super(props);
         this.state = {
@@ -146,9 +146,9 @@ class BulkCaseForm extends React.Component<
                 name: 'hospitalAdmission',
                 dateRange: c.dateHospitalized
                     ? {
-                        start: c.dateHospitalized,
-                        end: c.dateHospitalized,
-                    }
+                          start: c.dateHospitalized,
+                          end: c.dateHospitalized,
+                      }
                     : undefined,
             });
         }
@@ -212,9 +212,9 @@ class BulkCaseForm extends React.Component<
                 geometry:
                     c.latitude && c.longitude
                         ? {
-                            latitude: c.latitude,
-                            longitude: c.longitude,
-                        }
+                              latitude: c.latitude,
+                              longitude: c.longitude,
+                          }
                         : undefined,
                 geoResolution: geoResolution,
                 name: c.locationName,
@@ -246,9 +246,8 @@ class BulkCaseForm extends React.Component<
     ): Promise<CaseValidationError[]> {
         const validationErrors: CaseValidationError[] = [];
         for (let i = 0; i < cases.length; i++) {
-            const c = cases[i];
             try {
-                await axios.post('/api/cases?validate_only=true', c);
+                await axios.post('/api/cases?validate_only=true', cases[i]);
             } catch (e) {
                 validationErrors.push(
                     new CaseValidationError(i + 1, e.response.data),


### PR DESCRIPTION
![bulk_errors](https://user-images.githubusercontent.com/63060924/87207460-f0b05080-c2d9-11ea-8484-8b5769574a68.gif)

Styling isn't perfect, and I think we'll want to aggregate errors in some situations (in lieu of truncating). But I think we'll get a lot of mileage out of this initial cut, which should suffice to begin testing.