### PR TITLE
Add a batchUpsert endpoint in the curator service case API.

### DIFF
--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -244,6 +244,25 @@ paths:
           $ref: "#/components/responses/422"
         "500":
           $ref: "#/components/responses/500"
+  /cases/batchUpsert:
+    post:
+      tags: [Case]
+      summary: Upserts multiple cases
+      operationId: batchUpsertCase
+      requestBody:
+        description: Cases to upsert
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CaseArray"
+      responses:
+        "200":
+          $ref: "#/components/responses/200BatchCaseUpsert"
+        "207":
+          $ref: "#/components/responses/207BatchCaseUpsert"
+        "500":
+          $ref: "#/components/responses/500"
   /cases/{id}:
     parameters:
       - name: id
@@ -435,7 +454,56 @@ components:
       type: array
       items:
         $ref: "#components/schemas/Location"
+    BatchCaseUpsertResponse:
+      description: Response to batch upsert case API requests
+      properties:
+        phase:
+          type: string
+          description: The last operation completed by the server
+          enum:
+            - GEOCODE
+            - VALIDATE
+            - UPSERT
+        numUpserted:
+          type: integer
+          description: The number of cases upserted by the server
+          format: int32
+          minimum: 0
+        numErrors:
+          type: integer
+          description: The number of cases found to have errors
+          format: int32
+          minimum: 0
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              index:
+                type: integer
+              message:
+                type: string
+            required:
+              - index
+              - message
+      required:
+        - phase
+        - numUpserted
+        - numErrors
+        - errors
   responses:
+    "200BatchCaseUpsert":
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BatchCaseUpsertResponse"
+    "207BatchCaseUpsert":
+      description: Multi-Status
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BatchCaseUpsertResponse"
     "200Case":
       description: OK
       content:

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -151,6 +151,8 @@ export default class CasesController {
             }
 
             // 3. Upsert each case.
+            // Consider adding a batchUpsert endpoint on the data service if
+            // this slows us down too much.
             for (let index = 0; index < req.body.cases.length; index++) {
                 const c = req.body.cases[index];
                 await axios.put(this.dataServerURL + '/api/cases', c);

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -128,7 +128,7 @@ export default class CasesController {
             if (geocodeErrors.length > 0) {
                 res.status(207).send({
                     phase: 'GEOCODE',
-                    numCreated: 0,
+                    numUpserted: 0,
                     numErrors: geocodeErrors.length,
                     errors: geocodeErrors,
                 });
@@ -143,7 +143,7 @@ export default class CasesController {
             if (validationResponse.data.errors.length > 0) {
                 res.status(207).send({
                     phase: 'VALIDATE',
-                    numCreated: 0,
+                    numUpserted: 0,
                     numErrors: validationResponse.data.errors.length,
                     errors: validationResponse.data.errors,
                 });
@@ -159,7 +159,7 @@ export default class CasesController {
             }
             res.status(200).send({
                 phase: 'UPSERT',
-                numCreated: req.body.cases.length,
+                numUpserted: req.body.cases.length,
                 numErrors: 0,
                 errors: [],
             });

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -204,6 +204,10 @@ export default class CasesController {
      *
      * @returns {boolean} Whether lat lng were either provided or geocoded
      */
+    // For batch requests, the case body is nested.
+    // While we could define a type here, the right change is probably to use a
+    // batch geocoding API for such cases.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private async geocode(req: Request | any): Promise<boolean> {
         // Geocode query if no lat lng were provided.
         const location = req.body['location'];
@@ -274,8 +278,9 @@ export default class CasesController {
                         index: index,
                         message: err.message,
                     });
+                } else {
+                    throw err;
                 }
-                throw err;
             }
         }
         return geocodeErrors;

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -170,6 +170,11 @@ apiRouter.get(
     casesController.get,
 );
 apiRouter.post('/cases', mustHaveAnyRole(['curator']), casesController.create);
+apiRouter.post(
+    '/cases/batchUpsert',
+    mustHaveAnyRole(['curator']),
+    casesController.batchUpsert,
+);
 apiRouter.put('/cases', mustHaveAnyRole(['curator']), casesController.upsert);
 apiRouter.put(
     '/cases/:id([a-z0-9]{24})',

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -278,7 +278,7 @@ describe('Cases', () => {
                     },
                     {
                         age: '42',
-                        location: { query: 'Lyon' },
+                        location: {},
                     },
                     {
                         age: '42',
@@ -294,7 +294,11 @@ describe('Cases', () => {
         expect(res.body.numErrors).toBe(2);
         expect(res.body.phase).toBe('GEOCODE');
         expect(res.body.errors).toEqual([
-            { index: 1, message: 'no geolocation found for Lyon' },
+            {
+                index: 1,
+                message:
+                    'location.query must be specified to be able to geocode',
+            },
             { index: 2, message: 'no geolocation found for Lyon' },
         ]);
     });

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -250,7 +250,7 @@ describe('Cases', () => {
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.put).toHaveBeenCalledTimes(2);
-        expect(res.body.numCreated).toBe(2);
+        expect(res.body.numUpserted).toBe(2);
         expect(res.body.numErrors).toBe(0);
         expect(res.body.phase).toBe('UPSERT');
         expect(res.body.errors).toHaveLength(0);
@@ -290,7 +290,7 @@ describe('Cases', () => {
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).not.toHaveBeenCalled();
         expect(mockedAxios.put).not.toHaveBeenCalled();
-        expect(res.body.numCreated).toBe(0);
+        expect(res.body.numUpserted).toBe(0);
         expect(res.body.numErrors).toBe(2);
         expect(res.body.phase).toBe('GEOCODE');
         expect(res.body.errors).toEqual([
@@ -345,7 +345,7 @@ describe('Cases', () => {
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.put).not.toHaveBeenCalled();
-        expect(res.body.numCreated).toBe(0);
+        expect(res.body.numUpserted).toBe(0);
         expect(res.body.numErrors).toBe(2);
         expect(res.body.phase).toBe('VALIDATE');
         expect(res.body.errors).toEqual(validationErrors);


### PR DESCRIPTION
Re: #571 

This was a little tricky, due to geocoding happening on the curator service, but I think this is the best balance of clarity and efficiency. It might be somewhat better if we moved geocoding to the data service, but that's a separate thread. For now, orchestrating this work in the curator service API, taking advantage of the batchValidate endpoint I'd added to the data service API.

The plan is to migrate the bulk upload UI to use this endpoint, and likely to use it from parsing functions as well. I think this should more or less fix the aforementioned issue (since the bulk of the slowdown seemed to be network latency between clients/our server), but there are a couple TODOs with improvements should we need them.