### PR TITLE
Remove enums from the mongodb json schema in favor of strings

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -58,11 +58,7 @@
             }
           },
           "sex": {
-            "enum": [
-              "Male",
-              "Female",
-              "Other"
-            ]
+            "bsonType": "string"
           },
           "profession": {
             "bsonType": "string"
@@ -127,13 +123,7 @@
             "bsonType": "string"
           },
           "geoResolution": {
-            "enum": [
-              "Point",
-              "Admin3",
-              "Admin2",
-              "Admin1",
-              "Country"
-            ]
+            "bsonType": "string"
           },
           "geometry": {
             "bsonType": "object",
@@ -197,11 +187,7 @@
             }
           },
           "status": {
-            "enum": [
-              "Asymptomatic",
-              "Presymptomatic",
-              "Symptomatic"
-            ]
+            "bsonType": "string"
           }
         }
       },
@@ -255,13 +241,7 @@
                       "bsonType": "string"
                     },
                     "geoResolution": {
-                      "enum": [
-                        "Point",
-                        "Admin3",
-                        "Admin2",
-                        "Admin1",
-                        "Country"
-                      ]
+                      "bsonType": "string"
                     },
                     "geometry": {
                       "bsonType": "object",
@@ -298,26 +278,13 @@
                   }
                 },
                 "purpose": {
-                  "enum": [
-                    "Business",
-                    "Leisure",
-                    "Family",
-                    "Other"
-                  ]
+                  "bsonType": "string"
                 },
                 "methods": {
                   "bsonType": "array",
                   "uniqueItems": true,
                   "items": {
-                    "enum": [
-                      "Bus",
-                      "Car",
-                      "Coach",
-                      "Ferry",
-                      "Plane",
-                      "Train",
-                      "Other"
-                    ]
+                    "bsonType": "string"
                   }
                 }
               }


### PR DESCRIPTION
Note that these are still validated by Mongoose in the data server so this is a no-op
