### PR TITLE
fix multi account login issue

### DIFF
--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -76,7 +76,7 @@ export class AuthController {
             '/google/redirect',
             // Try to authenticate with the google strategy.
             // This 'google' string is hardcoded within passport.
-            passport.authenticate('google'),
+            passport.authenticate('google', { prompt: 'select_account' }),
             (req: Request, res: Response): void => {
                 // User has successfully logged-in.
                 res.redirect(this.afterLoginRedirURL);
@@ -94,6 +94,7 @@ export class AuthController {
             '/google',
             passport.authenticate('google', {
                 scope: ['email'],
+                prompt: 'select_account',
             }),
         );
 


### PR DESCRIPTION
This fixes the issue by forcing the account selection prompt dialog when clicking login the first time even if there's already an account in the system.
Based on the solution proposed in https://github.com/jaredhanson/passport-google-oauth2/issues/18
Verified that it works with multi account on the same browser session now:
![ezgif-6-49210c3cd47c](https://user-images.githubusercontent.com/1255432/88032054-bb0f3100-cb3d-11ea-815d-6c9b4d82a3fb.gif)


Fixes #486 