### PR TITLE
Allow specifying multiple geocode limits/types.

### DIFF
--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -152,15 +152,19 @@ export default class CasesController {
         }
         const opts: GeocodeOptions = {};
         if (location['limitToResolution']) {
-            opts.limitToResolution =
-                Resolution[
-                    location['limitToResolution'] as keyof typeof Resolution
-                ];
-            if (!opts.limitToResolution) {
-                throw new InvalidParamError(
-                    `invalid limitToResolution: ${location['limitToResolution']}`,
-                );
-            }
+            opts.limitToResolution = [];
+            location['limitToResolution']
+                .split(',')
+                .forEach((supplied: string) => {
+                    const resolution =
+                        Resolution[supplied as keyof typeof Resolution];
+                    if (!resolution) {
+                        throw new InvalidParamError(
+                            `invalid limitToResolution: ${supplied}`,
+                        );
+                    }
+                    opts.limitToResolution?.push(resolution);
+                });
         }
         for (const geocoder of this.geocoders) {
             const features = await geocoder.geocode(location?.query, opts);

--- a/verification/curator-service/api/src/geocoding/geocoder.ts
+++ b/verification/curator-service/api/src/geocoding/geocoder.ts
@@ -28,9 +28,9 @@ export enum Resolution {
 }
 
 export interface GeocodeOptions {
-    // If set, will only return features with the given resolution
-    // otherwise all available resolutions can be returned.
-    limitToResolution?: Resolution;
+    // If set, will only return features with the given resolutions.
+    // Otherwise all available resolutions can be returned.
+    limitToResolution?: Resolution[];
 }
 
 // A geocoder can geocode queries into places.

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -91,12 +91,20 @@ export default class MapboxGeocoder {
             // with features of that specific type.
             // The context of the feature can still has other types
             // (if you ask for a region, the context will still contain the country).
-            if (opts?.limitToResolution) {
-                const type = resolutionToGeocodeQueryType.get(
-                    opts?.limitToResolution,
-                );
-                if (type) {
-                    req.types = [type];
+            const requestedResolutions = opts?.limitToResolution;
+            if (requestedResolutions) {
+                const types = requestedResolutions
+                    .map((r: Resolution) => resolutionToGeocodeQueryType.get(r))
+                    .filter((t) => t);
+                if (types) {
+                    req.types = [];
+                    types.forEach((t: GeocodeQueryType | undefined) => {
+                        // They're filtered above, but Typescript can't take
+                        // the hint.
+                        if (t) {
+                            req.types?.push(t);
+                        }
+                    });
                 }
             }
             const resp: MapiResponse = await this.geocodeService

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -274,6 +274,41 @@ describe('Cases', () => {
         expect(res.text).toEqual(message);
     });
 
+    it('handles multiple location restrictions', async () => {
+        const lyon: GeocodeResult = {
+            administrativeAreaLevel1: 'Rhône',
+            administrativeAreaLevel2: '',
+            administrativeAreaLevel3: 'Lyon',
+            country: 'France',
+            geometry: { latitude: 45.75889, longitude: 4.84139 },
+            place: '',
+            name: 'Lyon',
+            geoResolution: Resolution.Admin3,
+        };
+        await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
+        mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);
+
+        await curatorRequest
+            .post('/api/cases')
+            .send({
+                age: '42',
+                location: {
+                    query: 'Lyon',
+                    limitToResolution: 'Admin3,Admin2',
+                },
+            })
+            .expect(200)
+            .expect('Content-Type', /json/);
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            'http://localhost:3000/api/cases',
+            {
+                age: '42',
+                location: lyon,
+            },
+        );
+    });
+
     it('throws on invalid location restrictions', async () => {
         await curatorRequest
             .post('/api/cases')

--- a/verification/curator-service/api/test/geocoding/mapbox.test.ts
+++ b/verification/curator-service/api/test/geocoding/mapbox.test.ts
@@ -43,7 +43,7 @@ describe('geocode', () => {
         features.push(lyon);
         const geocoder = new Geocoder('token', 'mapbox.places');
         let feats = await geocoder.geocode('some query', {
-            limitToResolution: Resolution.Admin3,
+            limitToResolution: [Resolution.Admin3, Resolution.Admin2],
         });
         expect(feats).toHaveLength(1);
         const wantFeature: GeocodeResult = {
@@ -60,7 +60,7 @@ describe('geocode', () => {
         expect(callCount).toBe(1);
         // Call again, cache should have been hit.
         feats = await geocoder.geocode('some query', {
-            limitToResolution: Resolution.Admin3,
+            limitToResolution: [Resolution.Admin3, Resolution.Admin2],
         });
         expect(feats[0]).toEqual(wantFeature);
         expect(callCount).toBe(1);


### PR DESCRIPTION
Adding a feature to limit the impact of issues like #530 while we wait on resolving admin2 geocoding.