### PR TITLE
Make location fields editable

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
@@ -50,6 +50,8 @@ describe('Curator', function () {
         cy.get('div[data-testid="location"]').type('France');
         cy.contains('France');
         cy.contains('li', 'France').click();
+        // Change France to something else to check we can edit geocode results.
+        cy.get('input[name="location.country"]').clear().type('Frankreich');
         cy.get('input[name="confirmedDate"]').type('2020-01-01');
         cy.get('div[data-testid="methodOfConfirmation"]').click();
         cy.get('li[data-value="PCR test"').click();
@@ -160,7 +162,7 @@ describe('Curator', function () {
             cy.contains('Asian');
             cy.contains('Afghan, Albanian');
             cy.contains('Accountant');
-            cy.contains('France');
+            cy.contains('Frankreich');
             cy.contains('1/1/2020');
             cy.contains('dry cough, mild fever');
             cy.contains('Airborne infection');
@@ -195,7 +197,7 @@ describe('Curator', function () {
             // Location.
             cy.get('input[name="location.country"]').should(
                 'have.value',
-                'France',
+                'Frankreich',
             );
             cy.get('input[name="location.geometry.latitude"]').should(
                 'have.value',
@@ -295,7 +297,7 @@ describe('Curator', function () {
             cy.contains('Accountant');
             cy.contains('Afghan, Albanian');
             cy.contains('Asian');
-            cy.contains('France');
+            cy.contains('Frankreich');
             // Rounded numbers when displayed.
             cy.contains('45.7589');
             cy.contains('4.8414');

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.test.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.test.tsx
@@ -1,12 +1,13 @@
 import { Form, Formik } from 'formik';
 
+import { Location as Loc } from '../Case';
 import Location from './Location';
 import React from 'react';
 import { render } from '@testing-library/react';
 
 test('shows location when passed location information', async () => {
     const loc: Loc = {
-        geoResolution: 'place',
+        geoResolution: 'Admin3',
         country: 'United States',
         administrativeAreaLevel1: 'Hillsborough County',
         administrativeAreaLevel2: '',
@@ -25,11 +26,10 @@ test('shows location when passed location information', async () => {
             </Form>
         </Formik>,
     );
-    expect(getByDisplayValue(/place/i)).toBeInTheDocument();
+    expect(getByDisplayValue(/Admin3/i)).toBeInTheDocument();
     expect(getByDisplayValue(/united States/i)).toBeInTheDocument();
     expect(getByDisplayValue(/Hillsborough County/i)).toBeInTheDocument();
     expect(getByDisplayValue(/Some city/i)).toBeInTheDocument();
-    expect(getByDisplayValue(/place/i)).toBeInTheDocument();
     expect(getByDisplayValue(/80.45/i)).toBeInTheDocument();
     expect(getByDisplayValue(/27.9379/i)).toBeInTheDocument();
 });

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -1,5 +1,5 @@
 import { Divider } from '@material-ui/core';
-import { Field } from 'formik';
+import { FastField } from 'formik';
 import { Geometry } from '../Case';
 import React from 'react';
 import StaticMap from '../StaticMap';
@@ -32,11 +32,12 @@ export default function Location(props: {
     return (
         <>
             <div className={classes.root}>
-                <Field
+                <FastField
                     className={classes.field}
                     disabled
                     label="Location type"
                     size="small"
+                    required
                     name={`${props.locationPath}.geoResolution`}
                     type="text"
                     component={TextField}
@@ -44,18 +45,19 @@ export default function Location(props: {
                         shrink: true,
                     }}
                 />
-                <Field
+                <FastField
                     className={classes.field}
                     disabled
                     label="Country"
                     name={`${props.locationPath}.country`}
                     type="text"
+                    required
                     component={TextField}
                     InputLabelProps={{
                         shrink: true,
                     }}
                 />
-                <Field
+                <FastField
                     className={classes.field}
                     disabled
                     label="Admin area 1"
@@ -66,7 +68,7 @@ export default function Location(props: {
                         shrink: true,
                     }}
                 />
-                <Field
+                <FastField
                     className={classes.field}
                     disabled
                     label="Admin area 2"
@@ -77,7 +79,7 @@ export default function Location(props: {
                         shrink: true,
                     }}
                 />
-                <Field
+                <FastField
                     className={classes.field}
                     disabled
                     label="Admin area 3"
@@ -88,23 +90,25 @@ export default function Location(props: {
                         shrink: true,
                     }}
                 />
-                <Field
+                <FastField
                     className={classes.field}
                     disabled
                     label="Latitude"
                     name={`${props.locationPath}.geometry.latitude`}
                     type="number"
+                    required
                     component={TextField}
                     InputLabelProps={{
                         shrink: true,
                     }}
                 />
-                <Field
+                <FastField
                     className={classes.field}
                     disabled
                     label="Longitude"
                     name={`${props.locationPath}.geometry.longitude`}
                     type="number"
+                    required
                     component={TextField}
                     InputLabelProps={{
                         shrink: true,

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -1,9 +1,12 @@
-import { Divider } from '@material-ui/core';
+import { Divider, MenuItem } from '@material-ui/core';
+import { Select, TextField } from 'formik-material-ui';
+
 import { FastField } from 'formik';
+import FormControl from '@material-ui/core/FormControl';
 import { Geometry } from '../Case';
+import InputLabel from '@material-ui/core/InputLabel';
 import React from 'react';
 import StaticMap from '../StaticMap';
-import { TextField } from 'formik-material-ui';
 import { makeStyles } from '@material-ui/core/styles';
 
 const styles = makeStyles(() => ({
@@ -32,22 +35,29 @@ export default function Location(props: {
     return (
         <>
             <div className={classes.root}>
+                <FormControl className={classes.field}>
+                    <InputLabel htmlFor={`${props.locationPath}.geoResolution`}>
+                        Geo resolution
+                    </InputLabel>
+                    <FastField
+                        as="select"
+                        id={`${props.locationPath}.geoResolution`}
+                        name={`${props.locationPath}.geoResolution`}
+                        type="text"
+                        component={Select}
+                    >
+                        {['Point', 'Admin3', 'Admin2', 'Admin1', 'Country'].map(
+                            (res) => (
+                                <MenuItem key={res} value={res}>
+                                    {res}
+                                </MenuItem>
+                            ),
+                        )}
+                    </FastField>
+                </FormControl>
+
                 <FastField
                     className={classes.field}
-                    disabled
-                    label="Location type"
-                    size="small"
-                    required
-                    name={`${props.locationPath}.geoResolution`}
-                    type="text"
-                    component={TextField}
-                    InputLabelProps={{
-                        shrink: true,
-                    }}
-                />
-                <FastField
-                    className={classes.field}
-                    disabled
                     label="Country"
                     name={`${props.locationPath}.country`}
                     type="text"
@@ -59,7 +69,6 @@ export default function Location(props: {
                 />
                 <FastField
                     className={classes.field}
-                    disabled
                     label="Admin area 1"
                     name={`${props.locationPath}.administrativeAreaLevel1`}
                     type="text"
@@ -70,7 +79,6 @@ export default function Location(props: {
                 />
                 <FastField
                     className={classes.field}
-                    disabled
                     label="Admin area 2"
                     name={`${props.locationPath}.administrativeAreaLevel2`}
                     type="text"
@@ -81,7 +89,6 @@ export default function Location(props: {
                 />
                 <FastField
                     className={classes.field}
-                    disabled
                     label="Admin area 3"
                     name={`${props.locationPath}.administrativeAreaLevel3`}
                     type="text"
@@ -92,7 +99,6 @@ export default function Location(props: {
                 />
                 <FastField
                     className={classes.field}
-                    disabled
                     label="Latitude"
                     name={`${props.locationPath}.geometry.latitude`}
                     type="number"
@@ -104,7 +110,6 @@ export default function Location(props: {
                 />
                 <FastField
                     className={classes.field}
-                    disabled
                     label="Longitude"
                     name={`${props.locationPath}.geometry.longitude`}
                     type="number"


### PR DESCRIPTION
This enables curators to manually add missing admin levels for example.

Temporary unblock #426.

This PR follows #595.

![image](https://user-images.githubusercontent.com/1255432/88029950-ec3a3200-cb3a-11ea-984e-008df10b1978.png)
