### PR TITLE
Add top-level NewCase properties to API docs & use to validate create requests

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -169,6 +169,42 @@ components:
     NewCase:
       description: The subset of "#/components/schemas/Case" required to create the entity
       type: object
+      properties:
+        caseReference:
+          type: object
+        demographics:
+          type: object
+        location:
+          type: object
+        events:
+          type: array
+          items:
+            type: object
+        symptoms:
+          type: object
+        preexistingConditions:
+          type: object
+        transmission:
+          type: object
+        travelHistory:
+          type: object
+        genomeSequences:
+          type: array
+          items:
+            type: object
+        pathogens:
+          type: array
+          items:
+            type: object
+        notes:
+          type: string
+        revisionMetadata:
+          type: object
+      required:
+        - caseReference
+        - location
+        - events
+        - revisionMetadata
   responses:
     "200Case":
       description: OK

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -24,14 +24,6 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 // Configure app routes.
 app.get('/', homeController.get);
-const apiRouter = express.Router();
-apiRouter.get('/cases/:id([a-z0-9]{24})', caseController.get);
-apiRouter.get('/cases', caseController.list);
-apiRouter.post('/cases', caseController.create);
-apiRouter.put('/cases', caseController.upsert);
-apiRouter.put('/cases/:id([a-z0-9]{24})', caseController.update);
-apiRouter.delete('/cases/:id([a-z0-9]{24})', caseController.del);
-app.use('/api', apiRouter);
 
 // API documentation.
 const swaggerDocument = YAML.load('./api/openapi.yaml');
@@ -55,7 +47,16 @@ app.get('/health', (req: Request, res: Response) => {
 new OpenApiValidator({
     apiSpec: './api/openapi.yaml',
     validateResponses: true,
-}).install(app);
+}).install(app).then(() => {
+    const apiRouter = express.Router();
+    apiRouter.get('/cases/:id([a-z0-9]{24})', caseController.get);
+    apiRouter.get('/cases', caseController.list);
+    apiRouter.post('/cases', caseController.create);
+    apiRouter.put('/cases', caseController.upsert);
+    apiRouter.put('/cases/:id([a-z0-9]{24})', caseController.update);
+    apiRouter.delete('/cases/:id([a-z0-9]{24})', caseController.del);
+    app.use('/api', apiRouter);
+});
 
 (async (): Promise<void> => {
     try {


### PR DESCRIPTION
Note: Also needed to move the express handlers for API endpoints to be registered after the open api validator is installed -- without this, it wasn't actually validating

Next few PRs will be fleshing out the sub-props

![image](https://user-images.githubusercontent.com/3913264/87583244-a4825900-c6a9-11ea-8ad7-5d9090ebfb15.png)
