### PR TITLE
Enable request & response validation in curator service

### DIFF
--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -10,6 +10,25 @@ info:
     url: "https://opensource.org/licenses/MIT"
   version: 1.0.0
 paths:
+  /auth/register:
+    post:
+      tags: [Auth]
+      summary: Authorize a user for the given roles
+      operationId: registerAuth
+      requestBody:
+        description: User to authorize
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+      responses:
+        "200":
+          $ref: "#/components/responses/200Auth"
+        "400":
+          $ref: "#/components/responses/400"
+        "500":
+          $ref: "#/components/responses/500"
   /suggest/locations:
     get:
       tags: [Location]
@@ -57,6 +76,13 @@ paths:
         - name: url
           in: query
           description: Origin URL substring on which to filter the result set
+          required: false
+          allowEmptyValue: true
+          allowReserved: true
+          schema:
+            type: string
+        - name: access_token
+          in: query
           required: false
           schema:
             type: string
@@ -183,6 +209,14 @@ paths:
             minimum: 1
             maximum: 100
             default: 10
+        - name: q
+          in: query
+          description: The search query
+          required: false
+          allowEmptyValue: true
+          allowReserved: true
+          schema:
+            type: string
       responses:
         "200":
           $ref: "#/components/responses/200CaseArray"
@@ -205,6 +239,15 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/NewCase"
+      parameters:
+        - name: validate_only
+          in: query
+          description: Whether to validate the case without creating it
+          required: false
+          schema:
+            type: boolean
+            default: false
+          allowEmptyValue: true
       responses:
         "201":
           $ref: "#/components/responses/201Case"
@@ -328,6 +371,45 @@ paths:
           $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
+  /geocode/seed:
+    post:
+      tags: [Geocode]
+      summary: Adds geocodes to the geocoding database
+      operationId: seedGeocodes
+      requestBody:
+        description: A single geocode record
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: OK
+  /geocode/clear:
+    post:
+      tags: [Geocode]
+      summary: Clears geocodes from the geocoding database
+      operationId: clearGeocodes
+      responses:
+        "200":
+          description: OK
+  /geocode/suggest:
+    get:
+      tags: [Geocode]
+      summary: Suggests geocodes for a given query string
+      operationId: suggestGeocodes
+      parameters:
+        - name: q
+          in: query
+          description: The location string for which to find geocodes
+          required: true
+          allowReserved: true
+          schema:
+            type: string
+      responses:
+        "200":
+          $ref: "#/components/responses/200GeocodeArray"
   /users:
     get:
       tags: [User]
@@ -383,7 +465,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Roles"
+              $ref: "#/components/schemas/RoleArray"
       responses:
         "200":
           $ref: "#/components/responses/200User"
@@ -404,7 +486,7 @@ paths:
       operationId: listUserRoles
       responses:
         "200":
-          $ref: "#/components/responses/200Roles"
+          $ref: "#/components/responses/200RoleArray"
         "403":
           $ref: "#/components/responses/403"
         "500":
@@ -416,36 +498,87 @@ components:
       allOf:
         - $ref: "#/components/schemas/NewSource"
         - type: object
+          # TODO: Define Source object.
     SourceArray:
-      type: array
+      type: object
+      properties:
+        sources:
+          type: array
+          items:
+            $ref: "#/components/schemas/Source"
+        nextPage:
+          type: integer
+        total:
+          type: integer
       items:
         $ref: "#/components/schemas/Source"
     NewSource:
       description: The subset of "#/components/schemas/Source" required to create the entity
       type: object
+          # TODO: Define NewSource object.
     Case:
       description: A complete case; a superset of "#/components/schemas/NewCase" with server-added fields
       allOf:
         - $ref: "#/components/schemas/NewCase"
         - type: object
+          # TODO: Define Case object.
     CaseArray:
+      type: object
+      properties:
+        cases:
+          type: array
+          items:
+            $ref: "#/components/schemas/Case"
+      required:
+        - cases
+    Geocode:
+      type: object
+      # TODO: Define Geocode object.
+    GeocodeArray:
       type: array
       items:
-        $ref: "#/components/schemas/Case"
+        $ref: "#/components/schemas/Geocode"
     NewCase:
       description: The subset of "#/components/schemas/Case" required to create the entity
       type: object
+      # TODO: Define NewCase object.
     User:
       description: A user
       type: object
+      properties:
+        allOf:
+          $ref: "#/components/schemas/RoleArray"
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        googleID:
+          type: string
+      required:
+        - email
     UserArray:
-      type: array
-      items:
-        $ref: "#/components/schemas/User"
-    Roles:
-      type: array
-      items:
-        type: string
+      type: object
+      properties:
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/User"
+        total:
+          type: integer
+    Role:
+      type: string
+      enum:
+        - admin
+        - curator
+        - reader
+    RoleArray:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: "#/components/schemas/Role"
     Location:
       description: A geo location
       type: object
@@ -453,7 +586,7 @@ components:
       description: A list of geo locations
       type: array
       items:
-        $ref: "#components/schemas/Location"
+        $ref: "#/components/schemas/Location"
     BatchCaseUpsertResponse:
       description: Response to batch upsert case API requests
       properties:
@@ -492,6 +625,12 @@ components:
         - numErrors
         - errors
   responses:
+    "200Auth":
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
     "200BatchCaseUpsert":
       description: OK
       content:
@@ -522,6 +661,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Case"
+    "200GeocodeArray":
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GeocodeArray"
     "200Source":
       description: OK
       content:
@@ -552,12 +697,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/UserArray"
-    "200Roles":
+    "200RoleArray":
       description: OK
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Roles"
+            $ref: "#/components/schemas/RoleArray"
     "200LocationArray":
       description: OK
       content:
@@ -575,5 +720,5 @@ components:
     "500":
       description: Internal server error
 servers:
-  - url: http://localhost:3001/api
+  - url: http://localhost:3002/api
     description: Local server

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -720,5 +720,5 @@ components:
     "500":
       description: Internal server error
 servers:
-  - url: http://localhost:3002/api
+  - url: http://localhost:3001/api
     description: Local server

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -12,7 +12,9 @@ info:
 paths:
   /auth/register:
     post:
-      tags: [Auth]
+      tags: 
+        - Auth
+        - User
       summary: Authorize a user for the given roles
       operationId: registerAuth
       requestBody:

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -52,7 +52,7 @@ export default class CasesController {
             const response = await axios.delete(
                 this.dataServerURL + '/api' + req.url,
             );
-            res.status(response.status).json(response.data);
+            res.status(response.status).end();
         } catch (err) {
             console.log(err);
             if (err.response?.status && err.response?.data) {

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -28,8 +28,8 @@ export default class SourcesController {
         }
         const filter = req.query.url
             ? {
-                'origin.url': new RegExp(req.query.url as string, 'i'),
-            }
+                  'origin.url': new RegExp(req.query.url as string, 'i'),
+              }
             : {};
         try {
             const [docs, total] = await Promise.all([

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -101,130 +101,143 @@ const awsEventsClient = new AwsEventsClient(
     awsLambdaClient,
 );
 
-// Configure curator API routes.
-const apiRouter = express.Router();
-
-// Configure sources controller.
-const sourcesController = new SourcesController(
-    awsEventsClient,
-    env.GLOBAL_RETRIEVAL_FUNCTION_ARN,
-);
-apiRouter.get(
-    '/sources',
-    mustHaveAnyRole(['reader', 'curator']),
-    sourcesController.list,
-);
-apiRouter.get(
-    '/sources/:id([a-z0-9]{24})',
-    mustHaveAnyRole(['reader', 'curator']),
-    sourcesController.get,
-);
-apiRouter.post(
-    '/sources',
-    mustHaveAnyRole(['curator']),
-    sourcesController.create,
-);
-apiRouter.put(
-    '/sources/:id([a-z0-9]{24})',
-    mustHaveAnyRole(['curator']),
-    sourcesController.update,
-);
-apiRouter.delete(
-    '/sources/:id([a-z0-9]{24})',
-    mustHaveAnyRole(['curator']),
-    sourcesController.del,
-);
-
-// Chain geocoders so that during dev/integration tests we can use the fake one.
-// It might also just be useful to have various geocoders plugged-in at some point.
-const geocoders = new Array<Geocoder>();
-if (env.ENABLE_FAKE_GEOCODER) {
-    console.log('Using fake geocoder');
-    const fakeGeocoder = new FakeGeocoder();
-    apiRouter.post('/geocode/seed', fakeGeocoder.seed);
-    apiRouter.post('/geocode/clear', fakeGeocoder.clear);
-    geocoders.push(fakeGeocoder);
-}
-if (env.MAPBOX_TOKEN !== '') {
-    console.log('Using mapbox geocoder');
-    geocoders.push(
-        new MapboxGeocoder(
-            env.MAPBOX_TOKEN,
-            env.MAPBOX_PERMANENT_GEOCODE
-                ? 'mapbox.places-permanent'
-                : 'mapbox.places',
-        ),
-    );
-}
-
-// Configure cases controller proxying to data service.
-const casesController = new CasesController(env.DATASERVER_URL, geocoders);
-apiRouter.get(
-    '/cases',
-    mustHaveAnyRole(['reader', 'curator']),
-    casesController.list,
-);
-apiRouter.get(
-    '/cases/:id([a-z0-9]{24})',
-    mustHaveAnyRole(['reader', 'curator']),
-    casesController.get,
-);
-apiRouter.post('/cases', mustHaveAnyRole(['curator']), casesController.create);
-apiRouter.post(
-    '/cases/batchUpsert',
-    mustHaveAnyRole(['curator']),
-    casesController.batchUpsert,
-);
-apiRouter.put('/cases', mustHaveAnyRole(['curator']), casesController.upsert);
-apiRouter.put(
-    '/cases/:id([a-z0-9]{24})',
-    mustHaveAnyRole(['curator']),
-    casesController.update,
-);
-apiRouter.delete(
-    '/cases/:id([a-z0-9]{24})',
-    mustHaveAnyRole(['curator']),
-    casesController.del,
-);
-
-// Configure users controller.
-apiRouter.get('/users', usersController.list);
-apiRouter.put('/users/:id', usersController.updateRoles);
-apiRouter.get('/users/roles', usersController.listRoles);
-
-// Suggest locations based on the request's "q" query param.
-const geocodeSuggester = new GeocodeSuggester(geocoders);
-apiRouter.get(
-    '/geocode/suggest',
-    mustHaveAnyRole(['curator']),
-    geocodeSuggester.suggest,
-);
-
-app.use('/api', apiRouter);
-
-// Basic health check handler.
-app.get('/health', (req: Request, res: Response) => {
-    // 0: disconnected, 1: connected, 2: connecting, 3: disconnecting.
-    // https://mongoosejs.com/docs/api.html#connection_Connection-readyState
-    if (mongoose.connection.readyState == 1) {
-        res.sendStatus(200);
-        return;
-    }
-    // Unavailable, this is wrong as per HTTP RFC, 503 would mean that we
-    // couldn't determine if the backend was healthy or not but honestly
-    // this is simple enough that it makes sense.
-    return res.sendStatus(503);
-});
-
-// API documentation.
-const swaggerDocument = YAML.load('./openapi/openapi.yaml');
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
-
 // API validation.
 new OpenApiValidator({
     apiSpec: './openapi/openapi.yaml',
     validateResponses: true,
-}).install(app);
+})
+    .install(app)
+    .then(() => {
+        // Configure curator API routes.
+        const apiRouter = express.Router();
+
+        // Configure sources controller.
+        const sourcesController = new SourcesController(
+            awsEventsClient,
+            env.GLOBAL_RETRIEVAL_FUNCTION_ARN,
+        );
+        apiRouter.get(
+            '/sources',
+            mustHaveAnyRole(['reader', 'curator']),
+            sourcesController.list,
+        );
+        apiRouter.get(
+            '/sources/:id([a-z0-9]{24})',
+            mustHaveAnyRole(['reader', 'curator']),
+            sourcesController.get,
+        );
+        apiRouter.post(
+            '/sources',
+            mustHaveAnyRole(['curator']),
+            sourcesController.create,
+        );
+        apiRouter.put(
+            '/sources/:id([a-z0-9]{24})',
+            mustHaveAnyRole(['curator']),
+            sourcesController.update,
+        );
+        apiRouter.delete(
+            '/sources/:id([a-z0-9]{24})',
+            mustHaveAnyRole(['curator']),
+            sourcesController.del,
+        );
+
+        // Chain geocoders so that during dev/integration tests we can use the fake one.
+        // It might also just be useful to have various geocoders plugged-in at some point.
+        const geocoders = new Array<Geocoder>();
+        if (env.ENABLE_FAKE_GEOCODER) {
+            console.log('Using fake geocoder');
+            const fakeGeocoder = new FakeGeocoder();
+            apiRouter.post('/geocode/seed', fakeGeocoder.seed);
+            apiRouter.post('/geocode/clear', fakeGeocoder.clear);
+            geocoders.push(fakeGeocoder);
+        }
+        if (env.MAPBOX_TOKEN !== '') {
+            console.log('Using mapbox geocoder');
+            geocoders.push(
+                new MapboxGeocoder(
+                    env.MAPBOX_TOKEN,
+                    env.MAPBOX_PERMANENT_GEOCODE
+                        ? 'mapbox.places-permanent'
+                        : 'mapbox.places',
+                ),
+            );
+        }
+
+        // Configure cases controller proxying to data service.
+        const casesController = new CasesController(
+            env.DATASERVER_URL,
+            geocoders,
+        );
+        apiRouter.get(
+            '/cases',
+            mustHaveAnyRole(['reader', 'curator']),
+            casesController.list,
+        );
+        apiRouter.get(
+            '/cases/:id([a-z0-9]{24})',
+            mustHaveAnyRole(['reader', 'curator']),
+            casesController.get,
+        );
+        apiRouter.post(
+            '/cases',
+            mustHaveAnyRole(['curator']),
+            casesController.create,
+        );
+        apiRouter.post(
+            '/cases/batchUpsert',
+            mustHaveAnyRole(['curator']),
+            casesController.batchUpsert,
+        );
+        apiRouter.put(
+            '/cases',
+            mustHaveAnyRole(['curator']),
+            casesController.upsert,
+        );
+        apiRouter.put(
+            '/cases/:id([a-z0-9]{24})',
+            mustHaveAnyRole(['curator']),
+            casesController.update,
+        );
+        apiRouter.delete(
+            '/cases/:id([a-z0-9]{24})',
+            mustHaveAnyRole(['curator']),
+            casesController.del,
+        );
+
+        // Configure users controller.
+        apiRouter.get('/users', usersController.list);
+        apiRouter.put('/users/:id', usersController.updateRoles);
+        apiRouter.get('/users/roles', usersController.listRoles);
+
+        // Suggest locations based on the request's "q" query param.
+        const geocodeSuggester = new GeocodeSuggester(geocoders);
+        apiRouter.get(
+            '/geocode/suggest',
+            mustHaveAnyRole(['curator']),
+            geocodeSuggester.suggest,
+        );
+
+        app.use('/api', apiRouter);
+
+        // Basic health check handler.
+        app.get('/health', (req: Request, res: Response) => {
+            // 0: disconnected, 1: connected, 2: connecting, 3: disconnecting.
+            // https://mongoosejs.com/docs/api.html#connection_Connection-readyState
+            if (mongoose.connection.readyState == 1) {
+                res.sendStatus(200);
+                return;
+            }
+            // Unavailable, this is wrong as per HTTP RFC, 503 would mean that we
+            // couldn't determine if the backend was healthy or not but honestly
+            // this is simple enough that it makes sense.
+            return res.sendStatus(503);
+        });
+
+        // API documentation.
+        const swaggerDocument = YAML.load('./openapi/openapi.yaml');
+        app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+    });
 
 // Serve static UI content if static directory was specified.
 if (env.STATIC_DIR) {

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -34,14 +34,6 @@ afterAll(async () => {
     await Session.deleteMany({});
 });
 
-const emptyAxiosResponse = {
-    data: {},
-    status: 202,
-    statusText: 'OK',
-    config: {},
-    headers: {},
-};
-
 describe('Cases', () => {
     let curatorRequest: any;
     beforeEach(async () => {
@@ -55,21 +47,25 @@ describe('Cases', () => {
         await curatorRequest.post('/api/geocode/clear').expect(200);
     });
     it('denies access to non readers', async () => {
-        await supertest
+        return supertest
             .agent(app)
-            .get('/api/cases?limit=10&page=1&filter=')
+            .get('/api/cases?limit=10&page=1&q=')
             .expect(403, /reader/)
             .expect('Content-Type', /json/);
     });
     it('proxies list calls', async () => {
-        mockedAxios.get.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.get.mockResolvedValueOnce({
+            status: 200,
+            statusText: 'OK',
+            data: { cases: [] },
+        });
         await curatorRequest
-            .get('/api/cases?limit=10&page=1&filter=')
-            .expect(202)
+            .get('/api/cases?limit=10&page=1&q=cough')
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.get).toHaveBeenCalledTimes(1);
         expect(mockedAxios.get).toHaveBeenCalledWith(
-            'http://localhost:3000/api/cases?limit=10&page=1&filter=',
+            'http://localhost:3000/api/cases?limit=10&page=1&q=cough',
         );
     });
 
@@ -80,16 +76,20 @@ describe('Cases', () => {
             response: { status: code, data: message },
         });
         const res = await curatorRequest
-            .get('/api/cases?limit=10&page=1&filter=')
+            .get('/api/cases?limit=10&page=1&q=')
             .expect(code);
         expect(res.text).toEqual(message);
     });
 
     it('proxies get calls', async () => {
-        mockedAxios.get.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.get.mockResolvedValueOnce({
+            status: 200,
+            statusText: 'OK',
+            data: {},
+        });
         await curatorRequest
             .get('/api/cases/5e99f21a1c9d440000ceb088')
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.get).toHaveBeenCalledTimes(1);
         expect(mockedAxios.get).toHaveBeenCalledWith(
@@ -110,11 +110,15 @@ describe('Cases', () => {
     });
 
     it('proxies update calls', async () => {
-        mockedAxios.put.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.put.mockResolvedValueOnce({
+            status: 200,
+            statusText: 'OK',
+            data: {},
+        });
         await curatorRequest
             .put('/api/cases/5e99f21a1c9d440000ceb088')
             .send({ age: '42' })
-            .expect(202)
+            .expect(200)
             .expect('Content-Type', /json/);
         expect(mockedAxios.put).toHaveBeenCalledTimes(1);
         expect(
@@ -139,11 +143,13 @@ describe('Cases', () => {
     });
 
     it('proxies delete calls', async () => {
-        mockedAxios.delete.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.delete.mockResolvedValueOnce({
+            status: 204,
+            statusText: 'Case deleted',
+        });
         await curatorRequest
             .delete('/api/cases/5e99f21a1c9d440000ceb088')
-            .expect(202)
-            .expect('Content-Type', /json/);
+            .expect(204);
         expect(mockedAxios.delete).toHaveBeenCalledTimes(1);
         expect(mockedAxios.delete).toHaveBeenCalledWith(
             'http://localhost:3000/api/cases/5e99f21a1c9d440000ceb088',
@@ -174,11 +180,15 @@ describe('Cases', () => {
             geoResolution: Resolution.Admin3,
         };
         await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
-        mockedAxios.put.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.put.mockResolvedValueOnce({
+            status: 201,
+            statusText: 'Created',
+            data: {},
+        });
         await curatorRequest
             .put('/api/cases')
             .send({ age: '42', location: { query: 'Lyon' } })
-            .expect(202)
+            .expect(201)
             .expect('Content-Type', /json/);
         expect(mockedAxios.put).toHaveBeenCalledTimes(1);
         expect(mockedAxios.put).toHaveBeenCalledWith(
@@ -228,10 +238,10 @@ describe('Cases', () => {
         };
         await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
         mockedAxios.post.mockResolvedValueOnce({
-            ...emptyAxiosResponse,
+            status: 207,
             data: { errors: [] },
         });
-        mockedAxios.put.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.put.mockResolvedValueOnce({ status: 200 });
         const res = await curatorRequest
             .post('/api/cases/batchUpsert')
             .send({
@@ -320,7 +330,7 @@ describe('Cases', () => {
             { index: 2, message: 'Darn!' },
         ];
         mockedAxios.post.mockResolvedValueOnce({
-            ...emptyAxiosResponse,
+            status: 207,
             data: { errors: validationErrors },
         });
         const res = await curatorRequest
@@ -364,7 +374,7 @@ describe('Cases', () => {
         };
         await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
         mockedAxios.post.mockResolvedValueOnce({
-            ...emptyAxiosResponse,
+            status: 207,
             data: { errors: [] },
         });
 
@@ -405,14 +415,18 @@ describe('Cases', () => {
             geoResolution: Resolution.Admin3,
         };
         await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
-        mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.post.mockResolvedValueOnce({
+            status: 201,
+            statusText: 'Created',
+            data: {},
+        });
         await curatorRequest
             .post('/api/cases')
             .send({
                 age: '42',
                 location: { query: 'Lyon', limitToResolution: 'Admin3' },
             })
-            .expect(202)
+            .expect(201)
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -464,7 +478,11 @@ describe('Cases', () => {
             geoResolution: Resolution.Admin3,
         };
         await curatorRequest.post('/api/geocode/seed').send(lyon).expect(200);
-        mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.post.mockResolvedValueOnce({
+            status: 201,
+            statusText: 'Created',
+            data: {},
+        });
 
         await curatorRequest
             .post('/api/cases')
@@ -475,7 +493,7 @@ describe('Cases', () => {
                     limitToResolution: 'Admin3,Admin2',
                 },
             })
-            .expect(202)
+            .expect(201)
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -501,7 +519,11 @@ describe('Cases', () => {
     });
 
     it('returns 404 when no geocode could be found on create', async () => {
-        mockedAxios.post.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.post.mockResolvedValueOnce({
+            status: 201,
+            statusText: 'Created',
+            data: {},
+        });
         await curatorRequest
             .post('/api/cases')
             .send({ age: '42', location: { query: 'Lyon' } })

--- a/verification/curator-service/api/test/geocoding/fake.test.ts
+++ b/verification/curator-service/api/test/geocoding/fake.test.ts
@@ -15,8 +15,8 @@ afterAll(async () => {
 });
 
 describe('FakeGeocoder', () => {
-    it('can seed geocodes', (done) => {
-        request(app)
+    it('can seed geocodes', async () => {
+        return request(app)
             .post('/api/geocode/seed')
             .send({
                 administrativeAreaLevel1: 'Rhône',
@@ -24,9 +24,9 @@ describe('FakeGeocoder', () => {
                 geometry: { latitude: 45.75889, longitude: 4.84139 },
                 name: 'Lyon',
             })
-            .expect(200, done);
+            .expect(200);
     });
-    it('can clear geocodes', (done) => {
-        request(app).post('/api/geocode/clear').expect(200, done);
+    it('can clear geocodes', () => {
+        return request(app).post('/api/geocode/clear').expect(200);
     });
 });

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -117,7 +117,7 @@ describe('GET', () => {
         expect(res.body.nextPage).toBeUndefined();
         expect(res.body.total).toEqual(15);
 
-        // Fetch nonexistant page.
+        // Fetch nonexistent page.
         res = await curatorRequest
             .get('/api/sources?page=42&limit=10')
             .expect(200)

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -117,7 +117,7 @@ describe('GET', () => {
         expect(res.body.nextPage).toBeUndefined();
         expect(res.body.total).toEqual(15);
 
-        // Fetch inexistant page.
+        // Fetch nonexistant page.
         res = await curatorRequest
             .get('/api/sources?page=42&limit=10')
             .expect(200)
@@ -128,10 +128,10 @@ describe('GET', () => {
         expect(res.body.total).toEqual(15);
     });
     it('rejects negative page param', (done) => {
-        curatorRequest.get('/api/sources?page=-7').expect(422, done);
+        curatorRequest.get('/api/sources?page=-7').expect(400, done);
     });
     it('rejects negative limit param', (done) => {
-        curatorRequest.get('/api/sources?page=1&limit=-2').expect(422, done);
+        curatorRequest.get('/api/sources?page=1&limit=-2').expect(400, done);
     });
     it('one existing item should return 200', async () => {
         const source = await new Source({
@@ -213,9 +213,13 @@ describe('PUT', () => {
             source.set('name', newName).toAwsRuleDescription(),
         );
     });
-    it('cannot update an inexistent source', (done) => {
+    it('cannot update an nonexistent source', (done) => {
         curatorRequest
-            .put('/api/sources/424242424242424242424242')
+            .put('/api/sources/5ea86423bae6982635d2e1f8')
+            .send({
+                name: 'test-source',
+                origin: { url: 'http://foo.bar' },
+            })
             .expect(404, done);
     });
     it('should not update to an invalid source', async () => {
@@ -272,7 +276,10 @@ describe('POST', () => {
         );
     });
     it('should not create invalid source', async () => {
-        const res = await curatorRequest.post('/api/sources').expect(422);
+        const res = await curatorRequest
+            .post('/api/sources')
+            .send({})
+            .expect(422);
         expect(res.body).toMatch('Enter a name');
     });
 });

--- a/verification/curator-service/api/test/users.test.ts
+++ b/verification/curator-service/api/test/users.test.ts
@@ -92,11 +92,11 @@ describe('GET', () => {
     });
 
     it('rejects negative page param', async () => {
-        await adminRequest.get('/api/users?page=-7').expect(422);
+        return adminRequest.get('/api/users?page=-7').expect(400);
     });
 
     it('rejects negative limit param', async () => {
-        await adminRequest.get('/api/users?page=1&limit=-2').expect(422);
+        return adminRequest.get('/api/users?page=1&limit=-2').expect(400);
     });
 });
 
@@ -118,14 +118,12 @@ describe('PUT', () => {
         // Check stuff that didn't change.
         expect(res.body.email).toEqual(userRes.body.email);
     });
-    it('cannot update an inexistent user', async () => {
-        const request = supertest.agent(app);
-        await request
-            .post('/auth/register')
+    it('cannot update an nonexistent user', async () => {
+        return supertest
+            .agent(app)
+            .put('/api/users/5ea86423bae6982635d2e1f8')
             .send({ ...baseUser, ...{ roles: ['admin'] } })
-            .expect(200)
-            .expect('Content-Type', /json/);
-        await request.put('/api/users/424242424242424242424242').expect(404);
+            .expect(404);
     });
     it('should not update to an invalid role', async () => {
         const request = supertest.agent(app);
@@ -134,11 +132,9 @@ describe('PUT', () => {
             .send({ ...baseUser, ...{ roles: ['admin'] } })
             .expect(200)
             .expect('Content-Type', /json/);
-        const res = await request
+        return request
             .put(`/api/users/${userRes.body._id}`)
             .send({ roles: ['invalidRole'] })
-            .expect(422);
-        expect(res.body).toContain('Validation failed');
-        expect(res.body).toContain('invalidRole');
+            .expect(400);
     });
 });


### PR DESCRIPTION
- Fixed the issue where requests & responses weren't being validated because we needed to await installing the OpenAPI validator in `index.ts`
- Added the endpoints that were missing from the OpenAPI spec
- Fixed incorrect requests/response definitions in the spec
- Fixed tests using incorrect requests/responses
- Left TODOs in the OpenAPI spec where things need to be.... spec'ed (which I'll be doing next)
- Cried