### PR TITLE
Add script to generate boundaries files that is optimized for serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ kustomization.yaml
 # MongoDB global configs
 globalConfig.json
 
+# Mapbox secrets.
+boundaries.json
+
 # Created by https://www.gitignore.io/api/osx,linux,python,pycharm,windows,visualstudiocode,node
 # Edit at https://www.gitignore.io/?templates=osx,linux,python,pycharm,windows,visualstudiocode,node
 

--- a/verification/scripts/boundaries.sh
+++ b/verification/scripts/boundaries.sh
@@ -22,10 +22,8 @@ Admin 1 file: $1
 Admin 2 file: $2
 Admin 3 file: $3"
 
-# Clear previous output so that each line below can append to it.
-touch ${SCRIPT_PATH}/boundaries.json
 # Generate one JSON object per line and append the result to the final file.
-cat $1 | jq -c '.adm1.data.all | to_entries[] | {id: .key, name: .value.name}' >> ${SCRIPT_PATH}/boundaries.json
+cat $1 | jq -c '.adm1.data.all | to_entries[] | {id: .key, name: .value.name}' > ${SCRIPT_PATH}/boundaries.json
 cat $2 | jq -c '.adm2.data.all | to_entries[] | {id: .key, name: .value.name}' >> ${SCRIPT_PATH}/boundaries.json
 cat $3 | jq -c '.adm3.data.all | to_entries[] | {id: .key, name: .value.name}' >> ${SCRIPT_PATH}/boundaries.json
 

--- a/verification/scripts/boundaries.sh
+++ b/verification/scripts/boundaries.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Converts boundaries files provided by Mapbox into files optimized for serving.
+# Will output a single file named boundaries.json that can be used as a config
+# map in a kubernetes cluster and that the curator service can load to serve
+# administrative boundaries during geocoding.
+# In that file each line is a JSON object like {"id": "id of boundary", "name": "name of boundary"}.
+# If you are wondering how to get your hands on the boundaries-adm*-v3.json files, you have
+# to contact mapbox sales people and they will send those to you once you register
+# for the boundaries API.
+
+readonly USAGE="usage: $0 /path/to/boundaries-adm1-v3.json /path/to/boundaries-adm2-v3.json boundaries-adm3-v3.json"
+readonly SCRIPT_PATH="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$#" -ne 3 ]; then
+    echo "Illegal number of parameters: $USAGE"
+    exit 1
+fi
+
+echo -e "Running with:\n
+Admin 1 file: $1
+Admin 2 file: $2
+Admin 3 file: $3"
+
+# Clear previous output so that each line below can append to it.
+touch ${SCRIPT_PATH}/boundaries.json
+# Generate one JSON object per line and append the result to the final file.
+cat $1 | jq -c '.adm1.data.all | to_entries[] | {id: .key, name: .value.name}' >> ${SCRIPT_PATH}/boundaries.json
+cat $2 | jq -c '.adm2.data.all | to_entries[] | {id: .key, name: .value.name}' >> ${SCRIPT_PATH}/boundaries.json
+cat $3 | jq -c '.adm3.data.all | to_entries[] | {id: .key, name: .value.name}' >> ${SCRIPT_PATH}/boundaries.json
+
+echo -e 'Fin!'


### PR DESCRIPTION
Mapbox sales gave us access to 3 files for boundaries that contain the IDs and the names (amongst many other things) of the boundaries returned when doing a tilequery lookup for a point (Cf. other PR I sent you earlier).

These files shouldn't become public as per Mapbox terms of service, so we need to put them as config maps in kubernetes and the curator service will then be able to access them from there.
Before doing that though we need to optimize them a bit because 99% of the stuff in there is useless to us.

Before:
```
du -hs ~/Downloads/boundaries-adm*
1.6M	/Users/timothe/Downloads/boundaries-adm1-v3.json
 20M	/Users/timothe/Downloads/boundaries-adm2-v3.json
 36M	/Users/timothe/Downloads/boundaries-adm3-v3.json

wc -l ~/Downloads/boundaries-adm*
    3915 /Users/timothe/Downloads/boundaries-adm1-v3.json
   48663 /Users/timothe/Downloads/boundaries-adm2-v3.json
  109805 /Users/timothe/Downloads/boundaries-adm3-v3.json
  162383 total
```

After:
```
./boundaries.sh ~/Downloads/boundaries-adm1-v3.json ~/Downloads/boundaries-adm2-v3.json  ~/Downloads/boundaries-adm3-v3.json
Running with:

Admin 1 file: /Users/timothe/Downloads/boundaries-adm1-v3.json
Admin 2 file: /Users/timothe/Downloads/boundaries-adm2-v3.json
Admin 3 file: /Users/timothe/Downloads/boundaries-adm3-v3.json
Fin!

wc -l boundaries.json
161386 boundaries.json

du -hs boundaries.json
6.4M	boundaries.json
```


Example of input:
```
"BTA115":{"feature_id":332321,"wikidata_id":"Q754448","worldview":"CN","unit_code":"15","name":"Haa","names":{"dz":["ཧཱ་རྫོང་ཁག"],"en":["Haa District","Haa"]},"description":"district","source_date":"2017","iso_3166_1_alpha_3":"BTN","iso_3166_1":"BT","z_min":0,"centroid":[89.1538,27.303],"bounds":[88.9063,27.0278,89.3883,27.5773],"area_sqkm":1968},
```

Example of (unrelated) output:
`{"id":"AZA10117","name":"Abşeron rayonu"}`

For #426