### PR TITLE
Add/use an updating file upload progress spinner in the bulk upload form

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
@@ -33,7 +33,7 @@ describe('Bulk upload form', function () {
         cy.wait('@upsertCase');
         cy.wait('@upsertCase');
         cy.contains('Success! Created 2 new rows.');
-        cy.get('[data-testid="progress"]').should('not.be.visible');
+        cy.get('[data-testid="progress"]').should('not.exist');
         cy.get('button[aria-label="close overlay"').click();
 
         // Common data.
@@ -67,7 +67,7 @@ describe('Bulk upload form', function () {
         cy.get('button[data-testid="submit"]').click();
         cy.wait('@upsertCases');
         cy.contains('Success! Created 2 new rows.');
-        cy.get('[data-testid="progress"]').should('not.be.visible');
+        cy.get('[data-testid="progress"]').should('not.exist');
         cy.get('button[aria-label="close overlay"').click();
 
         cy.visit('/cases');
@@ -86,7 +86,7 @@ describe('Bulk upload form', function () {
         cy.get('button[data-testid="submit"]').click();
         cy.wait('@upsertCases');
         cy.contains('Success! Updated 2 rows.');
-        cy.get('[data-testid="progress"]').should('not.be.visible');
+        cy.get('[data-testid="progress"]').should('not.exist');
 
         cy.visit('/cases');
         // The updated case now has a gender of Female.
@@ -110,7 +110,7 @@ describe('Bulk upload form', function () {
         cy.wait('@upsertCase');
         cy.wait('@upsertCase');
         cy.contains('Success! Created 3 new rows.');
-        cy.get('[data-testid="progress"]').should('not.be.visible');
+        cy.get('[data-testid="progress"]').should('not.exist');
         cy.get('button[aria-label="close overlay"').click();
 
         cy.visit('/cases');

--- a/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
@@ -33,6 +33,7 @@ describe('Bulk upload form', function () {
         cy.wait('@upsertCase');
         cy.wait('@upsertCase');
         cy.contains('Success! Created 2 new rows.');
+        cy.get('[data-testid="progress"]').should('not.be.visible');
         cy.get('button[aria-label="close overlay"').click();
 
         // Common data.
@@ -66,6 +67,7 @@ describe('Bulk upload form', function () {
         cy.get('button[data-testid="submit"]').click();
         cy.wait('@upsertCases');
         cy.contains('Success! Created 2 new rows.');
+        cy.get('[data-testid="progress"]').should('not.be.visible');
         cy.get('button[aria-label="close overlay"').click();
 
         cy.visit('/cases');
@@ -84,6 +86,7 @@ describe('Bulk upload form', function () {
         cy.get('button[data-testid="submit"]').click();
         cy.wait('@upsertCases');
         cy.contains('Success! Updated 2 rows.');
+        cy.get('[data-testid="progress"]').should('not.be.visible');
 
         cy.visit('/cases');
         // The updated case now has a gender of Female.
@@ -107,6 +110,7 @@ describe('Bulk upload form', function () {
         cy.wait('@upsertCase');
         cy.wait('@upsertCase');
         cy.contains('Success! Created 3 new rows.');
+        cy.get('[data-testid="progress"]').should('not.be.visible');
         cy.get('button[aria-label="close overlay"').click();
 
         cy.visit('/cases');

--- a/verification/curator-service/ui/src/components/BulkCaseForm.test.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.test.tsx
@@ -88,6 +88,6 @@ it('displays spinner post upload', async () => {
 
     fireEvent.change(inputField);
     fireEvent.click(getByText(/Upload cases/));
-    expect(getByTestId('cap-progress')).toBeInTheDocument();
-    waitForElementToBeRemoved(() => getByTestId('cap-progress'));
+    expect(getByTestId('progress')).toBeInTheDocument();
+    waitForElementToBeRemoved(() => getByTestId('progress'));
 });

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -10,6 +10,7 @@ import Alert from '@material-ui/lab/Alert';
 import AppModal from './AppModal';
 import CaseValidationError from './bulk-case-form-fields/CaseValidationError';
 import FileUpload from './bulk-case-form-fields/FileUpload';
+import FileUploadProgress from './bulk-case-form-fields/FileUploadProgress';
 import React from 'react';
 import Source from './common-form-fields/Source';
 import ValidationErrorList from './bulk-case-form-fields/ValidationErrorList';
@@ -40,6 +41,13 @@ const styles = () =>
             marginTop: '2em',
             maxWidth: '80%',
         },
+        uploadButton: {
+            marginRight: '2em',
+        },
+        uploadDiv: {
+            display: 'flex',
+            alignItems: 'center',
+        },
     });
 
 interface BulkCaseFormProps extends WithStyles<typeof styles> {
@@ -51,6 +59,8 @@ interface BulkCaseFormState {
     errorMessage: string;
     successMessage: string;
     errors: CaseValidationError[];
+    uploadProgress: number;
+    uploadTotalRequests: number;
 }
 
 interface BulkCaseFormValues {
@@ -134,6 +144,8 @@ class BulkCaseForm extends React.Component<
             errorMessage: '',
             successMessage: '',
             errors: [],
+            uploadProgress: 0,
+            uploadTotalRequests: 0,
         };
     }
 
@@ -256,6 +268,30 @@ class BulkCaseForm extends React.Component<
         };
     }
 
+    incrementProgress(): void {
+        const incrementPercent = 100 / this.state.uploadTotalRequests;
+        this.setState({
+            uploadProgress: this.state.uploadProgress + incrementPercent,
+        });
+    }
+
+    /**
+     * Determine the number of remote requests required to upload the provided
+     * row.
+     *
+     * Each row is validated, accounting for one request, and incurs a further
+     * `caseCount` requests to write rows to the server.
+     */
+    getUploadTotalRequests(cases: CompleteParsedCase[]): number {
+        return cases
+            .map((c) => {
+                return 1 + (c.caseCount ? c.caseCount : 1);
+            })
+            .reduce((accumulator, currentValue) => {
+                return accumulator + currentValue;
+            }, 0);
+    }
+
     upsertCase(c: CompleteParsedCase): Promise<AxiosResponse<Case>> {
         return axios.put('/api/cases', c);
     }
@@ -278,6 +314,7 @@ class BulkCaseForm extends React.Component<
                     new CaseValidationError(i + 1, e.response.data),
                 );
             }
+            this.incrementProgress();
         }
         return validationErrors;
     }
@@ -307,6 +344,9 @@ class BulkCaseForm extends React.Component<
                 caseReference,
             );
         });
+        this.setState({
+            uploadTotalRequests: this.getUploadTotalRequests(cases),
+        });
         const validationErrors = await this.validateCases(cases);
         this.setState({ errors: validationErrors });
         if (validationErrors.length > 0) {
@@ -324,6 +364,7 @@ class BulkCaseForm extends React.Component<
                 const casesToUpsert = c.caseCount ? c.caseCount : 1;
                 for (let i = 0; i < casesToUpsert; i++) {
                     const response = await this.upsertCase(c);
+                    this.incrementProgress();
                     response.status === 201 ? created++ : updated++;
                 }
             } catch (e) {
@@ -344,21 +385,26 @@ class BulkCaseForm extends React.Component<
         });
     }
 
-    async submitCases(values: BulkCaseFormValues): Promise<void> {
-        if (values.file) {
-            const papaparseOptions: ParseConfig<RawParsedCase> = {
-                complete: (results) => {
-                    // CaseReference is required per form validation.
-                    // But, Typescript doesn't know that.
-                    if (values.caseReference) {
-                        this.uploadData(results, values.caseReference);
-                    }
-                },
-                dynamicTyping: true,
-                header: true,
-                skipEmptyLines: true,
+    async submitCases(values: BulkCaseFormValues): Promise<unknown> {
+        if (values.file && values.caseReference) {
+            const parsePromise = (
+                file: File,
+                caseReference: CaseReference,
+            ): Promise<unknown> => {
+                return new Promise((resolve) => {
+                    const papaparseOptions: ParseConfig<RawParsedCase> = {
+                        complete: async (results) => {
+                            await this.uploadData(results, caseReference);
+                            resolve();
+                        },
+                        dynamicTyping: true,
+                        header: true,
+                        skipEmptyLines: true,
+                    };
+                    Papa.parse(file, papaparseOptions);
+                });
             };
-            Papa.parse(values.file, papaparseOptions);
+            return parsePromise(values.file, values.caseReference);
         }
     }
 
@@ -373,9 +419,9 @@ class BulkCaseForm extends React.Component<
                     validationSchema={BulkFormSchema}
                     validateOnChange={false}
                     initialValues={{ file: null, caseReference: undefined }}
-                    onSubmit={(values): Promise<void> =>
-                        this.submitCases(values)
-                    }
+                    onSubmit={async (values): Promise<void> => {
+                        await this.submitCases(values);
+                    }}
                 >
                     {({ isSubmitting, submitForm, values }): JSX.Element => (
                         <div className={classes.container}>
@@ -388,15 +434,23 @@ class BulkCaseForm extends React.Component<
                                 <div className={classes.formSection}>
                                     <FileUpload></FileUpload>
                                 </div>
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    data-testid="submit"
-                                    disabled={isSubmitting}
-                                    onClick={submitForm}
-                                >
-                                    Upload cases
-                                </Button>
+                                <div className={classes.uploadDiv}>
+                                    <Button
+                                        className={classes.uploadButton}
+                                        variant="contained"
+                                        color="primary"
+                                        data-testid="submit"
+                                        disabled={isSubmitting}
+                                        onClick={submitForm}
+                                    >
+                                        Upload cases
+                                    </Button>
+                                    {isSubmitting && (
+                                        <FileUploadProgress
+                                            value={this.state.uploadProgress}
+                                        />
+                                    )}
+                                </div>
                                 {this.state.errors.length > 0 && (
                                     <ValidationErrorList
                                         errors={this.state.errors}

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -10,7 +10,7 @@ import Alert from '@material-ui/lab/Alert';
 import AppModal from './AppModal';
 import CaseValidationError from './bulk-case-form-fields/CaseValidationError';
 import FileUpload from './bulk-case-form-fields/FileUpload';
-import FileUploadProgress from './bulk-case-form-fields/FileUploadProgress';
+import CaptionedProgress from './bulk-case-form-fields/CaptionedProgress';
 import React from 'react';
 import Source from './common-form-fields/Source';
 import ValidationErrorList from './bulk-case-form-fields/ValidationErrorList';
@@ -446,7 +446,7 @@ class BulkCaseForm extends React.Component<
                                         Upload cases
                                     </Button>
                                     {isSubmitting && (
-                                        <FileUploadProgress
+                                        <CaptionedProgress
                                             data-testid="progress"
                                             value={this.state.uploadProgress}
                                         />

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -447,6 +447,7 @@ class BulkCaseForm extends React.Component<
                                     </Button>
                                     {isSubmitting && (
                                         <FileUploadProgress
+                                            data-testid="progress"
                                             value={this.state.uploadProgress}
                                         />
                                     )}

--- a/verification/curator-service/ui/src/components/bulk-case-form-fields/CaptionedProgress.tsx
+++ b/verification/curator-service/ui/src/components/bulk-case-form-fields/CaptionedProgress.tsx
@@ -10,7 +10,11 @@ export default function FileUploadProgress(
     props: CircularProgressProps & { value: number },
 ): JSX.Element {
     return (
-        <Box position="relative" display="inline-flex">
+        <Box
+            position="relative"
+            data-testid="cap-progress"
+            display="inline-flex"
+        >
             <CircularProgress {...props} />
             <Box
                 top={0}

--- a/verification/curator-service/ui/src/components/bulk-case-form-fields/CaptionedProgress.tsx
+++ b/verification/curator-service/ui/src/components/bulk-case-form-fields/CaptionedProgress.tsx
@@ -10,11 +10,7 @@ export default function FileUploadProgress(
     props: CircularProgressProps & { value: number },
 ): JSX.Element {
     return (
-        <Box
-            position="relative"
-            data-testid="cap-progress"
-            display="inline-flex"
-        >
+        <Box position="relative" display="inline-flex">
             <CircularProgress {...props} />
             <Box
                 top={0}

--- a/verification/curator-service/ui/src/components/bulk-case-form-fields/FileUploadProgress.tsx
+++ b/verification/curator-service/ui/src/components/bulk-case-form-fields/FileUploadProgress.tsx
@@ -1,0 +1,33 @@
+import CircularProgress, {
+    CircularProgressProps,
+} from '@material-ui/core/CircularProgress';
+
+import Box from '@material-ui/core/Box';
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+export default function FileUploadProgress(
+    props: CircularProgressProps & { value: number },
+): JSX.Element {
+    return (
+        <Box position="relative" display="inline-flex">
+            <CircularProgress {...props} />
+            <Box
+                top={0}
+                left={0}
+                bottom={0}
+                right={0}
+                position="absolute"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+            >
+                <Typography
+                    variant="caption"
+                    component="div"
+                    color="textSecondary"
+                >{`${Math.round(props.value)}%`}</Typography>
+            </Box>
+        </Box>
+    );
+}


### PR DESCRIPTION
Re: #573.

Wrote this earlier today, prior to the mock, but it should be quite simple to tweak/move this into position when we move the upload button(s). Including a bit of testing here, but since our server requests are real rather than stubbed in Cypress, it's a bit non-trivial.

![spinner](https://user-images.githubusercontent.com/63060924/87739935-02e52f80-c7af-11ea-8893-b9299ee2944e.gif)

Includes a small change to awaiting form submission results/handling `isSubmitted` in order to get the right behavior during upload.