### PR TITLE
Add ability to specify arbitrary geocode from scratch

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -140,7 +140,6 @@ describe('New case form', function () {
         cy.get('svg[data-testid="check-icon"]').should('not.exist');
     });
 
-    // Full case is covered in curator test.
     it('Can specify geocode manually', function () {
         cy.visit('/cases/new');
         cy.contains('Create new COVID-19 line list case');

--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -139,4 +139,33 @@ describe('New case form', function () {
         cy.get('svg[data-testid="error-icon"]').should('exist');
         cy.get('svg[data-testid="check-icon"]').should('not.exist');
     });
+
+    // Full case is covered in curator test.
+    it('Can specify geocode manually', function () {
+        cy.visit('/cases/new');
+        cy.contains('Create new COVID-19 line list case');
+        enterSource('www.example.com');
+        cy.get('button[id="add-location"]').click();
+        cy.get('div[id="location.geoResolution"]').click();
+        cy.contains('li', 'Admin3').click();
+        cy.get('input[name="location.country"]').type('France');
+        cy.get('input[name="location.name"]').type('Paris');
+        cy.get('input[name="location.geometry.latitude"]').type('12.34');
+        cy.get('input[name="location.geometry.longitude"]').type('45.67');
+        cy.get('input[name="confirmedDate"]').type('2020-01-01');
+        cy.server();
+        cy.route('POST', '/api/cases').as('addCase');
+        cy.get('button[data-testid="submit"]').click();
+        cy.wait('@addCase');
+        cy.request({ method: 'GET', url: '/api/cases' }).then((resp) => {
+            expect(resp.body.cases).to.have.lengthOf(1);
+            cy.url().should('eq', 'http://localhost:3002/cases');
+            cy.contains(`Case ${resp.body.cases[0]._id} added`);
+            cy.contains('No records to display').should('not.exist');
+            cy.contains('www.example.com');
+            cy.contains('France');
+            cy.contains('Paris');
+            cy.contains('1/1/2020');
+        });
+    });
 });

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -58,7 +58,17 @@ export default function Location(props: {
                         )}
                     </FastField>
                 </FormControl>
-
+                <FastField
+                    className={classes.field}
+                    label="Name"
+                    name={`${props.locationPath}.name`}
+                    type="text"
+                    required
+                    component={TextField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                />
                 <FastField
                     className={classes.field}
                     label="Country"

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -36,7 +36,10 @@ export default function Location(props: {
         <>
             <div className={classes.root}>
                 <FormControl className={classes.field}>
-                    <InputLabel htmlFor={`${props.locationPath}.geoResolution`}>
+                    <InputLabel
+                        htmlFor={`${props.locationPath}.geoResolution`}
+                        shrink
+                    >
                         Geo resolution
                     </InputLabel>
                     <FastField
@@ -120,7 +123,7 @@ export default function Location(props: {
                     }}
                 />
             </div>
-            {props.geometry && (
+            {props.geometry?.latitude && props.geometry?.longitude && (
                 <div className={classes.mapContainer}>
                     <Divider className={classes.divider} variant="middle" />
                     <StaticMap geometry={props.geometry}></StaticMap>

--- a/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
@@ -1,7 +1,9 @@
 import { Field, useFormikContext } from 'formik';
 import { Typography, makeStyles } from '@material-ui/core';
 
+import AddIcon from '@material-ui/icons/Add';
 import { Autocomplete } from '@material-ui/lab';
+import Button from '@material-ui/core/Button';
 import CaseFormValues from './CaseFormValues';
 import FieldTitle from '../common-form-fields/FieldTitle';
 import { Location as Loc } from '../Case';
@@ -16,7 +18,9 @@ import { hasKey } from '../Utils';
 import throttle from 'lodash/throttle';
 
 function LocationForm(): JSX.Element {
-    const { values, initialValues } = useFormikContext<CaseFormValues>();
+    const { values, initialValues, setFieldValue } = useFormikContext<
+        CaseFormValues
+    >();
     return (
         <Scroll.Element name="location">
             <fieldset>
@@ -26,6 +30,16 @@ function LocationForm(): JSX.Element {
                     name="location"
                     required
                 />
+                {!values.location && (
+                    <Button
+                        variant="outlined"
+                        color="default"
+                        startIcon={<AddIcon />}
+                        onClick={() => setFieldValue('location', {})}
+                    >
+                        Specify geocode manually
+                    </Button>
+                )}
                 {values.location && (
                     <Location
                         locationPath="location"
@@ -101,10 +115,6 @@ export function PlacesAutocomplete(
             if (active) {
                 let newOptions = [] as Loc[];
 
-                if (value) {
-                    newOptions = [value];
-                }
-
                 if (results) {
                     newOptions = [...newOptions, ...results];
                 }
@@ -133,6 +143,7 @@ export function PlacesAutocomplete(
             onInputChange={(event, newInputValue): void => {
                 setInputValue(newInputValue);
             }}
+            noOptionsText="No locations"
             renderInput={(params): JSX.Element => (
                 <>
                     {/* Do not use FastField here */}

--- a/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/LocationForm.tsx
@@ -34,6 +34,7 @@ function LocationForm(): JSX.Element {
                     <Button
                         variant="outlined"
                         color="default"
+                        id="add-location"
                         startIcon={<AddIcon />}
                         onClick={() => setFieldValue('location', {})}
                     >


### PR DESCRIPTION
The new button when clicked opens the location form with all fields editable below and the button disappears.
![image](https://user-images.githubusercontent.com/1255432/88074356-98017300-cb77-11ea-89af-1d341c641599.png)

Also added the name field to the location fields to be able to tune whatever mapbox returns and also because that's a required field so we have to have a way to specify it manually.

Last small nit fix: make all fields input label shrink for consistency (they were all shrunck except geoResolution).