### PR TITLE
Add a tooltip for the CSV file upload component, linking to docs.

### DIFF
--- a/verification/curator-service/ui/src/components/bulk-case-form-fields/FileUpload.tsx
+++ b/verification/curator-service/ui/src/components/bulk-case-form-fields/FileUpload.tsx
@@ -4,6 +4,22 @@ import { RequiredHelperText } from '../common-form-fields/FormikFields';
 import { makeStyles } from '@material-ui/core';
 import { useFormikContext } from 'formik';
 
+const tooltip = (
+    <React.Fragment>
+        {'Select a CSV file to upload in the format described '}
+        <a
+            href={
+                'https://github.com/open-covid-data/healthmap-gdo-temp/tree/master/verification/curator-service/ui#bulk-upload-process'
+            }
+            rel="noopener noreferrer"
+            target="_blank"
+        >
+            {'here'}
+        </a>
+        {'.'}
+    </React.Fragment>
+);
+
 const useStyles = makeStyles(() => ({
     csvInput: {
         padding: '15px',
@@ -16,7 +32,11 @@ export default function FileUpload(): JSX.Element {
     const name = 'file';
     return (
         <fieldset>
-            <FieldTitle title="CSV Data"></FieldTitle>
+            <FieldTitle
+                title="CSV Data"
+                tooltip={tooltip}
+                interactive
+            ></FieldTitle>
             <input
                 className={classes.csvInput}
                 data-testid="csv-input"

--- a/verification/curator-service/ui/src/components/common-form-fields/FieldTitle.tsx
+++ b/verification/curator-service/ui/src/components/common-form-fields/FieldTitle.tsx
@@ -29,7 +29,8 @@ const AppTooltip = withStyles((theme: Theme) => ({
 
 interface FieldTitleProps extends WithStyles<typeof styles> {
     title: string;
-    tooltip?: string;
+    tooltip?: string | JSX.Element;
+    interactive?: boolean;
 }
 
 function FieldTitle(props: FieldTitleProps): JSX.Element {
@@ -40,7 +41,11 @@ function FieldTitle(props: FieldTitleProps): JSX.Element {
                 {props.title.toLocaleUpperCase()}
             </div>
             {props.tooltip && (
-                <AppTooltip title={props.tooltip} className={classes.tooltip}>
+                <AppTooltip
+                    interactive={props.interactive}
+                    title={props.tooltip}
+                    className={classes.tooltip}
+                >
                     <HelpOutlineIcon fontSize="small" />
                 </AppTooltip>
             )}


### PR DESCRIPTION
There isn't a mocked tooltip or copy for this, but it's a helpful stopgap while we iron out issues.

![image](https://user-images.githubusercontent.com/63060924/87568976-7e05f300-c694-11ea-848d-1c0d3448091f.png)
