### PR TITLE
Preserve status in successful requests proxied via the curator service API

### DIFF
--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -20,7 +20,7 @@ export default class CasesController {
             const response = await axios.get(
                 this.dataServerURL + '/api' + req.url,
             );
-            res.json(response.data);
+            res.status(response.status).json(response.data);
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {
@@ -36,7 +36,7 @@ export default class CasesController {
             const response = await axios.get(
                 this.dataServerURL + '/api' + req.url,
             );
-            res.json(response.data);
+            res.status(response.status).json(response.data);
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {
@@ -52,7 +52,7 @@ export default class CasesController {
             const response = await axios.delete(
                 this.dataServerURL + '/api' + req.url,
             );
-            res.json(response.data);
+            res.status(response.status).json(response.data);
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {
@@ -69,7 +69,7 @@ export default class CasesController {
                 this.dataServerURL + '/api' + req.url,
                 req.body,
             );
-            res.json(response.data);
+            res.status(response.status).json(response.data);
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {
@@ -92,7 +92,7 @@ export default class CasesController {
                 this.dataServerURL + '/api' + req.url,
                 req.body,
             );
-            res.json(response.data);
+            res.status(response.status).json(response.data);
         } catch (err) {
             if (err instanceof InvalidParamError) {
                 res.status(422).send(err.message);
@@ -119,7 +119,7 @@ export default class CasesController {
                 this.dataServerURL + '/api' + req.url,
                 req.body,
             );
-            res.json(response.data);
+            res.status(response.status).json(response.data);
         } catch (err) {
             if (err instanceof InvalidParamError) {
                 res.status(422).send(err.message);

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -20,7 +20,7 @@ export default class CasesController {
             const response = await axios.get(
                 this.dataServerURL + '/api' + req.url,
             );
-            res.status(response.status).json(response.data);
+            res.json(response.data);
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {
@@ -36,7 +36,7 @@ export default class CasesController {
             const response = await axios.get(
                 this.dataServerURL + '/api' + req.url,
             );
-            res.status(response.status).json(response.data);
+            res.json(response.data);
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {
@@ -52,7 +52,7 @@ export default class CasesController {
             const response = await axios.delete(
                 this.dataServerURL + '/api' + req.url,
             );
-            res.status(response.status).json(response.data);
+            res.json(response.data);
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {
@@ -69,7 +69,7 @@ export default class CasesController {
                 this.dataServerURL + '/api' + req.url,
                 req.body,
             );
-            res.status(response.status).json(response.data);
+            res.json(response.data);
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {
@@ -92,7 +92,7 @@ export default class CasesController {
                 this.dataServerURL + '/api' + req.url,
                 req.body,
             );
-            res.status(response.status).json(response.data);
+            res.json(response.data);
         } catch (err) {
             if (err instanceof InvalidParamError) {
                 res.status(422).send(err.message);
@@ -119,7 +119,7 @@ export default class CasesController {
                 this.dataServerURL + '/api' + req.url,
                 req.body,
             );
-            res.status(response.status).json(response.data);
+            res.json(response.data);
         } catch (err) {
             if (err instanceof InvalidParamError) {
                 res.status(422).send(err.message);

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -36,7 +36,7 @@ afterAll(async () => {
 
 const emptyAxiosResponse = {
     data: {},
-    status: 202,
+    status: 200,
     statusText: 'OK',
     config: {},
     headers: {},
@@ -65,7 +65,7 @@ describe('Cases', () => {
         mockedAxios.get.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
             .get('/api/cases?limit=10&page=1&filter=')
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.get).toHaveBeenCalledTimes(1);
         expect(mockedAxios.get).toHaveBeenCalledWith(
@@ -89,7 +89,7 @@ describe('Cases', () => {
         mockedAxios.get.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
             .get('/api/cases/5e99f21a1c9d440000ceb088')
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.get).toHaveBeenCalledTimes(1);
         expect(mockedAxios.get).toHaveBeenCalledWith(
@@ -114,7 +114,7 @@ describe('Cases', () => {
         await curatorRequest
             .put('/api/cases/5e99f21a1c9d440000ceb088')
             .send({ age: '42' })
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.put).toHaveBeenCalledTimes(1);
         expect(
@@ -142,7 +142,7 @@ describe('Cases', () => {
         mockedAxios.delete.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
             .delete('/api/cases/5e99f21a1c9d440000ceb088')
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.delete).toHaveBeenCalledTimes(1);
         expect(mockedAxios.delete).toHaveBeenCalledWith(
@@ -178,7 +178,7 @@ describe('Cases', () => {
         await curatorRequest
             .put('/api/cases')
             .send({ age: '42', location: { query: 'Lyon' } })
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.put).toHaveBeenCalledTimes(1);
         expect(mockedAxios.put).toHaveBeenCalledWith(
@@ -234,7 +234,7 @@ describe('Cases', () => {
                 age: '42',
                 location: { query: 'Lyon', limitToResolution: 'Admin3' },
             })
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -297,7 +297,7 @@ describe('Cases', () => {
                     limitToResolution: 'Admin3,Admin2',
                 },
             })
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.post).toHaveBeenCalledWith(

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -36,7 +36,7 @@ afterAll(async () => {
 
 const emptyAxiosResponse = {
     data: {},
-    status: 200,
+    status: 202,
     statusText: 'OK',
     config: {},
     headers: {},
@@ -65,7 +65,7 @@ describe('Cases', () => {
         mockedAxios.get.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
             .get('/api/cases?limit=10&page=1&filter=')
-            .expect(200)
+            .expect(202)
             .expect('Content-Type', /json/);
         expect(mockedAxios.get).toHaveBeenCalledTimes(1);
         expect(mockedAxios.get).toHaveBeenCalledWith(
@@ -89,7 +89,7 @@ describe('Cases', () => {
         mockedAxios.get.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
             .get('/api/cases/5e99f21a1c9d440000ceb088')
-            .expect(200)
+            .expect(202)
             .expect('Content-Type', /json/);
         expect(mockedAxios.get).toHaveBeenCalledTimes(1);
         expect(mockedAxios.get).toHaveBeenCalledWith(
@@ -114,7 +114,7 @@ describe('Cases', () => {
         await curatorRequest
             .put('/api/cases/5e99f21a1c9d440000ceb088')
             .send({ age: '42' })
-            .expect(200)
+            .expect(202)
             .expect('Content-Type', /json/);
         expect(mockedAxios.put).toHaveBeenCalledTimes(1);
         expect(
@@ -142,7 +142,7 @@ describe('Cases', () => {
         mockedAxios.delete.mockResolvedValueOnce(emptyAxiosResponse);
         await curatorRequest
             .delete('/api/cases/5e99f21a1c9d440000ceb088')
-            .expect(200)
+            .expect(202)
             .expect('Content-Type', /json/);
         expect(mockedAxios.delete).toHaveBeenCalledTimes(1);
         expect(mockedAxios.delete).toHaveBeenCalledWith(
@@ -178,7 +178,7 @@ describe('Cases', () => {
         await curatorRequest
             .put('/api/cases')
             .send({ age: '42', location: { query: 'Lyon' } })
-            .expect(200)
+            .expect(202)
             .expect('Content-Type', /json/);
         expect(mockedAxios.put).toHaveBeenCalledTimes(1);
         expect(mockedAxios.put).toHaveBeenCalledWith(
@@ -234,7 +234,7 @@ describe('Cases', () => {
                 age: '42',
                 location: { query: 'Lyon', limitToResolution: 'Admin3' },
             })
-            .expect(200)
+            .expect(202)
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -297,7 +297,7 @@ describe('Cases', () => {
                     limitToResolution: 'Admin3,Admin2',
                 },
             })
-            .expect(200)
+            .expect(202)
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.post).toHaveBeenCalledWith(

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -4,7 +4,9 @@ import { Button, withStyles } from '@material-ui/core';
 import { Case, CaseReference, Event } from './Case';
 import { Form, Formik } from 'formik';
 import Papa, { ParseConfig, ParseResult } from 'papaparse';
+import axios, { AxiosResponse } from 'axios';
 
+import Alert from '@material-ui/lab/Alert';
 import AppModal from './AppModal';
 import CaseValidationError from './bulk-case-form-fields/CaseValidationError';
 import FileUpload from './bulk-case-form-fields/FileUpload';
@@ -12,7 +14,6 @@ import React from 'react';
 import Source from './common-form-fields/Source';
 import ValidationErrorList from './bulk-case-form-fields/ValidationErrorList';
 import { WithStyles } from '@material-ui/core/styles/withStyles';
-import axios from 'axios';
 import { createStyles } from '@material-ui/core/styles';
 
 interface User {
@@ -35,6 +36,10 @@ const styles = () =>
         formSection: {
             margin: '2em 0',
         },
+        statusMessage: {
+            marginTop: '2em',
+            maxWidth: '80%',
+        },
     });
 
 interface BulkCaseFormProps extends WithStyles<typeof styles> {
@@ -43,7 +48,8 @@ interface BulkCaseFormProps extends WithStyles<typeof styles> {
 }
 
 interface BulkCaseFormState {
-    statusMessage: string;
+    errorMessage: string;
+    successMessage: string;
     errors: CaseValidationError[];
 }
 
@@ -121,11 +127,12 @@ const BulkFormSchema = Yup.object().shape({
 class BulkCaseForm extends React.Component<
     BulkCaseFormProps,
     BulkCaseFormState
-> {
+    > {
     constructor(props: BulkCaseFormProps) {
         super(props);
         this.state = {
-            statusMessage: '',
+            errorMessage: '',
+            successMessage: '',
             errors: [],
         };
     }
@@ -148,9 +155,9 @@ class BulkCaseForm extends React.Component<
                 name: 'hospitalAdmission',
                 dateRange: c.dateHospitalized
                     ? {
-                          start: c.dateHospitalized,
-                          end: c.dateHospitalized,
-                      }
+                        start: c.dateHospitalized,
+                        end: c.dateHospitalized,
+                    }
                     : undefined,
                 value: 'Yes',
             });
@@ -230,9 +237,9 @@ class BulkCaseForm extends React.Component<
                 geometry:
                     c.latitude && c.longitude
                         ? {
-                              latitude: c.latitude,
-                              longitude: c.longitude,
-                          }
+                            latitude: c.latitude,
+                            longitude: c.longitude,
+                        }
                         : undefined,
                 name: c.locationName,
                 limitToResolution: geoResolutionLimit,
@@ -249,7 +256,7 @@ class BulkCaseForm extends React.Component<
         };
     }
 
-    async upsertCase(c: CompleteParsedCase): Promise<void> {
+    upsertCase(c: CompleteParsedCase): Promise<AxiosResponse<Case>> {
         return axios.put('/api/cases', c);
     }
 
@@ -303,23 +310,38 @@ class BulkCaseForm extends React.Component<
         const validationErrors = await this.validateCases(cases);
         this.setState({ errors: validationErrors });
         if (validationErrors.length > 0) {
+            this.setState({
+                errors: validationErrors,
+                errorMessage: '',
+                successMessage: '',
+            });
             return;
         }
+        let created = 0;
+        let updated = 0;
         for (const c of cases) {
             try {
                 const casesToUpsert = c.caseCount ? c.caseCount : 1;
                 for (let i = 0; i < casesToUpsert; i++) {
-                    await this.upsertCase(c);
+                    const response = await this.upsertCase(c);
+                    response.status === 201 ? created++ : updated++;
                 }
-                this.setState({ statusMessage: 'Success!' });
             } catch (e) {
                 this.setState({
-                    statusMessage: `System error during upload: ${JSON.stringify(
+                    errorMessage: `System error during upload: ${JSON.stringify(
                         e,
                     )}`,
+                    successMessage: '',
                 });
             }
         }
+        const createdMessage =
+            created > 0 ? `Created ${created} new rows. ` : '';
+        const updatedMessage = updated > 0 ? `Updated ${updated} rows.` : '';
+        this.setState({
+            errorMessage: '',
+            successMessage: `Success! ${createdMessage}${updatedMessage}`,
+        });
     }
 
     async submitCases(values: BulkCaseFormValues): Promise<void> {
@@ -375,16 +397,27 @@ class BulkCaseForm extends React.Component<
                                 >
                                     Upload cases
                                 </Button>
-                                {this.state.statusMessage && (
-                                    <h3>
-                                        {this.state.statusMessage as string}
-                                    </h3>
-                                )}
                                 {this.state.errors.length > 0 && (
                                     <ValidationErrorList
                                         errors={this.state.errors}
                                         maxDisplayErrors={10}
                                     />
+                                )}
+                                {this.state.successMessage && (
+                                    <Alert
+                                        className={classes.statusMessage}
+                                        severity="success"
+                                    >
+                                        {this.state.successMessage}
+                                    </Alert>
+                                )}
+                                {this.state.errorMessage && (
+                                    <Alert
+                                        className={classes.statusMessage}
+                                        severity="error"
+                                    >
+                                        {this.state.errorMessage}
+                                    </Alert>
                                 )}
                             </Form>
                         </div>


### PR DESCRIPTION
This is necessary to distinguish, e.g., between creations and updates performed as a result of calling the upsert API.

Related: #539.