### PR TITLE
Add API docs for caseReference, demographics, and location props

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -223,10 +223,20 @@ components:
               type: string
             place:
               type: string
-            query:
+            name:
               type: string
             geoResolution: 
               type: string
+            geometry:
+              type: object
+              properties:
+                latitude:
+                  type: number
+                longitude:
+                  type: number
+              required:
+                - latitude
+                - longitude
         events:
           type: array
           items:
@@ -270,6 +280,8 @@ components:
         location:
           required:
             - country
+            - geoResolution
+            - geometry
       required:
         - caseReference
         - location

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -60,13 +60,7 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: "#/components/schemas/Case"
-              required:
-                - caseReference
-                - location
-                - events
-                - revisionMetadata
+              $ref: "#/components/schemas/NewCase"
       parameters:
         - name: validate_only
           in: query
@@ -186,10 +180,53 @@ components:
       properties:
         caseReference:
           type: object
+          properties:
+            sourceId:
+              type: string
+              pattern: '^[a-f\d]{24}$'
+            sourceUrl:
+              type: string
+            additionalSources:
+              type: array
+              items:
+                type: string
         demographics:
           type: object
+          properties:
+            gender:
+              type: string
+            ageRange:
+              type: object
+              properties:
+                start:
+                  type: number
+                end:
+                  type: number
+            ethnicity:
+              type: string
+            nationalities:
+              type: array
+              items:
+                type: string
+            occupation:
+              type: string
         location:
           type: object
+          properties:
+            country:
+              type: string
+            administrativeAreaLevel1:
+              type: string
+            administrativeAreaLevel2:
+              type: string
+            administrativeAreaLevel3:
+              type: string
+            place:
+              type: string
+            query:
+              type: string
+            geoResolution: 
+              type: string
         events:
           type: array
           items:
@@ -221,6 +258,23 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Case"
+    NewCase:
+      description: A "#/components/schemas/Case" with additional required fields for newly-created cases
+      allOf:
+        - $ref: "#/components/schemas/Case"
+      properties:
+        caseReference:
+          required:
+            - sourceId
+            - sourceUrl
+        location:
+          required:
+            - country
+      required:
+        - caseReference
+        - location
+        - events
+        - revisionMetadata
   responses:
     "200Case":
       description: OK

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -282,6 +282,7 @@ components:
             - country
             - geoResolution
             - geometry
+            - name
       required:
         - caseReference
         - location

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -30,7 +30,10 @@ export const locationSchema = new mongoose.Schema(
         // Place represents a precise location, such as an establishment or POI.
         place: String,
         // A human-readable name of the location.
-        name: String,
+        name: {
+            type: String,
+            required: true,
+        },
         geoResolution: {
             type: String,
             required: true,

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -1,37 +1,32 @@
 import mongoose from 'mongoose';
 
-const fieldRequiredValidator = [
-    function (this: LocationDocument): boolean {
-        return (
-            this != null &&
-            this.country == null &&
-            this.administrativeAreaLevel1 == null &&
-            this.administrativeAreaLevel2 == null &&
-            this.administrativeAreaLevel3 == null
-        );
+const geometrySchema = new mongoose.Schema(
+    {
+        latitude: {
+            type: Number,
+            min: -90.0,
+            max: 90.0,
+            required: true,
+        },
+        longitude: {
+            type: Number,
+            min: -180.0,
+            max: 180.0,
+            required: true,
+        },
     },
-    'One of country, administrativeAreaLevel1, administrativeAreaLevel2, ' +
-        'or administrativeAreaLevel3 is required',
-];
+    { _id: false },
+);
 
 export const locationSchema = new mongoose.Schema(
     {
         country: {
             type: String,
-            required: fieldRequiredValidator,
+            required: true,
         },
-        administrativeAreaLevel1: {
-            type: String,
-            required: fieldRequiredValidator,
-        },
-        administrativeAreaLevel2: {
-            type: String,
-            required: fieldRequiredValidator,
-        },
-        administrativeAreaLevel3: {
-            type: String,
-            required: fieldRequiredValidator,
-        },
+        administrativeAreaLevel1: String,
+        administrativeAreaLevel2: String,
+        administrativeAreaLevel3: String,
         // Place represents a precise location, such as an establishment or POI.
         place: String,
         // A human-readable name of the location.
@@ -41,37 +36,8 @@ export const locationSchema = new mongoose.Schema(
             required: true,
         },
         geometry: {
-            latitude: {
-                type: Number,
-                min: -90.0,
-                max: 90.0,
-                required: [
-                    function (this: LocationDocument): boolean {
-                        return (
-                            this != null &&
-                            this.geometry?.latitude == null &&
-                            this.geometry?.longitude != null
-                        );
-                    },
-                    'latitude must be specified if geometry is present',
-                ],
-            },
-            longitude: {
-                type: Number,
-                min: -180.0,
-                max: 180.0,
-                required: [
-                    function (this: LocationDocument): boolean {
-                        return (
-                            this != null &&
-                            this.geometry?.longitude == null &&
-                            this.geometry?.latitude != null
-                        );
-                    },
-                    'longitude must be specified if geometry is present',
-                ],
-            },
-            _id: false,
+            type: geometrySchema,
+            required: true,
         },
     },
     { _id: false },

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -195,7 +195,7 @@ describe('PUT', () => {
     });
     it('upsert present item should return 200 OK', async () => {
         const c = new Case(minimalCase);
-        const sourceId = 'abc123';
+        const sourceId = '5ea86423bae6982635d2e1f8';
         const entryId = 'def456';
         c.set('caseReference.sourceId', sourceId);
         c.set('caseReference.sourceEntryId', entryId);
@@ -226,7 +226,7 @@ describe('PUT', () => {
             .expect(201);
     });
     it('upsert items without sourceEntryId should return 201 CREATED', async () => {
-        const sharedSourceId = 'abc123';
+        const sharedSourceId = '5ea86423bae6982635d2e1f8';
         const firstUniqueCase = new Case(minimalCase);
         firstUniqueCase.set('caseReference.sourceId', sharedSourceId);
         await firstUniqueCase.save();
@@ -249,7 +249,7 @@ describe('PUT', () => {
     });
     it('invalid upsert present item should return 422', async () => {
         const c = new Case(minimalCase);
-        const sourceId = 'abc123';
+        const sourceId = '5ea86423bae6982635d2e1f8';
         const entryId = 'def456';
         c.set('caseReference.sourceId', sourceId);
         c.set('caseReference.sourceEntryId', entryId);

--- a/data-serving/data-service/test/model/data/case-reference.full.json
+++ b/data-serving/data-service/test/model/data/case-reference.full.json
@@ -1,5 +1,5 @@
 {
-    "sourceId": "sourceId",
+    "sourceId": "5ef8e943dfe6e00030892d58",
     "sourceEntryId": "entryId",
     "sourceUrl": "cdc.gov",
     "additionalSources": [

--- a/data-serving/data-service/test/model/data/case-reference.minimal.json
+++ b/data-serving/data-service/test/model/data/case-reference.minimal.json
@@ -1,4 +1,4 @@
 {
-    "sourceId": "sourceId",
+    "sourceId": "5ef8e943dfe6e00030892d58",
     "sourceUrl": "cdc.gov"
 }

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -1,6 +1,6 @@
 {
     "caseReference": {
-        "sourceId": "sourceId",
+        "sourceId": "5ea86423bae6982635d2e1f8",
         "sourceEntryId": "entryId",
         "sourceUrl": "cdc.gov",
         "additionalSources": [

--- a/data-serving/data-service/test/model/data/case.minimal.json
+++ b/data-serving/data-service/test/model/data/case.minimal.json
@@ -14,7 +14,11 @@
     ],
     "location": {
         "country": "China",
-        "geoResolution": "Country"
+        "geoResolution": "Country",
+        "geometry": {
+            "latitude": 2.3522219,
+            "longitude": 48.85661400000001
+        }
     },
     "revisionMetadata": {
         "revisionNumber": 0,

--- a/data-serving/data-service/test/model/data/case.minimal.json
+++ b/data-serving/data-service/test/model/data/case.minimal.json
@@ -13,12 +13,13 @@
         }
     ],
     "location": {
-        "country": "China",
+        "country": "Canada",
         "geoResolution": "Country",
         "geometry": {
             "latitude": 2.3522219,
             "longitude": 48.85661400000001
-        }
+        },
+        "name": "Canada"
     },
     "revisionMetadata": {
         "revisionNumber": 0,

--- a/data-serving/data-service/test/model/data/case.minimal.json
+++ b/data-serving/data-service/test/model/data/case.minimal.json
@@ -1,6 +1,6 @@
 {
     "caseReference": {
-        "sourceId": "sourceId",
+        "sourceId": "5ea86423bae6982635d2e1f8",
         "sourceUrl": "cdc.gov"
     },
     "events": [

--- a/data-serving/data-service/test/model/data/location.minimal.json
+++ b/data-serving/data-service/test/model/data/location.minimal.json
@@ -1,6 +1,6 @@
 {
-    "place": "Kings County Hospital Center",
-    "geoResolution": "Point",
+    "country": "Canada",
+    "geoResolution": "Country",
     "geometry": {
         "latitude": 40.6809611,
         "longitude": -73.9740028

--- a/data-serving/data-service/test/model/data/location.minimal.json
+++ b/data-serving/data-service/test/model/data/location.minimal.json
@@ -4,5 +4,6 @@
     "geometry": {
         "latitude": 40.6809611,
         "longitude": -73.9740028
-    }
+    },
+    "name": "Canada"
 }

--- a/data-serving/data-service/test/model/data/location.minimal.json
+++ b/data-serving/data-service/test/model/data/location.minimal.json
@@ -1,4 +1,8 @@
 {
     "place": "Kings County Hospital Center",
-    "geo_resolution": "Point"
+    "geoResolution": "Point",
+    "geometry": {
+        "latitude": 40.6809611,
+        "longitude": -73.9740028
+    }
 }

--- a/data-serving/data-service/test/model/location.test.ts
+++ b/data-serving/data-service/test/model/location.test.ts
@@ -8,47 +8,25 @@ import mongoose from 'mongoose';
 const Location = mongoose.model<LocationDocument>('Location', locationSchema);
 
 describe('validate', () => {
-    it('empty location is invalid', async () => {
-        return new Location({}).validate((e) => {
-            expect(e.name).toBe(Error.ValidationError.name);
-        });
-    });
-
     it('a location without a geo resolution is invalid', async () => {
-        return new Location({ country: 'United States' }).validate((e) => {
+        const noGeoResolution = { ...minimalModel };
+        delete noGeoResolution.geoResolution;
+
+        return new Location(noGeoResolution).validate((e) => {
             expect(e.name).toBe(Error.ValidationError.name);
         });
     });
 
-    it('a location with only country is valid', async () => {
-        return new Location({
-            country: 'United States',
-            geoResolution: 'Country',
-        }).validate();
+    it('a location without a geometry is invalid', async () => {
+        const noGeometry = { ...minimalModel };
+        delete noGeometry.geometry;
+
+        return new Location(noGeometry).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
     });
 
-    it('a location with only administrativeAreaLevel1 is valid', async () => {
-        return new Location({
-            administrativeAreaLevel1: 'New York',
-            geoResolution: 'Admin1',
-        }).validate();
-    });
-
-    it('a location with only administrativeAreaLevel2 is valid', async () => {
-        return new Location({
-            administrativeAreaLevel2: 'Kings County',
-            geoResolution: 'Admin2',
-        }).validate();
-    });
-
-    it('a location with only administrativeAreaLevel3 is valid', async () => {
-        return new Location({
-            administrativeAreaLevel3: 'Brooklyn',
-            geoResolution: 'Admin3',
-        }).validate();
-    });
-
-    it('a latitude without a longitude is invalid', async () => {
+    it('a geometry without a longitude is invalid', async () => {
         return new Location({
             ...minimalModel,
             geometry: {
@@ -59,7 +37,7 @@ describe('validate', () => {
         });
     });
 
-    it('a longitude without a latitude is invalid', async () => {
+    it('a geometry without a latitude is invalid', async () => {
         return new Location({
             ...minimalModel,
             geometry: {
@@ -72,17 +50,5 @@ describe('validate', () => {
 
     it('a fully specified location is valid', async () => {
         return new Location(fullModel).validate();
-    });
-
-    it('validators work for embedded locations', async () => {
-        const FakeModel = mongoose.model(
-            'FakeDocument',
-            new mongoose.Schema({
-                location: locationSchema,
-            }),
-        );
-        return new FakeModel({ location: {} }).validate((e) => {
-            expect(e.name).toBe(Error.ValidationError.name);
-        });
     });
 });

--- a/data-serving/data-service/test/model/location.test.ts
+++ b/data-serving/data-service/test/model/location.test.ts
@@ -48,6 +48,10 @@ describe('validate', () => {
         });
     });
 
+    it('a minimal location is valid', async () => {
+        return new Location(minimalModel).validate();
+    });
+
     it('a fully specified location is valid', async () => {
         return new Location(fullModel).validate();
     });

--- a/data-serving/data-service/test/model/location.test.ts
+++ b/data-serving/data-service/test/model/location.test.ts
@@ -26,6 +26,15 @@ describe('validate', () => {
         });
     });
 
+    it('a location without a name is invalid', async () => {
+        const noName = { ...minimalModel };
+        delete noName.name;
+
+        return new Location(noName).validate((e) => {
+            expect(e.name).toBe(Error.ValidationError.name);
+        });
+    });
+
     it('a geometry without a longitude is invalid', async () => {
         return new Location({
             ...minimalModel,

--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -1,7 +1,7 @@
 [
     {
         "caseReference": {
-            "sourceId": "def456",
+            "sourceId": "5ea86423bae6982635d2e1f8",
             "sourceUrl": "https://www.colorado.gov/pacific/cdphe/news/10-new-presumptive-positive-cases-colorado-cdphe-confirms-limited-community-spread-covid-19"
         },
         "demographics": {

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -48,6 +48,7 @@ export function addCase(opts: {
                     latitude: 42,
                     longitude: 12,
                 },
+                name: opts.country,
             },
             events: [
                 {

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -35,7 +35,7 @@ export function addCase(opts: {
         url: '/api/cases',
         body: {
             caseReference: {
-                sourceId: 'CDC',
+                sourceId: '5ef8e943dfe6e00030892d58',
                 sourceUrl: 'www.example.com',
             },
             demographics: {

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -268,6 +268,7 @@ it('cannot edit data as a reader only', async () => {
                     latitude: 42,
                     longitude: 12,
                 },
+                name: 'France',
             },
             events: [
                 {

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -33,7 +33,7 @@ it('loads and displays cases', async () => {
                 outcome: 'Recovered',
             },
             caseReference: {
-                sourceId: 'CDC',
+                sourceId: '5ef8e943dfe6e00030892d58',
                 sourceUrl: 'www.example.com',
             },
             demographics: { ageRange: { start: 1, end: 3 } },

--- a/verification/curator-service/ui/src/components/ViewCase.test.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.test.tsx
@@ -39,7 +39,7 @@ it('loads and displays case', async () => {
             'https://www.colorado.gov/pacific/cdphe/news/10-new-presumptive-positive-cases-colorado-cdphe-confirms-limited-community-spread-covid-19',
         ),
     ).toBeInTheDocument();
-    expect(getByText('sourceId')).toBeInTheDocument();
+    expect(getByText('5ea86423bae6982635d2e1f8')).toBeInTheDocument();
     expect(getByText('twitter.com/a-tweet')).toHaveAttribute(
         'href',
         'https://twitter.com/a-tweet',

--- a/verification/curator-service/ui/src/components/fixtures/fullCase.json
+++ b/verification/curator-service/ui/src/components/fixtures/fullCase.json
@@ -1,7 +1,7 @@
 {
     "_id": "5ef8e943dfe6e00030892d58",
     "caseReference": {
-        "sourceId": "sourceId",
+        "sourceId": "5ea86423bae6982635d2e1f8",
         "sourceEntryId": "entryId",
         "sourceUrl": "https://www.colorado.gov/pacific/cdphe/news/10-new-presumptive-positive-cases-colorado-cdphe-confirms-limited-community-spread-covid-19",
         "additionalSources": [


### PR DESCRIPTION
Open to different names for `Case` vs. `NewCase` although I've seen this naming convention in OpenAPI examples. `NewCase` only modifies what's required, not the actual property defs.

![image](https://user-images.githubusercontent.com/3913264/87700928-23889780-c765-11ea-81af-59c2712d0427.png)
![image](https://user-images.githubusercontent.com/3913264/87701279-b4f80980-c765-11ea-8bdc-54534bfbcf67.png)

