### PR TITLE
Add admins fetcher using mapbox boundaries API

### DIFF
--- a/verification/curator-service/api/src/geocoding/adminsFetcher.ts
+++ b/verification/curator-service/api/src/geocoding/adminsFetcher.ts
@@ -40,9 +40,8 @@ export default class MapboxAdminsFetcher {
             geocode.geometry.latitude
         }.json?access_token=${this.accessToken}`;
         try {
-            const resp = await axios.get(url);
-            const features = (resp.data as BoundariesResponse).features;
-            features.forEach((feature) => {
+            const resp = await axios.get<BoundariesResponse>(url);
+            resp.data.features.forEach((feature) => {
                 switch (feature.properties.tilequery.layer) {
                     case 'boundaries_admin_1':
                     // TODO: Get name from prop.id and put in geocode.administrativeAreaLevel1;

--- a/verification/curator-service/api/src/geocoding/adminsFetcher.ts
+++ b/verification/curator-service/api/src/geocoding/adminsFetcher.ts
@@ -1,0 +1,95 @@
+import { GeocodeResult, Resolution } from './geocoder';
+
+import axios from 'axios';
+
+/**
+ * Mapbox administrative area fetcher using the boundaries API.
+ * https://www.mapbox.com/boundaries/.
+ *
+ * Some geocoding results do not contain the full administrative area details,
+ * such details can be subsequently fetched using the boundaries API by doing a
+ * tilequery fetch of the center of the geocode result with the administrative
+ * boundaries layers.
+ * Cf. https://docs.mapbox.com/help/glossary/tilequery-api/
+ *
+ * TODO: Explain the custom local fetches of names once implemented.
+ */
+export default class MapboxAdminsFetcher {
+    constructor(private readonly accessToken: string) {}
+
+    // Fill in missing admin levels for the given GeocodeResult.
+    async fillAdmins(geocode: GeocodeResult): Promise<void> {
+        // Get missing admins from geocode result.
+        const missingAdmins = new Set<Resolution>();
+        if (geocode.administrativeAreaLevel1 === '') {
+            missingAdmins.add(Resolution.Admin1);
+        }
+        if (geocode.administrativeAreaLevel2 === '') {
+            missingAdmins.add(Resolution.Admin2);
+        }
+        if (geocode.administrativeAreaLevel3 === '') {
+            missingAdmins.add(Resolution.Admin3);
+        }
+        if (missingAdmins.size === 0) {
+            return;
+        }
+        // Fetch all missing admins in one query.
+        const url = `https://api.mapbox.com/v4/${getLayersParam(
+            missingAdmins,
+        )}/tilequery/${geocode.geometry.longitude},${
+            geocode.geometry.latitude
+        }.json?access_token=${this.accessToken}`;
+        try {
+            const resp = await axios.get(url);
+            const features = (resp.data as BoundariesResponse).features;
+            features.forEach((feature) => {
+                switch (feature.properties.tilequery.layer) {
+                    case 'boundaries_admin_1':
+                    // TODO: Get name from prop.id and put in geocode.administrativeAreaLevel1;
+                    case 'boundaries_admin_2':
+                    // TODO: Get name from prop.id and put in geocode.administrativeAreaLevel2;
+                    case 'boundaries_admin_3':
+                    // TODO: Get name from prop.id and put in geocode.administrativeAreaLevel3;
+                }
+            });
+        } catch (e) {
+            // Fail gracefully, not being able to fetch all admins isn't a huge deal.
+            console.error(`Retrieving admins from url: ${url}:`, e);
+            return;
+        }
+    }
+}
+
+// Mapbox boundaries types definitions, not part of the mapbox SDK.
+interface BoundariesResponse {
+    features: Feature[];
+}
+
+interface Feature {
+    properties: Properties;
+}
+
+interface Properties {
+    id: string;
+    tilequery: Tilequery;
+}
+
+interface Tilequery {
+    layer: string;
+}
+
+// Map of admin resolutions to their URL params counterpart in the mapbox boundaries API.
+const adminToLayer = new Map<Resolution, string>([
+    [Resolution.Admin1, 'mapbox.enterprise-boundaries-a1-v2'],
+    [Resolution.Admin2, 'mapbox.enterprise-boundaries-a2-v2'],
+    [Resolution.Admin3, 'mapbox.enterprise-boundaries-a3-v2'],
+]);
+
+// getLayersParams return the layers query param used by the mapbox boundaries API based on missing admin levels.
+function getLayersParam(admins: Set<Resolution>): string {
+    const layers = [];
+    for (const admin of admins) {
+        layers.push(adminToLayer.get(admin));
+    }
+    return layers.sort().join(',');
+}

--- a/verification/curator-service/api/src/geocoding/geocoder.ts
+++ b/verification/curator-service/api/src/geocoding/geocoder.ts
@@ -19,6 +19,15 @@ export interface GeocodeResult {
     geoResolution: Resolution;
 }
 
+// Returns whether a given geocode result is missing some administrative areas levels.
+export function isMissingAdmins(result: GeocodeResult): boolean {
+    return (
+        result.administrativeAreaLevel1 === '' ||
+        result.administrativeAreaLevel2 === '' ||
+        result.administrativeAreaLevel3 === ''
+    );
+}
+
 export enum Resolution {
     Point = 'Point',
     Admin3 = 'Admin3',

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -1,4 +1,9 @@
-import { GeocodeOptions, GeocodeResult, Resolution } from './geocoder';
+import {
+    GeocodeOptions,
+    GeocodeResult,
+    Resolution,
+    isMissingAdmins,
+} from './geocoder';
 import Geocoding, {
     GeocodeFeature,
     GeocodeMode,
@@ -9,6 +14,7 @@ import Geocoding, {
 } from '@mapbox/mapbox-sdk/services/geocoding';
 
 import LRUCache from 'lru-cache';
+import MapboxAdminsFetcher from './adminsFetcher';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
 
 // getFeatureTypeFromContext will return the feature 'text' field if it is of the provided type.
@@ -58,6 +64,7 @@ const resolutionToGeocodeQueryType = new Map<Resolution, GeocodeQueryType>([
 export default class MapboxGeocoder {
     private geocodeService: GeocodeService;
     private cache: LRUCache<string, GeocodeResult[]>;
+    private adminsFetcher: MapboxAdminsFetcher;
     constructor(accessToken: string, private readonly endpoint: GeocodeMode) {
         this.geocodeService = Geocoding({
             accessToken: accessToken,
@@ -65,6 +72,7 @@ export default class MapboxGeocoder {
         this.cache = new LRUCache<string, GeocodeResult[]>({
             max: 500,
         });
+        this.adminsFetcher = new MapboxAdminsFetcher(accessToken);
     }
 
     async geocode(
@@ -111,34 +119,40 @@ export default class MapboxGeocoder {
                 .forwardGeocode(req)
                 .send();
             const features = (resp.body as GeocodeResponse).features;
-            const geocodes = features.map((feature) => {
-                const contexts: GeocodeFeature[] = [feature];
-                if (feature.context) {
-                    contexts.push(...feature.context);
-                }
-                return {
-                    geometry: {
-                        longitude: feature.center[0],
-                        latitude: feature.center[1],
-                    },
-                    country: getFeatureTypeFromContext(contexts, 'country'),
-                    administrativeAreaLevel1: getFeatureTypeFromContext(
-                        contexts,
-                        'region',
-                    ),
-                    administrativeAreaLevel2: getFeatureTypeFromContext(
-                        contexts,
-                        'district',
-                    ),
-                    administrativeAreaLevel3: getFeatureTypeFromContext(
-                        contexts,
-                        'place',
-                    ),
-                    place: getFeatureTypeFromContext(contexts, 'poi'),
-                    name: feature.place_name,
-                    geoResolution: getResolution(contexts),
-                };
-            });
+            const geocodes = await Promise.all(
+                features.map(async (feature) => {
+                    const contexts: GeocodeFeature[] = [feature];
+                    if (feature.context) {
+                        contexts.push(...feature.context);
+                    }
+                    const res: GeocodeResult = {
+                        geometry: {
+                            longitude: feature.center[0],
+                            latitude: feature.center[1],
+                        },
+                        country: getFeatureTypeFromContext(contexts, 'country'),
+                        administrativeAreaLevel1: getFeatureTypeFromContext(
+                            contexts,
+                            'region',
+                        ),
+                        administrativeAreaLevel2: getFeatureTypeFromContext(
+                            contexts,
+                            'district',
+                        ),
+                        administrativeAreaLevel3: getFeatureTypeFromContext(
+                            contexts,
+                            'place',
+                        ),
+                        place: getFeatureTypeFromContext(contexts, 'poi'),
+                        name: feature.place_name,
+                        geoResolution: getResolution(contexts),
+                    };
+                    if (isMissingAdmins(res)) {
+                        await this.adminsFetcher.fillAdmins(res);
+                    }
+                    return res;
+                }),
+            );
             this.cache.set(cacheKey, geocodes);
             return geocodes;
         } catch (e) {

--- a/verification/curator-service/api/test/geocoding/adminsFetcher.test.ts
+++ b/verification/curator-service/api/test/geocoding/adminsFetcher.test.ts
@@ -27,7 +27,7 @@ describe('Admins', () => {
             name: 'the',
             place: 'to be',
         });
-        expect(mockedAxios.get).toHaveBeenCalledTimes(0);
+        expect(mockedAxios.get).not.toHaveBeenCalled();
     });
 
     it('fetches missing admins', async () => {

--- a/verification/curator-service/api/test/geocoding/adminsFetcher.test.ts
+++ b/verification/curator-service/api/test/geocoding/adminsFetcher.test.ts
@@ -1,0 +1,84 @@
+import MapboxAdminsFetcher from '../../src/geocoding/adminsFetcher';
+import { Resolution } from '../../src/geocoding/geocoder';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const testToken = 'test-token';
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('Admins', () => {
+    it('are not fetched when not needed', async () => {
+        const fetcher = new MapboxAdminsFetcher(testToken);
+        await fetcher.fillAdmins({
+            administrativeAreaLevel1: 'foo',
+            administrativeAreaLevel2: 'bar',
+            administrativeAreaLevel3: 'baz',
+            country: 'Brasilistan',
+            geoResolution: Resolution.Admin3,
+            geometry: {
+                latitude: 12.34,
+                longitude: 45.67,
+            },
+            name: 'the',
+            place: 'to be',
+        });
+        expect(mockedAxios.get).toHaveBeenCalledTimes(0);
+    });
+
+    it('fetches missing admins', async () => {
+        const fetcher = new MapboxAdminsFetcher(testToken);
+        mockedAxios.get.mockResolvedValueOnce({
+            status: 200,
+            statusText: 'OK',
+            data: {
+                features: [
+                    {
+                        properties: {
+                            id: 'USAFOO',
+                            tilequery: {
+                                layer: 'boundaries_admin_1',
+                            },
+                        },
+                    },
+                    {
+                        properties: {
+                            id: 'USABAR',
+                            tilequery: {
+                                layer: 'boundaries_admin_2',
+                            },
+                        },
+                    },
+                    {
+                        properties: {
+                            id: 'USABAR',
+                            tilequery: {
+                                layer: 'boundaries_admin_3',
+                            },
+                        },
+                    },
+                ],
+            },
+        });
+        await fetcher.fillAdmins({
+            administrativeAreaLevel1: '',
+            administrativeAreaLevel2: '',
+            administrativeAreaLevel3: '',
+            country: 'Brasilistan',
+            geoResolution: Resolution.Country,
+            geometry: {
+                latitude: 12.34,
+                longitude: 45.67,
+            },
+            name: 'the',
+            place: 'to be',
+        });
+        expect(mockedAxios.get).toHaveBeenCalledWith(
+            'https://api.mapbox.com/v4/mapbox.enterprise-boundaries-a1-v2,mapbox.enterprise-boundaries-a2-v2,mapbox.enterprise-boundaries-a3-v2/tilequery/45.67,12.34.json?access_token=test-token',
+        );
+    });
+});

--- a/verification/curator-service/api/test/geocoding/mapbox.test.ts
+++ b/verification/curator-service/api/test/geocoding/mapbox.test.ts
@@ -5,11 +5,15 @@ import { GeocodeResult, Resolution } from '../../src/geocoding/geocoder';
 import Geocoder from '../../src/geocoding/mapbox';
 import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
+import axios from 'axios';
 
 // Typings defined by DefinitelyTyped are not fully compatible with the response we get.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const features: any[] = [];
 let callCount = 0;
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 jest.mock('@mapbox/mapbox-sdk/services/geocoding', () => {
     return jest.fn().mockImplementation(() => {
@@ -34,12 +38,19 @@ jest.mock('@mapbox/mapbox-sdk/services/geocoding', () => {
 
 beforeEach(() => {
     jest.clearAllMocks();
-    features.splice(0);
+    features.splice(0, features.length);
     callCount = 0;
 });
 
 describe('geocode', () => {
     it('succeeds', async () => {
+        mockedAxios.get.mockResolvedValueOnce({
+            status: 200,
+            statusText: 'OK',
+            data: {
+                features: [],
+            },
+        });
         features.push(lyon);
         const geocoder = new Geocoder('token', 'mapbox.places');
         let feats = await geocoder.geocode('some query', {


### PR DESCRIPTION
This is step 1/2: it gets the admins but not their name so not filling this in just yet in the geocode results.
Getting the names is going to be slightly complex due to the way mapbox gives it to us (not via an API but via static files (!)) so I'll do that in a next PR.

For #426