### PR TITLE
Add a common lib function to encapsulate Lambda handler boilerplate.

### DIFF
--- a/ingestion/functions/parsing/common/python/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib.py
@@ -86,3 +86,44 @@ def obtain_api_credentials():
 def extract_source_id(s3_key):
     """Extracts the source ID based on the canonical object key format."""
     return s3_key.split(S3_KEY_PATH_SEPERATOR, 1)[0]
+
+
+def run_lambda(event, context, parsing_function):
+    """
+    Encapsulates all of the work performed by a parsing Lambda.
+
+    Parameters
+    ----------
+    event: dict, required
+        Input event JSON-as-dict.
+        This must contain `s3Bucket`, `s3Key`, and `sourceUrl` fields specifying
+        the details of the stored source content.
+
+    context: object, required
+        Lambda Context runtime methods and attributes.
+        For more information, see:
+          https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
+
+    parsing_function: function, required
+        Python function that parses raw source data into G.h case data.
+        This function must accept (in order): a file containing raw source
+        data, a string representing the source UUID, and a string representing
+        the source URL.
+
+    Returns
+    ------
+    JSON object containing the count of line list cases successfully written to
+    G.h servers.
+    For more information on return types, see:
+      https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
+    """
+
+    source_url, s3_bucket, s3_key = extract_event_fields(event)
+    raw_data_file = retrieve_raw_data_file(s3_bucket, s3_key)
+    case_data = parsing_function(
+        raw_data_file, extract_source_id(s3_key),
+        source_url)
+    api_creds = obtain_api_credentials()
+    count_success, count_error = write_to_server(
+        case_data, api_creds)
+    return {"count_success": count_success, "count_error": count_error}

--- a/ingestion/functions/parsing/common/python/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib.py
@@ -108,7 +108,10 @@ def run_lambda(event, context, parsing_function):
         Python function that parses raw source data into G.h case data.
         This function must accept (in order): a file containing raw source
         data, a string representing the source UUID, and a string representing
-        the source URL.
+        the source URL. It must return a list of data conforming to the G.h
+        case format (TODO: add a link to this definition).
+        For an example, see:
+          https://github.com/open-covid-data/healthmap-gdo-temp/blob/master/ingestion/functions/parsing/india/india.py#L57
 
     Returns
     ------

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -104,35 +104,4 @@ def parse_cases(raw_data_file, source_id, source_url):
 
 
 def lambda_handler(event, context):
-    """
-    Case data parsing function for the COVID19-India API.
-
-    Parameters
-    ----------
-    event: dict, required
-        Input event JSON-as-dict.
-        This must contain `s3Bucket`, `s3Key`, and `sourceUrl` fields specifying
-        the details of the stored source content.
-
-    context: object, required
-        Lambda Context runtime methods and attributes.
-        For more information, see:
-          https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
-
-    Returns
-    ------
-    JSON object containing the count of line list cases successfully written to
-    G.h servers.
-    For more information on return types, see:
-      https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
-    """
-
-    source_url, s3_bucket, s3_key = parsing_lib.extract_event_fields(event)
-    raw_data_file = parsing_lib.retrieve_raw_data_file(s3_bucket, s3_key)
-    case_data = parse_cases(
-        raw_data_file, parsing_lib.extract_source_id(s3_key),
-        source_url)
-    api_creds = parsing_lib.obtain_api_credentials()
-    count_success, count_error = parsing_lib.write_to_server(
-        case_data, api_creds)
-    return {"count_success": count_success, "count_error": count_error}
+    return parsing_lib.run_lambda(event, context, parse_cases)


### PR DESCRIPTION
Not pursuing the optimization of `parsing_lib` too much just yet, but this was low-hanging fruit that I wanted to knock out.

Allows us to introduce a solid ~E2E test for the library, which is a plus.