### PR TITLE
Make location display component form-ready

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
@@ -194,10 +194,18 @@ describe('Curator', function () {
             cy.contains('Albanian');
 
             // Location.
-            cy.contains('France');
-            cy.contains('Country');
-            cy.contains('45.75');
-            cy.contains('4.84');
+            cy.get('input[name="location.country"]').should(
+                'have.value',
+                'France',
+            );
+            cy.get('input[name="location.geometry.latitude"]').should(
+                'have.value',
+                '45.75889',
+            );
+            cy.get('input[name="location.geometry.longitude"]').should(
+                'have.value',
+                '4.84139',
+            );
             // Events.
             cy.get('input[name="onsetSymptomsDate"]').should(
                 'have.value',
@@ -289,6 +297,7 @@ describe('Curator', function () {
             cy.contains('Afghan, Albanian');
             cy.contains('Asian');
             cy.contains('France');
+            // Rounded numbers when displayed.
             cy.contains('45.7589');
             cy.contains('4.8414');
             // Events.

--- a/verification/curator-service/ui/src/components/EditCase.test.tsx
+++ b/verification/curator-service/ui/src/components/EditCase.test.tsx
@@ -74,12 +74,12 @@ it('loads and displays case to edit', async () => {
     ).toBeInTheDocument();
     expect(getByDisplayValue('NC_045512.2')).toBeInTheDocument();
     expect(getByDisplayValue('33000')).toBeInTheDocument();
-    expect(getByText('France')).toBeInTheDocument();
-    expect(getByText('Île-de-F')).toBeInTheDocument();
-    expect(getByText('Paris')).toBeInTheDocument();
+    expect(getByDisplayValue('France')).toBeInTheDocument();
+    expect(getByDisplayValue('Île-de-F')).toBeInTheDocument();
+    expect(getByDisplayValue('Paris')).toBeInTheDocument();
     expect(getByDisplayValue('Recovered')).toBeInTheDocument();
     expect(getByText('Severe pneumonia')).toBeInTheDocument();
-    expect(getByText('United States')).toBeInTheDocument();
+    expect(getByDisplayValue('United States')).toBeInTheDocument();
     expect(getByDisplayValue('Family')).toBeInTheDocument();
     // TODO: These show up locally but we need to figure out how to properly
     // query them in tests.

--- a/verification/curator-service/ui/src/components/StaticMap.tsx
+++ b/verification/curator-service/ui/src/components/StaticMap.tsx
@@ -1,10 +1,10 @@
-import { Location } from './Case';
+import { Geometry } from './Case';
 import React from 'react';
 
-export default function StaticMap(props: { location: Location }): JSX.Element {
+export default function StaticMap(props: { geometry: Geometry }): JSX.Element {
     return (
         <img
-            src={`https://api.mapbox.com/styles/v1/mapbox/light-v10/static/${props.location?.geometry?.longitude},${props.location?.geometry?.latitude},5,0/450x200?access_token=${process.env.REACT_APP_PUBLIC_MAPBOX_TOKEN}`}
+            src={`https://api.mapbox.com/styles/v1/mapbox/light-v10/static/${props.geometry.longitude},${props.geometry.latitude},5,0/450x200?access_token=${process.env.REACT_APP_PUBLIC_MAPBOX_TOKEN}`}
             alt="map"
         ></img>
     );

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -527,7 +527,9 @@ function TravelRow(props: { travel: Travel }): JSX.Element {
 function MapRow(props: { location?: Location }): JSX.Element {
     return (
         <Grid item xs={8}>
-            {props.location && <StaticMap location={props.location} />}
+            {props.location?.geometry && (
+                <StaticMap geometry={props.location.geometry} />
+            )}
         </Grid>
     );
 }

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.test.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.test.tsx
@@ -1,37 +1,35 @@
-import { render, screen } from '@testing-library/react';
+import { Form, Formik } from 'formik';
 
 import Location from './Location';
 import React from 'react';
+import { render } from '@testing-library/react';
 
 test('shows location when passed location information', async () => {
-    render(
-        <Location
-            location={{
-                geoResolution: 'place',
-                country: 'United States',
-                administrativeAreaLevel1: 'Hillsborough County',
-                administrativeAreaLevel2: '',
-                administrativeAreaLevel3: 'Some city',
-                geometry: {
-                    latitude: 80.45,
-                    longitude: 27.9379,
-                },
-                name: 'some name',
-                place: '',
-            }}
-        />,
+    const loc: Loc = {
+        geoResolution: 'place',
+        country: 'United States',
+        administrativeAreaLevel1: 'Hillsborough County',
+        administrativeAreaLevel2: '',
+        administrativeAreaLevel3: 'Some city',
+        geometry: {
+            latitude: 80.45,
+            longitude: 27.9379,
+        },
+        name: 'some name',
+        place: '',
+    };
+    const { getByDisplayValue } = render(
+        <Formik initialValues={{ location: loc }}>
+            <Form>
+                <Location locationPath="location" geometry={loc.geometry} />
+            </Form>
+        </Formik>,
     );
-    expect(screen.getByText(/place/i)).toBeInTheDocument();
-    expect(screen.getByText(/united States/i)).toBeInTheDocument();
-    expect(screen.getByText(/Hillsborough County/i)).toBeInTheDocument();
-    expect(screen.getByText(/Some city/i)).toBeInTheDocument();
-    expect(screen.getByText(/place/i)).toBeInTheDocument();
-    expect(screen.getByText(/80.4500/i)).toBeInTheDocument();
-    expect(screen.getByText(/27.9379/i)).toBeInTheDocument();
-    expect(screen.getByText(/N\/A/i)).toBeInTheDocument();
-});
-
-test('shows empty defaults when location undefined', async () => {
-    render(<Location location={undefined} />);
-    expect(screen.getByText(/Country/i)).toBeInTheDocument();
+    expect(getByDisplayValue(/place/i)).toBeInTheDocument();
+    expect(getByDisplayValue(/united States/i)).toBeInTheDocument();
+    expect(getByDisplayValue(/Hillsborough County/i)).toBeInTheDocument();
+    expect(getByDisplayValue(/Some city/i)).toBeInTheDocument();
+    expect(getByDisplayValue(/place/i)).toBeInTheDocument();
+    expect(getByDisplayValue(/80.45/i)).toBeInTheDocument();
+    expect(getByDisplayValue(/27.9379/i)).toBeInTheDocument();
 });

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -1,8 +1,9 @@
-import { Divider, Typography } from '@material-ui/core';
-
-import { Location as Loc } from '../Case';
+import { Divider } from '@material-ui/core';
+import { Field } from 'formik';
+import { Geometry } from '../Case';
 import React from 'react';
 import StaticMap from '../StaticMap';
+import { TextField } from 'formik-material-ui';
 import { makeStyles } from '@material-ui/core/styles';
 
 const styles = makeStyles(() => ({
@@ -10,73 +11,110 @@ const styles = makeStyles(() => ({
         display: 'flex',
         flexWrap: 'wrap',
     },
-    column: {
+    field: {
         marginRight: '1em',
+        width: '8em',
     },
     mapContainer: {
         textAlign: 'center',
     },
     divider: {
+        marginTop: '1em',
         marginBottom: '1em',
     },
 }));
 
-export default function Location(props: { location?: Loc }): JSX.Element {
+export default function Location(props: {
+    locationPath: string;
+    geometry?: Geometry;
+}): JSX.Element {
     const classes = styles();
     return (
         <>
             <div className={classes.root}>
-                <div className={classes.column}>
-                    <p>
-                        <Typography variant="caption">Location Type</Typography>
-                    </p>
-                    <p>{props.location?.geoResolution}</p>
-                </div>
-                <div className={classes.column}>
-                    <p>
-                        <Typography variant="caption">Country</Typography>
-                    </p>
-                    <p>{props.location?.country}</p>
-                </div>
-                <div className={classes.column}>
-                    <p>
-                        <Typography variant="caption">Admin area 1</Typography>
-                    </p>
-                    <p>{props.location?.administrativeAreaLevel1 || 'N/A'}</p>
-                </div>
-                <div className={classes.column}>
-                    <p>
-                        <Typography variant="caption">Admin area 2</Typography>
-                    </p>
-                    <p>{props.location?.administrativeAreaLevel2 || 'N/A'}</p>
-                </div>
-                <div className={classes.column}>
-                    <p>
-                        <Typography variant="caption">Admin area 3</Typography>
-                    </p>
-                    <p>{props.location?.administrativeAreaLevel3 || 'N/A'}</p>
-                </div>
-                <div className={classes.column}>
-                    <p>
-                        <Typography variant="caption">Latitude</Typography>
-                    </p>
-                    <p>
-                        {props.location?.geometry?.latitude?.toFixed(4) || '-'}
-                    </p>
-                </div>
-                <div className={classes.column}>
-                    <p>
-                        <Typography variant="caption">Longitude</Typography>
-                    </p>
-                    <p>
-                        {props.location?.geometry?.longitude?.toFixed(4) || '-'}
-                    </p>
-                </div>
+                <Field
+                    className={classes.field}
+                    disabled
+                    label="Location type"
+                    size="small"
+                    name={`${props.locationPath}.geoResolution`}
+                    type="text"
+                    component={TextField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                />
+                <Field
+                    className={classes.field}
+                    disabled
+                    label="Country"
+                    name={`${props.locationPath}.country`}
+                    type="text"
+                    component={TextField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                />
+                <Field
+                    className={classes.field}
+                    disabled
+                    label="Admin area 1"
+                    name={`${props.locationPath}.administrativeAreaLevel1`}
+                    type="text"
+                    component={TextField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                />
+                <Field
+                    className={classes.field}
+                    disabled
+                    label="Admin area 2"
+                    name={`${props.locationPath}.administrativeAreaLevel2`}
+                    type="text"
+                    component={TextField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                />
+                <Field
+                    className={classes.field}
+                    disabled
+                    label="Admin area 3"
+                    name={`${props.locationPath}.administrativeAreaLevel3`}
+                    type="text"
+                    component={TextField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                />
+                <Field
+                    className={classes.field}
+                    disabled
+                    label="Latitude"
+                    name={`${props.locationPath}.geometry.latitude`}
+                    type="number"
+                    component={TextField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                />
+                <Field
+                    className={classes.field}
+                    disabled
+                    label="Longitude"
+                    name={`${props.locationPath}.geometry.longitude`}
+                    type="number"
+                    component={TextField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                />
             </div>
-            {props.location?.geometry !== undefined && (
+            {props.geometry && (
                 <div className={classes.mapContainer}>
                     <Divider className={classes.divider} variant="middle" />
-                    <StaticMap location={props.location}></StaticMap>
+                    <StaticMap geometry={props.geometry}></StaticMap>
                 </div>
             )}
         </>

--- a/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
@@ -26,7 +26,12 @@ function LocationForm(): JSX.Element {
                     name="location"
                     required
                 />
-                {values.location && <Location location={values.location} />}
+                {values.location && (
+                    <Location
+                        locationPath="location"
+                        geometry={values.location?.geometry}
+                    />
+                )}
             </fieldset>
         </Scroll.Element>
     );

--- a/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
@@ -118,8 +118,13 @@ export default function Events(): JSX.Element {
                                                         ></PlacesAutocomplete>
                                                         {travelHistoryElement.location && (
                                                             <Location
-                                                                location={
-                                                                    travelHistoryElement.location
+                                                                locationPath={`travelHistory[${index}].location`}
+                                                                geometry={
+                                                                    values
+                                                                        .travelHistory[
+                                                                        index
+                                                                    ]?.location
+                                                                        ?.geometry
                                                                 }
                                                             ></Location>
                                                         )}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1255432/87944659-f9561300-ca9f-11ea-94f4-2fda46b14f27.png)

This is paving the way to making the fields editable in case mapbox doesn't have the full data or no data at all. Cf #572 #426 

Plans for future PRs are to add an always-present suggestion to the places autocomplete that says "add my own geocode" that will populate an empty Location and make these fields editable.

We did lose the formatting of N/A when no data is present for some admin levels but it feels cleaner considering we want to allow curators to enter those manually now.

Also not rounding the lat/lng numbers anymore because they are used as input fields (they are still rounded in the display case component)