### PR TITLE
Move reusable parsing subroutines into a common lib file/Lambda Layer

### DIFF
--- a/ingestion/functions/parsing/common/python/input_event.json
+++ b/ingestion/functions/parsing/common/python/input_event.json
@@ -1,0 +1,5 @@
+{
+    "s3Bucket": "epid-sources-raw",
+    "s3Key": "5f0b9a7ead3a2b003edc0e7f/2020/07/12/2320/content.json",
+    "sourceUrl": "https://foo.bar"
+}

--- a/ingestion/functions/parsing/common/python/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib.py
@@ -1,0 +1,87 @@
+import boto3
+import os
+import requests
+import google.auth.transport.requests
+from google.oauth2 import service_account
+
+LOCAL_DATA_FILE = "/tmp/data.json"
+METADATA_BUCKET = "epid-ingestion"
+SERVICE_ACCOUNT_CRED_FILE = "covid-19-map-277002-0943eeb6776b.json"
+SOURCE_URL_FIELD = "sourceUrl"
+S3_BUCKET_FIELD = "s3Bucket"
+S3_KEY_FIELD = "s3Key"
+S3_KEY_PATH_SEPERATOR = "/"
+
+s3_client = boto3.client("s3")
+
+
+def extract_event_fields(event):
+    if any(
+            field not in event
+            for field in [SOURCE_URL_FIELD, S3_BUCKET_FIELD, S3_KEY_FIELD]):
+        error_message = (
+            f"Required fields {SOURCE_URL_FIELD}; {S3_BUCKET_FIELD}; "
+            f"{S3_KEY_FIELD} not found in input event json.")
+        print(error_message)
+        raise ValueError(error_message)
+    return event[SOURCE_URL_FIELD], event[S3_BUCKET_FIELD], event[S3_KEY_FIELD]
+
+
+def retrieve_raw_data_file(s3_bucket, s3_key):
+    try:
+        local_data_file = LOCAL_DATA_FILE
+        print(f"Retrieving raw data from s3://{s3_bucket}/{s3_key}")
+        s3_client.download_file(s3_bucket, s3_key, local_data_file)
+        return local_data_file
+    except Exception as e:
+        print(e)
+        raise e
+
+
+def write_to_server(cases, headers):
+    """
+    Upserts the provided cases via the G.h Case API.
+
+    TODO: Parallelize these requests.
+    """
+    count_success = 0
+    count_error = 0
+    put_api_url = f"{os.environ['SOURCE_API_URL']}/cases"
+    print(f"Sending {len(cases)} cases to {put_api_url}")
+    for case in cases:
+        try:
+            requests.put(put_api_url, json=case,
+                         headers=headers).raise_for_status()
+            count_success += 1
+        except Exception as e:
+            print(e)
+            count_error += 1
+    return count_success, count_error
+
+
+def obtain_api_credentials():
+    """
+    Creates HTTP headers credentialed for access to the G.h Source API.
+    """
+    try:
+        local_creds_file = "/tmp/creds.json"
+        print(
+            "Retrieving service account credentials from "
+            f"s3://{METADATA_BUCKET}/{SERVICE_ACCOUNT_CRED_FILE}")
+        s3_client.download_file(
+            METADATA_BUCKET, SERVICE_ACCOUNT_CRED_FILE, local_creds_file)
+        credentials = service_account.Credentials.from_service_account_file(
+            local_creds_file, scopes=["email"])
+        headers = {}
+        request = google.auth.transport.requests.Request()
+        credentials.refresh(request)
+        credentials.apply(headers)
+        return headers
+    except Exception as e:
+        print(e)
+        raise e
+
+
+def extract_source_id(s3_key):
+    """Extracts the source ID based on the canonical object key format."""
+    return s3_key.split(S3_KEY_PATH_SEPERATOR, 1)[0]

--- a/ingestion/functions/parsing/common/python/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib_test.py
@@ -1,0 +1,155 @@
+
+import boto3
+import json
+import os
+import pytest
+import requests
+
+from datetime import date
+from moto import mock_s3
+from unittest.mock import MagicMock
+
+_SOURCE_ID = "abc123"
+_SOURCE_URL = "https://foo.bar"
+_PARSED_CASE = (
+    {
+        "caseReference": {
+            "sourceId": _SOURCE_ID,
+            "sourceEntryId": "48765",
+            "sourceUrl": _SOURCE_URL
+        },
+        "revisionMetadata": {
+            "revisionNumber": 0,
+            "creationMetadata": {
+                "curator": "auto",
+                "date": date.today().strftime("%m/%d/%Y")
+            }
+        },
+        "location": {
+            "country": "India",
+            "administrativeAreaLevel1": "Bihar",
+            "administrativeAreaLevel2": "Darbhanga",
+            "administrativeAreaLevel3": "Hanuman Nagar",
+            "query": "Hanuman Nagar, Darbhanga, Bihar, India"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange":
+                        {
+                            "start": "06/05/2020Z",
+                            "end": "06/05/2020Z"
+                        }
+            }
+        ],
+        "demographics": {
+            "ageRange": {
+                "start": 65,
+                "end": 65
+            },
+            "sex": "Male"
+        },
+        "notes": None
+    })
+
+
+@pytest.fixture()
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+
+@pytest.fixture()
+def s3(aws_credentials):
+    """Mock S3 connection."""
+    with mock_s3():
+        yield boto3.client("s3", region_name="us-east-1")
+
+
+@pytest.fixture()
+def input_event():
+    """Loads valid Event input from file."""
+    current_dir = os.path.dirname(__file__)
+    file_path = os.path.join(current_dir, "input_event.json")
+    with open(file_path) as event_file:
+        return json.load(event_file)
+
+
+@pytest.fixture()
+def sample_data():
+    """Loads sample source data from file."""
+    current_dir = os.path.dirname(__file__)
+    file_path = os.path.join(current_dir, "sample_data.json")
+    with open(file_path) as event_file:
+        return json.load(event_file)
+
+
+def test_extract_event_fields_returns_url_bucket_and_key(input_event):
+    from python import parsing_lib  # Import locally to avoid superseding mock
+    assert parsing_lib.extract_event_fields(input_event) == (
+        input_event[parsing_lib.SOURCE_URL_FIELD],
+        input_event[parsing_lib.S3_BUCKET_FIELD],
+        input_event[parsing_lib.S3_KEY_FIELD])
+
+
+def test_extract_event_fields_errors_if_missing_bucket_field():
+    from python import parsing_lib  # Import locally to avoid superseding mock
+    with pytest.raises(ValueError, match=parsing_lib.S3_BUCKET_FIELD):
+        parsing_lib.extract_event_fields({parsing_lib.S3_KEY_FIELD: "key"})
+
+
+def test_extract_event_fields_errors_if_missing_key_field():
+    from python import parsing_lib  # Import locally to avoid superseding mock
+    with pytest.raises(ValueError, match=parsing_lib.S3_BUCKET_FIELD):
+        parsing_lib.extract_event_fields(
+            {parsing_lib.S3_BUCKET_FIELD: "bucket"})
+
+
+@mock_s3
+def test_retrieve_raw_data_file_stores_s3_in_local_file(
+        input_event, s3, sample_data):
+    from python import parsing_lib  # Import locally to avoid superseding mock
+    s3.create_bucket(Bucket=input_event[parsing_lib.S3_BUCKET_FIELD])
+    s3.put_object(
+        Bucket=input_event[parsing_lib.S3_BUCKET_FIELD],
+        Key=input_event[parsing_lib.S3_KEY_FIELD],
+        Body=json.dumps(sample_data))
+
+    local_file = parsing_lib.retrieve_raw_data_file(
+        input_event[parsing_lib.S3_BUCKET_FIELD],
+        input_event[parsing_lib.S3_KEY_FIELD])
+    assert local_file == parsing_lib.LOCAL_DATA_FILE
+    with open(local_file, "r") as f:
+        assert json.load(f) == sample_data
+
+
+def test_write_to_server_returns_success_count_for_each_entered_case(
+        requests_mock):
+    from python import parsing_lib  # Import locally to avoid superseding mock
+    source_api_url = "http://foo.bar"
+    os.environ["SOURCE_API_URL"] = source_api_url
+    full_source_url = f"{source_api_url}/cases"
+    requests_mock.put(full_source_url)
+
+    count_success, count_error = parsing_lib.write_to_server([_PARSED_CASE], {})
+    assert requests_mock.request_history[0].url == full_source_url
+    assert count_success == 1
+    assert count_error == 0
+
+
+def test_write_to_server_returns_error_count_for_each_failed_write(
+        requests_mock):
+    from python import parsing_lib  # Import locally to avoid superseding mock
+    source_api_url = "http://foo.bar"
+    os.environ["SOURCE_API_URL"] = source_api_url
+    full_source_url = f"{source_api_url}/cases"
+    requests_mock.register_uri(
+        "PUT", source_api_url, exc=requests.exceptions.ConnectTimeout),
+
+    count_success, count_error = parsing_lib.write_to_server([_PARSED_CASE], {})
+    assert requests_mock.request_history[0].url == full_source_url
+    assert count_success == 0
+    assert count_error == 1

--- a/ingestion/functions/parsing/common/python/sample_data.json
+++ b/ingestion/functions/parsing/common/python/sample_data.json
@@ -1,0 +1,26 @@
+{
+    "raw_data": [
+        {
+            "agebracket": "65",
+            "contractedfromwhichpatientsuspected": "",
+            "currentstatus": "Hospitalized",
+            "dateannounced": "05/06/2020",
+            "detectedcity": "Hanuman Nagar",
+            "detecteddistrict": "Darbhanga",
+            "detectedstate": "Bihar",
+            "entryid": "48765",
+            "gender": "M",
+            "nationality": "",
+            "notes": "",
+            "numcases": "1",
+            "patientnumber": "78135",
+            "source1": "https://twitter.com/BiharHealthDept/status/1268824968953057281",
+            "source2": "",
+            "source3": "",
+            "statecode": "BR",
+            "statepatientnumber": "",
+            "statuschangedate": "",
+            "typeoftransmission": ""
+        }
+    ]
+}

--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -1,13 +1,9 @@
 
-import boto3
 import json
 import os
 import pytest
-import requests
 
 from datetime import date
-from moto import mock_s3
-from unittest.mock import MagicMock
 
 _SOURCE_ID = "abc123"
 _SOURCE_URL = "https://foo.bar"
@@ -54,96 +50,12 @@ _PARSED_CASE = (
 
 
 @pytest.fixture()
-def aws_credentials():
-    """Mocked AWS Credentials for moto."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-
-
-@pytest.fixture()
-def s3(aws_credentials):
-    """Mock S3 connection."""
-    with mock_s3():
-        yield boto3.client("s3", region_name="us-east-1")
-
-
-@pytest.fixture()
-def input_event():
-    """Loads valid Event input from file."""
-    current_dir = os.path.dirname(__file__)
-    file_path = os.path.join(current_dir, "input_event.json")
-    with open(file_path) as event_file:
-        return json.load(event_file)
-
-
-@pytest.fixture()
 def sample_data():
     """Loads sample source data from file."""
     current_dir = os.path.dirname(__file__)
     file_path = os.path.join(current_dir, "sample_data.json")
     with open(file_path) as event_file:
         return json.load(event_file)
-
-
-@mock_s3
-def test_lambda_handler_e2e(input_event, sample_data, requests_mock, s3):
-    from india import india  # Import locally to avoid superseding mock
-    india.obtain_api_credentials = MagicMock(name="obtain_api_credentials")
-    s3.create_bucket(Bucket=input_event[india.S3_BUCKET_FIELD])
-    s3.put_object(
-        Bucket=input_event[india.S3_BUCKET_FIELD],
-        Key=input_event[india.S3_KEY_FIELD],
-        Body=json.dumps(sample_data))
-    source_api_url = "http://foo.bar"
-    os.environ["SOURCE_API_URL"] = source_api_url
-    full_source_url = f"{source_api_url}/cases"
-    requests_mock.put(full_source_url)
-
-    response = india.lambda_handler(input_event, "")
-
-    assert requests_mock.request_history[0].url == full_source_url
-    assert response["count_success"] == 1
-    assert response["count_error"] == 0
-
-
-def test_extract_event_fields_returns_url_bucket_and_key(input_event):
-    from india import india  # Import locally to avoid superseding mock
-    assert india.extract_event_fields(input_event) == (
-        input_event[india.SOURCE_URL_FIELD],
-        input_event[india.S3_BUCKET_FIELD],
-        input_event[india.S3_KEY_FIELD])
-
-
-def test_extract_event_fields_errors_if_missing_bucket_field():
-    from india import india  # Import locally to avoid superseding mock
-    with pytest.raises(ValueError, match=india.S3_BUCKET_FIELD):
-        india.extract_event_fields({india.S3_KEY_FIELD: "key"})
-
-
-def test_extract_event_fields_errors_if_missing_key_field():
-    from india import india  # Import locally to avoid superseding mock
-    with pytest.raises(ValueError, match=india.S3_BUCKET_FIELD):
-        india.extract_event_fields({india.S3_BUCKET_FIELD: "bucket"})
-
-
-@mock_s3
-def test_retrieve_raw_data_file_stores_s3_in_local_file(
-        input_event, s3, sample_data):
-    from india import india  # Import locally to avoid superseding mock
-    s3.create_bucket(Bucket=input_event[india.S3_BUCKET_FIELD])
-    s3.put_object(
-        Bucket=input_event[india.S3_BUCKET_FIELD],
-        Key=input_event[india.S3_KEY_FIELD],
-        Body=json.dumps(sample_data))
-
-    local_file = india.retrieve_raw_data_file(
-        input_event[india.S3_BUCKET_FIELD],
-        input_event[india.S3_KEY_FIELD])
-    assert local_file == india.LOCAL_DATA_FILE
-    with open(local_file, "r") as f:
-        assert json.load(f) == sample_data
 
 
 def test_parse_cases_converts_fields_to_ghdsi_schema(sample_data):
@@ -154,32 +66,3 @@ def test_parse_cases_converts_fields_to_ghdsi_schema(sample_data):
 
     result, = india.parse_cases(data_file, _SOURCE_ID, _SOURCE_URL)
     assert result == _PARSED_CASE
-
-
-def test_write_to_server_returns_success_count_for_each_entered_case(
-        requests_mock):
-    from india import india  # Import locally to avoid superseding mock
-    source_api_url = "http://foo.bar"
-    os.environ["SOURCE_API_URL"] = source_api_url
-    full_source_url = f"{source_api_url}/cases"
-    requests_mock.put(full_source_url)
-
-    count_success, count_error = india.write_to_server([_PARSED_CASE], {})
-    assert requests_mock.request_history[0].url == full_source_url
-    assert count_success == 1
-    assert count_error == 0
-
-
-def test_write_to_server_returns_error_count_for_each_failed_write(
-        requests_mock):
-    from india import india  # Import locally to avoid superseding mock
-    source_api_url = "http://foo.bar"
-    os.environ["SOURCE_API_URL"] = source_api_url
-    full_source_url = f"{source_api_url}/cases"
-    requests_mock.register_uri(
-        "PUT", source_api_url, exc=requests.exceptions.ConnectTimeout),
-
-    count_success, count_error = india.write_to_server([_PARSED_CASE], {})
-    assert requests_mock.request_history[0].url == full_source_url
-    assert count_success == 0
-    assert count_error == 1

--- a/ingestion/functions/parsing/india/input_event.json
+++ b/ingestion/functions/parsing/india/input_event.json
@@ -1,5 +1,5 @@
 {
     "s3Bucket": "epid-sources-raw",
-    "s3Key": "5edfa9e02625ea002abd460d/2020/06/09/1526/content.json",
+    "s3Key": "5f0b9a7ead3a2b003edc0e7f/2020/07/12/2320/content.json",
     "sourceUrl": "https://foo.bar"
 }

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -30,6 +30,20 @@ Resources:
         Variables:
           SOURCE_API_URL:
             Ref: SourceApiUrl
+  ParsingLibLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: parsing_lib
+      Description: Common functions required for parsing
+      ContentUri: parsing/lib/
+      CompatibleRuntimes:
+        - python3.6
+        - python3.7
+        - python3.8
+      LicenseInfo: MIT
+      RetentionPolicy: Retain
+    Metadata:
+      BuildMethod: python3.6
   IndiaParsingFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
@@ -42,6 +56,8 @@ Resources:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
       Timeout: 60 # Seconds
+      Layers:
+        - !Ref ParsingLibLayer
       Environment:
         Variables:
           SOURCE_API_URL:


### PR DESCRIPTION
Diff appears large, but it's mostly just moving code around.

The code being moved isn't optimal -- there are a number of things (in the API, and in Pythonicisms) that should be changed. As a Python expert I'm sure you'll have comments on it! Feel free to comment, or, it might simply be better to sync offline and for us to make changes in subsequent PR(s). And of course please do comment on anything that isn't a drag-and-drop.

There are a couple oddities (like the way parsers import the lib), that are mostly a function of the way AWS Lambda Layers work. The import shenanigans are specifically so that we can run pytest unit tests in addition to invoking the function locally via `sam local invoke`. [This post is a pretty good summary of what this change does](https://aws.amazon.com/blogs/compute/working-with-aws-lambda-and-lambda-layers-in-aws-sam/), albeit with node as the example runtime. In separate PRs, there are some things I'd like to tweak, including:

- Seeing if we can shove the dependencies (as in `requirements.txt`) to the Layer level (in lieu of per-parser).
- Seeing if we can shove os env params (e.g. params configured in `template.yaml`) to the Layer level.

On my to-do today is poking some folks to try and sort the question around AWS credentials and running locally. In the meantime, I'd be happy to set you up an account so that you can run the SAM commands, if you'd like.