### PR TITLE
Add the top-level properties to the case requests & responses in data service

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -60,7 +60,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewCase"
+              allOf:
+                - $ref: "#/components/schemas/Case"
+              required:
+                - caseReference
+                - location
+                - events
+                - revisionMetadata
       parameters:
         - name: validate_only
           in: query
@@ -94,7 +100,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NewCase"
+              $ref: "#/components/schemas/Case"
       responses:
         "200":
           $ref: "#/components/responses/200Case"
@@ -173,10 +179,38 @@ paths:
 components:
   schemas:
     Case:
-      description: A complete case; a superset of "#/components/schemas/NewCase" with server-added fields
-      allOf:
-        - $ref: "#/components/schemas/NewCase"
-        - type: object
+      description: A single line-list case.
+      properties:
+        caseReference:
+          type: object
+        demographics:
+          type: object
+        location:
+          type: object
+        events:
+          type: array
+          items:
+            type: object
+        symptoms:
+          type: object
+        preexistingConditions:
+          type: object
+        transmission:
+          type: object
+        travelHistory:
+          type: object
+        genomeSequences:
+          type: array
+          items:
+            type: object
+        pathogens:
+          type: array
+          items:
+            type: object
+        notes:
+          type: string
+        revisionMetadata:
+          type: object
     CaseArray:
       type: object
       properties:
@@ -184,9 +218,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Case"
-    NewCase:
-      description: The subset of "#/components/schemas/Case" required to create the entity
-      type: object
   responses:
     "200Case":
       description: OK

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -100,7 +100,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Case"
+              allOf:
+                - $ref: "#/components/schemas/Case"
+              required:
+                - caseReference
       responses:
         "200":
           $ref: "#/components/responses/200Case"

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -7,6 +7,11 @@ import request from 'supertest';
 
 let mongoServer: MongoMemoryServer;
 
+const invalidCase = {
+    ...minimalCase,
+    demographics: { ageRange: { start: 400 } },
+};
+
 beforeAll(async () => {
     mongoServer = new MongoMemoryServer();
 });
@@ -131,6 +136,9 @@ describe('POST', () => {
     it('create with input missing required properties should return 400', () => {
         return request(app).post('/api/cases').send({}).expect(400);
     });
+    it('create with required properties but invalid input should return 422', () => {
+        return request(app).post('/api/cases').send(invalidCase).expect(422);
+    });
     it('create with valid input should return 201 OK', async () => {
         return request(app)
             .post('/api/cases')
@@ -233,8 +241,11 @@ describe('PUT', () => {
 
         expect(await secondUniqueCase.collection.countDocuments()).toEqual(2);
     });
+    it('upsert new item without required fields should return 400', () => {
+        return request(app).put('/api/cases').send({}).expect(400);
+    });
     it('upsert new item with invalid input should return 422', () => {
-        return request(app).put('/api/cases').send({}).expect(422);
+        return request(app).put('/api/cases').send(invalidCase).expect(422);
     });
     it('invalid upsert present item should return 422', async () => {
         const c = new Case(minimalCase);

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -128,8 +128,8 @@ describe('GET', () => {
 });
 
 describe('POST', () => {
-    it('create with invalid input should return 422', () => {
-        return request(app).post('/api/cases').send({}).expect(422);
+    it('create with input missing required properties should return 400', () => {
+        return request(app).post('/api/cases').send({}).expect(400);
     });
     it('create with valid input should return 201 OK', async () => {
         return request(app)
@@ -138,11 +138,11 @@ describe('POST', () => {
             .expect('Content-Type', /json/)
             .expect(201);
     });
-    it('create with invalid input and validate_only should return 422', async () => {
+    it('create with input missing required properties and validate_only should return 400', async () => {
         return request(app)
             .post('/api/cases?validate_only=true')
             .send({})
-            .expect(422);
+            .expect(400);
     });
     it('create with valid input and validate_only should not save case', async () => {
         const res = await request(app)


### PR DESCRIPTION
These requests & responses are now validated against the `Case` object definition in the API YAML -- and these show up in the API docs

Note that the `create` request has some required properties that the responses don't have (since legacy data might not have these properties)

Next PRs will be to flesh out the sub-props of the `Case` object

![api-docs](https://user-images.githubusercontent.com/3913264/87597647-28dfd680-c6c0-11ea-87a7-5944fc159c8b.png)
