### PR TITLE
Use the new batchUpsert API in the bulk case upload component

### DIFF
--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -19,8 +19,13 @@ const env = validateEnv();
 
 // Express configuration.
 app.set('port', env.PORT);
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({ limit: '50mb' }));
+app.use(
+    bodyParser.urlencoded({
+        limit: '50mb',
+        extended: true,
+    }),
+);
 
 // Configure app routes.
 app.get('/', homeController.get);

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -599,16 +599,16 @@ components:
             - GEOCODE
             - VALIDATE
             - UPSERT
-        numUpserted:
-          type: integer
-          description: The number of cases upserted by the server
-          format: int32
-          minimum: 0
-        numErrors:
-          type: integer
-          description: The number of cases found to have errors
-          format: int32
-          minimum: 0
+        createdCaseIds:
+          type: array
+          description: UUIDs of cases created by the batch upsert
+          items:
+            type: string
+        updatedCaseIds:
+          type: array
+          description: UUIDs of cases created by the batch upsert
+          items:
+            type: string
         errors:
           type: array
           items:
@@ -623,8 +623,8 @@ components:
               - message
       required:
         - phase
-        - numUpserted
-        - numErrors
+        - createdCaseIds
+        - updatedCaseIds
         - errors
   responses:
     "200Auth":

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -606,7 +606,7 @@ components:
             type: string
         updatedCaseIds:
           type: array
-          description: UUIDs of cases created by the batch upsert
+          description: UUIDs of cases updated by the batch upsert
           items:
             type: string
         errors:

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -26,8 +26,13 @@ import swaggerUi from 'swagger-ui-express';
 import validateEnv from './util/validate-env';
 
 const app = express();
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({ limit: '50mb' }));
+app.use(
+    bodyParser.urlencoded({
+        limit: '50mb',
+        extended: true,
+    }),
+);
 
 dotenv.config();
 const env = validateEnv();

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -241,7 +241,10 @@ describe('Cases', () => {
             status: 207,
             data: { errors: [] },
         });
-        mockedAxios.put.mockResolvedValueOnce({ status: 201 });
+        mockedAxios.put.mockResolvedValue({
+            data: { _id: 'abc123' },
+            status: 201,
+        });
         const res = await curatorRequest
             .post('/api/cases/batchUpsert')
             .send({

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -231,7 +231,10 @@ describe('Cases', () => {
             ...emptyAxiosResponse,
             data: { errors: [] },
         });
-        mockedAxios.put.mockResolvedValueOnce(emptyAxiosResponse);
+        mockedAxios.put.mockResolvedValue({
+            ...emptyAxiosResponse,
+            status: 201,
+        });
         const res = await curatorRequest
             .post('/api/cases/batchUpsert')
             .send({
@@ -250,9 +253,9 @@ describe('Cases', () => {
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.put).toHaveBeenCalledTimes(2);
-        expect(res.body.numUpserted).toBe(2);
-        expect(res.body.numErrors).toBe(0);
         expect(res.body.phase).toBe('UPSERT');
+        expect(res.body.createdCaseIds).toHaveLength(2);
+        expect(res.body.updatedCaseIds).toHaveLength(0);
         expect(res.body.errors).toHaveLength(0);
     });
 
@@ -290,9 +293,9 @@ describe('Cases', () => {
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).not.toHaveBeenCalled();
         expect(mockedAxios.put).not.toHaveBeenCalled();
-        expect(res.body.numUpserted).toBe(0);
-        expect(res.body.numErrors).toBe(2);
         expect(res.body.phase).toBe('GEOCODE');
+        expect(res.body.createdCaseIds).toHaveLength(0);
+        expect(res.body.updatedCaseIds).toHaveLength(0);
         expect(res.body.errors).toEqual([
             {
                 index: 1,
@@ -345,9 +348,9 @@ describe('Cases', () => {
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.put).not.toHaveBeenCalled();
-        expect(res.body.numUpserted).toBe(0);
-        expect(res.body.numErrors).toBe(2);
         expect(res.body.phase).toBe('VALIDATE');
+        expect(res.body.createdCaseIds).toHaveLength(0);
+        expect(res.body.updatedCaseIds).toHaveLength(0);
         expect(res.body.errors).toEqual(validationErrors);
     });
 

--- a/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
@@ -28,10 +28,9 @@ describe('Bulk upload form', function () {
         const csvFixture = '../fixtures/bulk_data.csv';
         cy.get('input[type="file"]').attachFile(csvFixture);
         cy.server();
-        cy.route('PUT', '/api/cases').as('upsertCase');
+        cy.route('POST', '/api/cases/batchUpsert').as('batchUpsert');
         cy.get('button[data-testid="submit"]').click();
-        cy.wait('@upsertCase');
-        cy.wait('@upsertCase');
+        cy.wait('@batchUpsert');
 
         // Check data in linelist table.
         cy.contains('No records to display').should('not.exist');
@@ -60,9 +59,9 @@ describe('Bulk upload form', function () {
         const csvFixture = '../fixtures/bulk_data.csv';
         cy.get('input[type="file"]').attachFile(csvFixture);
         cy.server();
-        cy.route('PUT', '/api/cases').as('upsertCases');
+        cy.route('POST', '/api/cases/batchUpsert').as('batchUpsert');
         cy.get('button[data-testid="submit"]').click();
-        cy.wait('@upsertCases');
+        cy.wait('@batchUpsert');
 
         // Check data in linelist table.
         cy.contains('No records to display').should('not.exist');
@@ -76,9 +75,9 @@ describe('Bulk upload form', function () {
         const updatedCsvFixture = '../fixtures/updated_bulk_data.csv';
         cy.get('input[type="file"]').attachFile(updatedCsvFixture);
         cy.server();
-        cy.route('PUT', '/api/cases').as('upsertCases');
+        cy.route('POST', '/api/cases/batchUpsert').as('batchUpsert');
         cy.get('button[data-testid="submit"]').click();
-        cy.wait('@upsertCases');
+        cy.wait('@batchUpsert');
 
         // The updated case now has a gender of Female.
         cy.contains('bulk_data.csv uploaded. 2 cases updated.');
@@ -96,11 +95,9 @@ describe('Bulk upload form', function () {
         const csvFixture = '../fixtures/bulk_data_with_case_count.csv';
         cy.get('input[type="file"]').attachFile(csvFixture);
         cy.server();
-        cy.route('PUT', '/api/cases').as('upsertCase');
+        cy.route('POST', '/api/cases/batchUpsert').as('batchUpsert');
         cy.get('button[data-testid="submit"]').click();
-        cy.wait('@upsertCase');
-        cy.wait('@upsertCase');
-        cy.wait('@upsertCase');
+        cy.wait('@batchUpsert');
 
         cy.contains(
             'bulk_data_with_case_count.csv uploaded. 3 new cases added.',
@@ -119,9 +116,9 @@ describe('Bulk upload form', function () {
         const csvFixture = '../fixtures/bad_bulk_data.csv';
         cy.get('input[type="file"]').attachFile(csvFixture);
         cy.server();
-        cy.route('POST', '/api/cases?validate_only=true').as('validateCases');
+        cy.route('POST', '/api/cases/batchUpsert').as('batchUpsert');
         cy.get('button[data-testid="submit"]').click();
-        cy.wait('@validateCases');
+        cy.wait('@batchUpsert');
         cy.contains(
             'p',
             'The selected file could not be uploaded. Found 1 row(s) with errors.',

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -1,6 +1,6 @@
 import * as Yup from 'yup';
 
-import { Button, withStyles } from '@material-ui/core';
+import { Button, CircularProgress, withStyles } from '@material-ui/core';
 import { Case, CaseReference, Event } from './Case';
 import { Form, Formik } from 'formik';
 import Papa, { ParseConfig, ParseResult } from 'papaparse';
@@ -9,7 +9,6 @@ import axios, { AxiosResponse } from 'axios';
 
 import Alert from '@material-ui/lab/Alert';
 import AppModal from './AppModal';
-import CaptionedProgress from './bulk-case-form-fields/CaptionedProgress';
 import CaseValidationError from './bulk-case-form-fields/CaseValidationError';
 import FileUpload from './bulk-case-form-fields/FileUpload';
 import React from 'react';
@@ -23,6 +22,18 @@ interface User {
     name: string;
     email: string;
     roles: string[];
+}
+
+interface BatchUpsertError {
+    index: number;
+    message: string;
+}
+
+interface BatchUpsertResponse {
+    phase: string;
+    createdCaseIds: string[];
+    updatedCaseIds: string[];
+    errors: BatchUpsertError[];
 }
 
 // Return type isn't meaningful.
@@ -53,7 +64,7 @@ const styles = () =>
 
 interface BulkCaseFormProps
     extends RouteComponentProps,
-        WithStyles<typeof styles> {
+    WithStyles<typeof styles> {
     user: User;
     onModalClose: () => void;
 }
@@ -139,7 +150,7 @@ const BulkFormSchema = Yup.object().shape({
 class BulkCaseForm extends React.Component<
     BulkCaseFormProps,
     BulkCaseFormState
-> {
+    > {
     constructor(props: BulkCaseFormProps) {
         super(props);
         this.state = {
@@ -168,9 +179,9 @@ class BulkCaseForm extends React.Component<
                 name: 'hospitalAdmission',
                 dateRange: c.dateHospitalized
                     ? {
-                          start: c.dateHospitalized,
-                          end: c.dateHospitalized,
-                      }
+                        start: c.dateHospitalized,
+                        end: c.dateHospitalized,
+                    }
                     : undefined,
                 value: 'Yes',
             });
@@ -250,9 +261,9 @@ class BulkCaseForm extends React.Component<
                 geometry:
                     c.latitude && c.longitude
                         ? {
-                              latitude: c.latitude,
-                              longitude: c.longitude,
-                          }
+                            latitude: c.latitude,
+                            longitude: c.longitude,
+                        }
                         : undefined,
                 name: c.locationName,
                 limitToResolution: geoResolutionLimit,
@@ -293,31 +304,19 @@ class BulkCaseForm extends React.Component<
             }, 0);
     }
 
-    upsertCase(c: CompleteParsedCase): Promise<AxiosResponse<Case>> {
-        return axios.put('/api/cases', c);
-    }
-
-    /**
-     * Provides any validation errors associated with the provided cases.
-     *
-     * TODO: Find a way to parallelize these requests. We need the AxiosResponse
-     * value; so we can't use Promise.allSettled().
-     */
-    async validateCases(
+    async batchUpsertCases(
         cases: CompleteParsedCase[],
-    ): Promise<CaseValidationError[]> {
-        const validationErrors: CaseValidationError[] = [];
-        for (let i = 0; i < cases.length; i++) {
-            try {
-                await axios.post('/api/cases?validate_only=true', cases[i]);
-            } catch (e) {
-                validationErrors.push(
-                    new CaseValidationError(i + 1, e.response.data),
-                );
-            }
-            this.incrementProgress();
-        }
-        return validationErrors;
+    ): Promise<BatchUpsertResponse> {
+        const casesToSend = cases.flatMap((c) =>
+            Array.from({ length: c.caseCount || 1 }, () => c),
+        );
+        const response = await axios.post<BatchUpsertResponse>(
+            '/api/cases/batchUpsert',
+            {
+                cases: casesToSend,
+            },
+        );
+        return response.data;
     }
 
     async uploadData(
@@ -349,7 +348,21 @@ class BulkCaseForm extends React.Component<
         this.setState({
             uploadTotalRequests: this.getUploadTotalRequests(cases),
         });
-        const validationErrors = await this.validateCases(cases);
+
+        let upsertResponse: BatchUpsertResponse;
+        try {
+            upsertResponse = await this.batchUpsertCases(cases);
+        } catch (e) {
+            this.setState({
+                errorMessage: `System error during upload: ${JSON.stringify(
+                    e,
+                )}`,
+            });
+            return;
+        }
+        const validationErrors = upsertResponse.errors.map(
+            (e) => new CaseValidationError(e.index + 1, e.message),
+        );
         this.setState({ errors: validationErrors });
         if (validationErrors.length > 0) {
             this.setState({
@@ -358,39 +371,20 @@ class BulkCaseForm extends React.Component<
             });
             return;
         }
-        const createdIds: string[] = [];
-        const updatedIds: string[] = [];
-        for (const c of cases) {
-            try {
-                const casesToUpsert = c.caseCount ? c.caseCount : 1;
-                for (let i = 0; i < casesToUpsert; i++) {
-                    const response = await this.upsertCase(c);
-                    this.incrementProgress();
-                    response.status === 201
-                        ? createdIds.push(response.data._id)
-                        : updatedIds.push(response.data._id);
-                }
-            } catch (e) {
-                this.setState({
-                    errorMessage: `System error during upload: ${JSON.stringify(
-                        e,
-                    )}`,
-                });
-                return;
-            }
-        }
+        const createdIds = upsertResponse.createdCaseIds;
+        const updatedIds = upsertResponse.updatedCaseIds;
         const createdMessage =
             createdIds.length === 0
                 ? ''
                 : createdIds.length === 1
-                ? '1 new case added. '
-                : `${createdIds.length} new cases added. `;
+                    ? '1 new case added. '
+                    : `${createdIds.length} new cases added. `;
         const updatedMessage =
             updatedIds.length === 0
                 ? ''
                 : updatedIds.length === 1
-                ? '1 case updated. '
-                : `${updatedIds.length} cases updated. `;
+                    ? '1 case updated. '
+                    : `${updatedIds.length} cases updated. `;
         this.props.history.push({
             pathname: '/cases',
             state: {
@@ -465,12 +459,7 @@ class BulkCaseForm extends React.Component<
                                     >
                                         Upload cases
                                     </Button>
-                                    {isSubmitting && (
-                                        <CaptionedProgress
-                                            data-testid="progress"
-                                            value={this.state.uploadProgress}
-                                        />
-                                    )}
+                                    {isSubmitting && <CircularProgress />}
                                 </div>
                                 {this.state.errors.length > 0 && (
                                     <ValidationErrorList


### PR DESCRIPTION
Not including the OpenAPI spec tweaks just yet -- I'll merge/write that commit after #604 is in.

Did some light testing with 1,000 rows of Ohio data:

- Under ideal conditions (my Linux machine, serving on localhost) it's a ~7X speed up.
- Under more realistic deployed conditions (as above, but with an induced 100ms network latency) it's a ~31X speed up.

Highly dependent on the number of cases used of course, since it's a scaling change, but this should make it tractable to submit thousands of cases via bulk upload. That previously took several minutes for low thousands, and hours for many tens of thousands (which was effectively impossible, since at least one request was likely to encounter an error).