### PR TITLE
Saner session settings

### DIFF
--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -65,8 +65,12 @@ const MongoStore = mongo(session);
 app.use(cookieParser());
 const sess: SessionOptions = {
     secret: env.SESSION_COOKIE_KEY,
-    resave: true,
-    saveUninitialized: true,
+    // MongoStore implements touch() so we don't need resave.
+    // Cf. https://github.com/expressjs/session#resave.
+    resave: false,
+    // Chosing false is useful for login sessions which is what we want.
+    // https://github.com/expressjs/session#saveuninitialized
+    saveUninitialized: false,
     store: new MongoStore({
         mongooseConnection: mongoose.connection,
         secret: env.SESSION_COOKIE_KEY,


### PR DESCRIPTION
Verified locally that we only got 1 session stored upon login instead of 20 (!).
Dev had 125k sessions in mongo (!!), I cleared them you'll have to relogin there.